### PR TITLE
Change env name to reflect new repo name

### DIFF
--- a/env/conda_environment.yaml
+++ b/env/conda_environment.yaml
@@ -1,4 +1,4 @@
-name: camdiag
+name: adf_diag
 channels:
   - conda-forge
   - defaults
@@ -14,4 +14,4 @@ dependencies:
   - netcdf4
   - geocat-comp
   - python=3.9
-prefix: /glade/u/home/brianpm/miniconda3/envs/camdiag
+prefix: /glade/u/home/brianpm/miniconda3/envs/adf_diag


### PR DESCRIPTION
Should we change the conda env name to reflect the new repo name?

Changing from `camdiag` to `adf_diag`