### PR TITLE
Re-arrange config (YAML) file variable ordering

### DIFF
--- a/config_cam_baseline_example.yaml
+++ b/config_cam_baseline_example.yaml
@@ -47,130 +47,130 @@
 #
 ##==============================
 
-#This first set of variables specify basic info required by all diagnostic runs:
+#This first set of variables specify basic info used by all diagnostic runs:
 diag_basic_info:
 
-  #Is this a model vs observations comparison?
-  #If "false", then a model-model comparison is assumed:
-  compare_obs: false
+    #Is this a model vs observations comparison?
+    #If "false" or missing, then a model-model comparison is assumed:
+    compare_obs: false
 
-  #Generate HTML website:
-  #Note:  The website files themselves will be located in the path
-  #specified by "cam_diag_plot_loc", under the "<diag_run>/website" subdirectory,
-  #where "<diag_run>" is the subdirectory created for this particular diagnostics run
-  #(usually "case_vs_obs_XXX" or "case_vs_baseline_XXX").
-  create_html: true
+    #Generate HTML website (assumed false if missing):
+    #Note:  The website files themselves will be located in the path
+    #specified by "cam_diag_plot_loc", under the "<diag_run>/website" subdirectory,
+    #where "<diag_run>" is the subdirectory created for this particular diagnostics run
+    #(usually "case_vs_obs_XXX" or "case_vs_baseline_XXX").
+    create_html: true
 
-  #Location of observational climatologies (only matters if "compare_obs" is true):
-  obs_climo_loc: /glade/work/brianpm/observations/climo_files
+    #Location of observational climatologies (only matters if "compare_obs" is true):
+    obs_climo_loc: /glade/work/brianpm/observations/climo_files
 
-  #Name of CAM case (or CAM run name):
-  cam_case_name: new_best.came-run
+    #Location where re-gridded CAM climatology files are stored:
+    cam_regrid_loc: /some/where/you/want/to/have/regridded_files #MUST EDIT!
 
-  #Location of CAM climatologies:
-  cam_climo_loc: /some/where/you/want/to/have/it
+    #Overwrite CAM re-gridded files?
+    #If false, or missing, then regridding will be skipped for regridded variables
+    #that already exist in "cam_regrid_loc":
+    cam_overwrite_regrid: false
 
-  #Name of CAM baseline case (only matters if "compare_obs" is false):
-  cam_baseline_case_name: best.cam_run-ever
-
-  #Location of baseline CAM cliimatologies (only matters if "compare_obs" is false):
-  cam_baseline_climo_loc: /some/where/else/you/want/to/have/it
-
-  #Location where re-gridded CAM climatology files are stored:
-  cam_regrid_loc: /any/directory/you/want
-
-  #Overwrite CAM re-gridded files?
-  #If false, then regridding will be skipped for regridded variables
-  #that already exist in "cam_regrid_loc":
-  cam_overwrite_regrid: false
-
-  #Location where CAM diagnostic plots are stored:
-  cam_diag_plot_loc: /any/other/directory/you/want
+    #Location where diagnostic plots are stored:
+    cam_diag_plot_loc: /some/where/you/want/to/have/diag_plots #MUST EDIT!
 
 
-#This second set of variables specify whether CAM climatologies need to be calculated:
+#This second set of variables provides info for the CAM simulation(s) being diagnosed:
 diag_cam_climo:
 
-  #Calculate cam climatologies?
-  #If false, neither the climatology or time-series files will be created:
-  calc_cam_climo: true
+    #Calculate climatologies?
+    #If false, neither the climatology or time-series files will be created:
+    calc_cam_climo: true
 
-  #Overwrite CAM climatology files?
-  #If false, then already existing climatology files will be skipped:
-  cam_overwrite_climo: false
+    #Overwrite CAM climatology files?
+    #If false, or not prsent, then already existing climatology files will be skipped:
+    cam_overwrite_climo: false
 
-  #Location of CAM history (h0) files:
-  cam_hist_loc: /location/where/you/stored/model/outputs
+    #Name of CAM case (or CAM run name):
+    cam_case_name: b.e20.BHIST.f09_g17.20thC.297_05
 
-  #model year when time series files should start:
-  #Note:  Leaving this entry blank will make time series
-  #       start at earliest available year.
-  start_year: 1850
+    #Location of CAM history (h0) files:
+    cam_hist_loc: /glade/p/cesm/ADF/b.e20.BHIST.f09_g17.20thC.297_05/
 
-  #model year when time series files should end:
-  #Note:  Leaving this entry blank will make time series
-  #       end at latest available year.
-  end_year: 2100
+    #Location of CAM climatologies:
+    cam_climo_loc: /some/where/you/want/to/have/climo_files/ #MUST EDIT!
 
-  #Do time series files need to be generated?
-  #If True, then diagnostics assumes that model files are already time series.
-  #If False, or if simply not present, then diagnostics will attempt to create
-  #time series files from history (time-slice) files:
-  cam_ts_done: false
+    #model year when time series files should start:
+    #Note:  Leaving this entry blank will make time series
+    #       start at earliest available year.
+    start_year: 1990
 
-  #Save interim time series files?
-  #WARNING:  This can take up a significant amount of space:
-  cam_ts_save: true
+    #model year when time series files should end:
+    #Note:  Leaving this entry blank will make time series
+    #       end at latest available year.
+    end_year: 1999
 
-  #Overwrite time series files, if found?
-  #If set to false, then time series creation will be skipped if files are found:
-  cam_overwrite_ts: false
+    #Do time series files need to be generated?
+    #If True, then diagnostics assumes that model files are already time series.
+    #If False, or if simply not present, then diagnostics will attempt to create
+    #time series files from history (time-slice) files:
+    cam_ts_done: false
 
-  #Location where time series files are (or will be) stored:
-  cam_ts_loc: /some/big/storage/location/to/save/time/series
+    #Save interim time series files?
+    #WARNING:  This can take up a significant amount of space:
+    cam_ts_save: true
+
+    #Overwrite time series files, if found?
+    #If set to false, then time series creation will be skipped if files are found:
+    cam_overwrite_ts: false
+
+    #Location where time series files are (or will be) stored:
+    cam_ts_loc: /some/where/you/want/to/have/time_series_files/ #MUST EDIT!
 
 
-#This third set of variables specify whether CAM baseline climatologies need to be calculated
+#This third set of variables provide info for the CAM baseline climatologies.
 #This only matters if "compare_obs" is false:
 diag_cam_baseline_climo:
 
-  #Calculate cam baseline climatologies?
-  #If false, neither the climatology or time-series files will be created:
-  calc_cam_climo: true
+    #Calculate cam baseline climatologies?
+    #If false, neither the climatology or time-series files will be created:
+    calc_cam_climo: true
 
-  #Overwrite CAM climatology files?
-  #If false, then already existing climatology files will be skipped:
-  cam_overwrite_climo: false
+    #Overwrite CAM climatology files?
+    #If false, or not present, then already existing climatology files will be skipped:
+    cam_overwrite_climo: false
 
-  #Location of CAM history (h0) files:
-  cam_hist_loc: /location/of/second/cam/run/output/or/baseline/data
+    #Name of CAM baseline case:
+    cam_case_name: b.e20.BHIST.f09_g16.20thC.125.02
 
-  #model year when time series files should start:
-  #Note:  Leaving this entry blank will make time series
-  #       start at earliest available year.
-  start_year: 1850
+    #Location of CAM baseline history (h0) files:
+    cam_hist_loc: /glade/p/cesm/ADF/b.e20.BHIST.f09_g16.20thC.125.02/
 
-  #model year when time series files should end:
-  #Note:  Leaving this entry blank will make time series
-  #       end at latest available year.
-  end_year: 2100
+    #Location of baseline CAM cliimatologies:
+    cam_climo_loc: /some/where/you/want/to/have/baseline_climo_files/ #MUST EDIT!
 
-  #Do time series files need to be generated?
-  #If True, then diagnostics assumes that model files are already time series.
-  #If False, or if simply not present, then diagnostics will attempt to create
-  #time series files from history (time-slice) files:
-  cam_ts_done: false
+    #model year when time series files should start:
+    #Note:  Leaving this entry blank will make time series
+    #       start at earliest available year.
+    start_year: 1990
 
-  #Save interim time series files for baseline run?
-  #WARNING:  This can take up a significant amount of space:
-  cam_ts_save: true
+    #model year when time series files should end:
+    #Note:  Leaving this entry blank will make time series
+    #       end at latest available year.
+    end_year: 1999
 
-  #Overwrite baseline time series files, if found?
-  #If set to false, then time series creation will be skipped if files are found:
-  cam_overwrite_ts: false
+    #Do time series files need to be generated?
+    #If True, then diagnostics assumes that model files are already time series.
+    #If False, or if simply not present, then diagnostics will attempt to create
+    #time series files from history (time-slice) files:
+    cam_ts_done: false
 
-  #Location where time series files are (or will be) stored:
-  cam_ts_loc: /another/big/storage/location/to/save/time/series
+    #Save interim time series files for baseline run?
+    #WARNING:  This can take up a significant amount of space:
+    cam_ts_save: true
+
+    #Overwrite baseline time series files, if found?
+    #If set to false, then time series creation will be skipped if files are found:
+    cam_overwrite_ts: false
+
+    #Location where time series files are (or will be) stored:
+    cam_ts_loc: /some/where/you/want/to/have/baseline_time_series_files/ #MUST EDIT!
 
 #+++++++++++++++++++++++++++++++++++++++++++++++++++
 #These variables below only matter if you are using
@@ -185,34 +185,34 @@ diag_cam_baseline_climo:
 #Name of time-averaging scripts being used to generate climatologies.
 #These scripts must be located in "scripts/averaging":
 time_averaging_scripts:
- - averaging_example
+    - averaging_example
 
 #Name of regridding scripts being used.
 #These scripts must be located in "scripts/regridding":
 regridding_scripts:
- - regrid_example
+    - regrid_example
 
 #List of analysis scripts being used.
 #These scripts must be located in "scripts/analysis":
 analysis_scripts:
- - amwg_table
+    - amwg_table
 
 #List of plotting scripts being used.
 #These scripts must be located in "scripts/plotting":
 plotting_scripts:
- - global_latlon_map
- - zonal_mean
+    - global_latlon_map
+    - zonal_mean
 
 #List of CAM variables that will be processesd:
 diag_var_list:
- - SWCF
- - LWCF
- - PSL
- - Q
+    - SWCF
+    - LWCF
+    - PSL
+    - Q
 #<Add more variables here.>
 
 #List of observation types (filename prefixes) CAM can be compared against:
 obs_type_list:
- - CERES_EBAF_Ed4.1
+    - CERES_EBAF_Ed4.1
 
 #END OF FILE

--- a/config_cam_baseline_example.yaml
+++ b/config_cam_baseline_example.yaml
@@ -5,12 +5,13 @@
 #for doing comparisons of a CAM run against
 #another CAM run, or a CAM baseline simulation.
 
-#Currently, if one is on NCAR's Casper
-#machine, then only the CAM model data
-#paths, case names, and model year spans
-#are needed.  Running this diagnostics on
-#a different machine, or with a different model,
-#may require additional modifications.
+#Currently, if one is on NCAR's Casper or
+#Cheyenne machine, then only the diagnostic output
+#paths are needed, at least to perform a quick test
+#run (these are indicated with "MUST EDIT" comments).
+#Running these diagnostics on a different machine,
+#or with a different, non-example simulation, will
+#require additional modifications.
 #
 #Config file Keywords:
 #--------------------
@@ -23,6 +24,9 @@
 #
 #    will set "cam_climo_loc" in the diagnostics package to:
 #    /some/where/cool_run
+#
+#    Please note that currently this will only work if the
+#    variable only exists in one location in the file.
 #
 #2.  Using ${<top_level_section>.xxx} will do the same as
 #    keyword 1 above, but specifies which sub-section the
@@ -38,7 +42,7 @@
 #    will set "cam_climo_loc" in the diagnostics package to:
 #    /some/where/1850
 #
-#Please note that for both 1 and 2 the keywords must be lowercase.
+#Finally, please note that for both 1 and 2 the keywords must be lowercase.
 #This is because future developments will hopefully use other keywords
 #that are uppercase. Also please avoid using periods (".") in variable
 #names, as this will likely cause issues with the current file parsing

--- a/lib/adf_config.py
+++ b/lib/adf_config.py
@@ -251,7 +251,7 @@ class AdfConfig(AdfBase):
 
     #########
 
-    def read_config_var(self, varname, conf_dict=None):
+    def read_config_var(self, varname, conf_dict=None, required=False):
 
         """
         Checks if variable/list/dictionary exists in
@@ -270,16 +270,22 @@ class AdfConfig(AdfBase):
 
         #Check that variable name exists in dictionary:
         if varname not in var_dict.keys():
-            emsg = f"Variable '{varname}' not found in config file."
-            emsg +=" Please see 'config_cam_baseline_example.yaml'."
-            raise KeyError(emsg)
+            #If variable is required, then throw an error:
+            if required:
+                emsg = f"Required variable '{varname}' not found in config file."
+                emsg +=" Please see 'config_cam_baseline_example.yaml'."
+                raise KeyError(emsg)
+
+            #If not, then just return None:
+            return None
 
         #Extract variable from dictionary:
         var = var_dict[varname]
 
-        #Check that configure variable is not empty (None):
-        if var is None:
-            emsg = f"Variable '{varname}' has not been set to a value."
+        #If variable is required, then check that
+        #configure variable is not empty (None):
+        if required and var is None:
+            emsg = f"Required variable '{varname}' has not been set to a value."
             emsg += " Please see 'config_cam_baseline_example.yaml'."
             raise ValueError(emsg)
 

--- a/lib/adf_diag.py
+++ b/lib/adf_diag.py
@@ -157,21 +157,22 @@ class AdfDiag(AdfConfig):
         super().__init__(config_file, debug=debug)
 
         #Add basic diagnostic info to object:
-        self.__basic_info = self.read_config_var('diag_basic_info')
+        self.__basic_info = self.read_config_var('diag_basic_info', required=True)
 
         #Expand basic info variable strings:
         self.expand_references(self.__basic_info)
 
         #Add CAM climatology info to object:
-        self.__cam_climo_info = self.read_config_var('diag_cam_climo')
+        self.__cam_climo_info = self.read_config_var('diag_cam_climo', required=True)
 
         #Expand CAM climo info variable strings:
         self.expand_references(self.__cam_climo_info)
 
         #Check if a CAM vs CAM baseline comparison is being performed:
-        if not self.__basic_info['compare_obs']:
+        if not self.read_config_var('compare_obs', conf_dict=self.__basic_info):
             #If so, then add CAM baseline climatology info to object:
-            self.__cam_bl_climo_info = self.read_config_var('diag_cam_baseline_climo')
+            self.__cam_bl_climo_info = self.read_config_var('diag_cam_baseline_climo',
+                                                            required=True)
 
             #Expand CAM baseline climo info variable strings:
             self.expand_references(self.__cam_bl_climo_info)
@@ -189,7 +190,7 @@ class AdfDiag(AdfConfig):
         self.__plotting_scripts = self.read_config_var('plotting_scripts')
 
         #Add CAM variable list:
-        self.__diag_var_list = self.read_config_var('diag_var_list')
+        self.__diag_var_list = self.read_config_var('diag_var_list', required=True)
 
         #Add CAM observation type list (filename prefix for observation files):
         self.__obs_type_list = self.read_config_var('obs_type_list')
@@ -203,13 +204,13 @@ class AdfDiag(AdfConfig):
     @property
     def compare_obs(self):
         """Return the "compare_obs" logical to user if requested."""
-        return self.__basic_info['compare_obs']
+        return self.read_config_var('compare_obs', conf_dict=self.__basic_info)
 
     # Create property needed to return "create_html" logical to user:
     @property
     def create_html(self):
         """Return the "create_html" logical to user if requested."""
-        return self.__basic_info['create_html']
+        return self.read_config_var('create_html', conf_dict=self.__basic_info)
 
     #########
 
@@ -770,7 +771,9 @@ class AdfDiag(AdfConfig):
         if self.__plot_loc:
             plot_location = self.__plot_loc
         else:
-            plot_location  = self.__basic_info['cam_diag_plot_loc']
+            plot_location  = self.read_config_var('cam_diag_plot_loc',
+                                                  conf_dict=self.__basic_info,
+                                                  required=True)
         #End if
 
         #Extract needed variables from yaml file:
@@ -781,7 +784,9 @@ class AdfDiag(AdfConfig):
         if self.compare_obs:
             data_name = "obs"
         else:
-            data_name = self.__basic_info['cam_baseline_case_name']
+            data_name = self.read_config_var('cam_baseline_case_name',
+                                             conf_dict=self.__basic_info,
+                                             required=True)
         #End if
 
         #Set preferred order of seasons:

--- a/lib/adf_diag.py
+++ b/lib/adf_diag.py
@@ -365,17 +365,20 @@ class AdfDiag(AdfConfig):
             #Then use the CAM baseline climo dictionary
             #and case name:
             cam_climo_dict = self.__cam_bl_climo_info
-            case_name = self.__basic_info['cam_baseline_case_name']
         else:
             #If not, then just extract the standard CAM climo dictionary
             #and case name::
             cam_climo_dict = self.__cam_climo_info
-            case_name = self.__basic_info['cam_case_name']
+
+        #Extract case name:
+        case_name = self.read_config_var('cam_case_name',
+                                         conf_dict=cam_climo_dict,
+                                         required=True)
 
         #Check if climatologies are being calculated:
-        if cam_climo_dict['calc_cam_climo']:
+        if self.read_config_var('calc_cam_climo', conf_dict=cam_climo_dict):
             # Skip history file stuff if time series are pre-computed:
-            if ('cam_ts_done' in cam_climo_dict) and (cam_climo_dict['cam_ts_done']):
+            if self.read_config_var('cam_ts_done', conf_dict=cam_climo_dict):
                 # skip time series generation, and just make the climo
                 emsg = "  Configuration file indicates time series files have been pre-computed,"
                 emsg += " will rely on those files only."
@@ -420,7 +423,10 @@ class AdfDiag(AdfConfig):
             var_list = self.__diag_var_list
 
             #Create path object for the CAM history file(s) location:
-            starting_location = Path(cam_climo_dict['cam_hist_loc'])
+            cam_hist_loc = self.read_config_var('cam_hist_loc',
+                                                conf_dict=cam_climo_dict,
+                                                required=True)
+            starting_location = Path(cam_hist_loc)
 
             #Check that path actually exists:
             if not starting_location.is_dir():
@@ -514,17 +520,24 @@ class AdfDiag(AdfConfig):
             #If so, then use the CAM baseline climo dictionary
             #case name, and output location:
             cam_climo_dict = self.__cam_bl_climo_info
-            case_name  = self.__basic_info['cam_baseline_case_name']
-            output_loc = self.__basic_info['cam_baseline_climo_loc']
         else:
             #If not, then just extract the standard CAM climo dictionary
             #case name, and output location:
             cam_climo_dict = self.__cam_climo_info
-            case_name = self.__basic_info['cam_case_name']
-            output_loc = self.__basic_info['cam_climo_loc']
 
-        #Check if users wants climatologies to be calculated:
-        if cam_climo_dict['calc_cam_climo']:
+
+        #Check if user wants climatologies to be calculated:
+        if self.read_config_var('calc_cam_climo', conf_dict=cam_climo_dict):
+
+            #Extract case name:
+            case_name = self.read_config_var('cam_case_name',
+                                             conf_dict=cam_climo_dict,
+                                             required=True)
+
+            #Extract output location:
+            output_loc = self.read_config_var('cam_climo_loc',
+                                              conf_dict=cam_climo_dict,
+                                              required=True)
 
             #If so, then extract names of time-averaging scripts:
             avg_func_names = self.__time_averaging_scripts  # this is a list of script names
@@ -534,10 +547,25 @@ class AdfDiag(AdfConfig):
                                                             # args(list), kwargs(dict), and
                                                             # module(str)
 
+            if not avg_func_names:
+                emsg = "No time_averaging_scripts provided for calculating"
+                emsg += " climatologies, but climatologies were requested.\n"
+                emsg += "Please either provide a valid averaging script,"
+                emsg += " or skip the calculation of climatologies."
+                raise AdfError(emsg)
+
             #Extract necessary variables from configure dictionary:
-            input_ts_loc    = cam_climo_dict['cam_ts_loc']
-            overwrite_climo = cam_climo_dict['cam_overwrite_climo']
-            var_list        = self.__diag_var_list
+
+            #Location of time series files:
+            input_ts_loc = self.read_config_var('cam_ts_loc',
+                                                conf_dict=cam_climo_dict,
+                                                required=True)
+
+            #Will climatologies be overwritten (If not present, then will default to False):
+            overwrite_climo = self.read_config_var('cam_overwrite_climo', conf_dict=cam_climo_dict)
+
+            #Variable list:
+            var_list = self.__diag_var_list
 
             #Set default script arguments:
             avg_func_args = [case_name, input_ts_loc, output_loc, var_list]
@@ -570,24 +598,6 @@ class AdfDiag(AdfConfig):
         nearest-neighbor regridding).
         """
 
-        #Check if comparison is being made to observations:
-        if self.compare_obs:
-            #Set regridding target to observations:
-            target_list = self.__obs_type_list
-            target_loc  = self.__basic_info['obs_climo_loc']
-        else:
-            #Assume a CAM vs. CAM comparison is being run,
-            #so set target to baseline climatologies:
-            target_list = [self.__basic_info['cam_baseline_case_name']]
-            target_loc  = self.__basic_info['cam_baseline_climo_loc']
-
-        #Extract remaining required info from configure dictionaries:
-        case_name        = self.__basic_info['cam_case_name']
-        input_climo_loc  = self.__basic_info['cam_climo_loc']
-        output_loc       = self.__basic_info['cam_regrid_loc']
-        overwrite_regrid = self.__basic_info['cam_overwrite_regrid']
-        var_list         = self.__diag_var_list
-
         #Extract names of re-gridding scripts:
         regrid_func_names = self.__regridding_scripts # this is a list of script names
                                                       # _OR_
@@ -595,11 +605,55 @@ class AdfDiag(AdfConfig):
                                                       # script names as keys that hold
                                                       # args(list), kwargs(dict), and module(str)
 
-        if all([func_names is None for func_names in regrid_func_names]):
+        if not regrid_func_names or all([func_names is None for func_names in regrid_func_names]):
             print("No regridding options provided, continue.")
             return
             # NOTE: if no regridding options provided, we should skip it, but
             #       do we need to still copy (symlink?) files into the regrid directory?
+
+
+        #Check if comparison is being made to observations:
+        if self.compare_obs:
+            #Set regridding target to observations:
+            target_list = self.__obs_type_list
+            target_loc  = self.read_config_var('obs_climo_loc',
+                                               conf_dict=self.__basic_info,
+                                               required=True)
+        else:
+            #Assume a CAM vs. CAM comparison is being run,
+            #so set target to baseline climatologies:
+            target_list = [self.read_config_var('cam_case_name',
+                                                conf_dict=self.__cam_bl_climo_info,
+                                                required=True)]
+
+            target_loc = self.read_config_var('cam_climo_loc',
+                                              conf_dict=self.__cam_bl_climo_info,
+                                              required=True)
+
+        #Extract remaining required info from configure dictionaries:
+
+        #Case name:
+        case_name = self.read_config_var('cam_case_name',
+                                         conf_dict=self.__cam_climo_info,
+                                         required=True)
+
+        #Case climo files:
+        input_climo_loc =  self.read_config_var('cam_climo_loc',
+                                         conf_dict=self.__cam_climo_info,
+                                         required=True)
+
+
+        #Regridded data output location:
+        output_loc =  self.read_config_var('cam_regrid_loc',
+                                         conf_dict=self.__basic_info,
+                                         required=True)
+
+        #Regrid overwrite check (if missing, then assume False):
+        overwrite_regrid = self.read_config_var('cam_overwrite_regrid',
+                                                conf_dict=self.__basic_info)
+
+        #Variable list:
+        var_list = self.__diag_var_list
 
 
         #Set default script arguments:
@@ -642,31 +696,55 @@ class AdfDiag(AdfConfig):
             #If so, then use the CAM baseline climo dictionary
             #case name, and output location:
             cam_climo_dict = self.__cam_bl_climo_info
-            case_name  = self.__basic_info['cam_baseline_case_name']
         else:
             #If not, then just extract the standard ADF climo dictionary
             #case name, and output location:
             cam_climo_dict = self.__cam_climo_info
-            case_name = self.__basic_info['cam_case_name']
-
 
         #Extract necessary variables from ADF configure dictionary:
-        input_ts_loc    = cam_climo_dict['cam_ts_loc']
-        write_html      = self.__basic_info['create_html']
-        var_list        = self.__diag_var_list
+
+        #case name:
+        case_name = self.read_config_var('cam_case_name',
+                                         conf_dict=cam_climo_dict,
+                                         required=True)
+
+        #Case time series location:
+        input_ts_loc = self.read_config_var('cam_ts_loc',
+                                            conf_dict=cam_climo_dict,
+                                            required=True)
+
+        #HTML-writing logical (assumed False if missing):
+        write_html = self.read_config_var('create_html',
+                                          conf_dict=self.__basic_info)
+
+        #Variable list:
+        var_list = self.__diag_var_list
 
         #Set "data_name" variable, which depends on "compare_obs":
         if self.compare_obs:
             data_name = "obs"
         else:
-            data_name = self.__basic_info['cam_baseline_case_name']
+            data_name = self.read_config_var('cam_case_name',
+                                             conf_dict = self.__cam_bl_climo_info,
+                                             required=True)
 
         #Set "plot_location" variable, if it doesn't exist already, and save value in diag object.
         #Please note that this is also assumed to be the output location for the analyses scripts.
         if not self.__plot_loc:
-            plot_dir   = self.__basic_info['cam_diag_plot_loc']
-            syear = self.__cam_climo_info["start_year"]
-            eyear   = self.__cam_climo_info["end_year"]
+
+            #Plot directory:
+            plot_dir = self.read_config_var('cam_diag_plot_loc',
+                                            conf_dict = self.__basic_info,
+                                            required=True)
+
+            #Start year (not currently required):
+            syear = self.read_config_var('start_year',
+                                         conf_dict = self.__cam_climo_info)
+
+            #End year (not currently rquired):
+            eyear = self.read_config_var('end_year',
+                                         conf_dict = self.__cam_climo_info)
+
             if syear and eyear:
                 self.__plot_loc = os.path.join(plot_dir,
                                                f"{case_name}_vs_{data_name}_{syear}_{eyear}")
@@ -710,25 +788,57 @@ class AdfDiag(AdfConfig):
             return
 
         #Extract required input variables:
-        case_name       = self.__basic_info['cam_case_name']
-        model_rgrid_loc = self.__basic_info['cam_regrid_loc']
-        var_list        = self.__diag_var_list
+
+        #Case name:
+        case_name = self.read_config_var('cam_case_name',
+                                         conf_dict = self.__cam_climo_info,
+                                         required=True)
+
+        #Regridded model data:
+        model_rgrid_loc = self.read_config_var('cam_regrid_loc',
+                                               conf_dict = self.__basic_info,
+                                               required=True)
+
+        #Variable list:
+        var_list = self.__diag_var_list
 
         #Set "data" variables, which depend on "compare_obs":
         if self.compare_obs:
+
             data_name = "obs"
-            data_loc  = self.__basic_info['obs_climo_loc']
+
+            data_loc = self.read_config_var('obs_climo_loc',
+                                            conf_dict = self.__basic_info,
+                                            required=True)
+
             data_list = self.__obs_type_list
+
         else:
-            data_name = self.__basic_info['cam_baseline_case_name']
-            data_loc  = self.__basic_info['cam_baseline_climo_loc']
+
+            data_name = self.read_config_var('cam_case_name',
+                                             conf_dict = self.__cam_bl_climo_info,
+                                             required=True)
+
+            data_loc = self.read_config_var('cam_climo_loc',
+                                            conf_dict = self.__cam_bl_climo_info,
+                                            required=True)
+
             data_list = [data_name]
 
         #Set "plot_location" variable, if it doesn't exist already, and save value in diag object:
         if not self.__plot_loc:
-            plot_dir   = self.__basic_info['cam_diag_plot_loc']
-            syear = self.__cam_climo_info["start_year"]
-            eyear   = self.__cam_climo_info["end_year"]
+            plot_dir = self.read_config_var('cam_diag_plot_loc',
+                                            conf_dict=self.__basic_info,
+                                            required=True)
+
+            #Start year (not currently required):
+            syear = self.read_config_var('start_year',
+                                         conf_dict = self.__cam_climo_info)
+
+            #End year (not currently rquired):
+            eyear = self.read_config_var('end_year',
+                                         conf_dict = self.__cam_climo_info)
+
             if syear and eyear:
                 self.__plot_loc = os.path.join(plot_dir,
                                                f"{case_name}_vs_{data_name}_{syear}_{eyear}")
@@ -777,15 +887,18 @@ class AdfDiag(AdfConfig):
         #End if
 
         #Extract needed variables from yaml file:
-        case_name = self.__basic_info['cam_case_name']
+        case_name = self.read_config_var('cam_case_name',
+                                         conf_dict=self.__cam_climo_info,
+                                         required=True)
+
         var_list = self.__diag_var_list
 
         #Set name of comparison data, which depends on "compare_obs":
         if self.compare_obs:
             data_name = "obs"
         else:
-            data_name = self.read_config_var('cam_baseline_case_name',
-                                             conf_dict=self.__basic_info,
+            data_name = self.read_config_var('cam_case_name',
+                                             conf_dict=self.__cam_bl_climo_info,
                                              required=True)
         #End if
 

--- a/lib/plotting_functions.py
+++ b/lib/plotting_functions.py
@@ -373,7 +373,7 @@ def plot_zonal_mean_and_save(wks, adata, apsurf, ahya, ahyb, bdata, bpsurf, bhya
         else:
             norm1 = mpl.colors.Normalize(vmin=minval, vmax=maxval)
             cmap1 = None
-        diffnorm = normfunc(vmin=np.min(diff), vcenter=0.0, vmax=np.max(diff))
+        diffnorm = normfunc(vmin=min(np.min(diff),-1*np.max(diff)), vcenter=0.0, vmax=np.max(diff))
         fig, ax = plt.subplots(nrows=3, constrained_layout=True, sharex=True, sharey=True)
         img0, ax[0] = zonal_plot(adata['lat'], azm, ax=ax[0], norm=norm1)
         img1, ax[1] = zonal_plot(bdata['lat'], bzm, ax=ax[1], norm=norm1)

--- a/lib/plotting_functions.py
+++ b/lib/plotting_functions.py
@@ -220,6 +220,10 @@ def lev_to_plev(data, ps, hyam, hybm, P0=100000., new_levels=None,
     and so can potentially be sped-up via the use of a DASK cluster.
     """
 
+    #Temporary print statement to notify users to ignore warning messages.
+    #This should be replaced by a debug-log stdout filter at some point:
+    print("Please ignore the interpolation warnings that follow!")
+
     #Apply GeoCAT hybrid->pressure interpolation:
     if new_levels is not None:
         data_interp = gcomp.interpolation.interp_hybrid_to_pressure(data, ps,
@@ -234,7 +238,6 @@ def lev_to_plev(data, ps, hyam, hybm, P0=100000., new_levels=None,
                                                                     hybm,
                                                                     p0=P0
                                                                    )
-
 
     #Rename vertical dimension back to "lev" in order to work with
     #the ADF plotting functions:

--- a/lib/test/unit_tests/test_adf_config.py
+++ b/lib/test/unit_tests/test_adf_config.py
@@ -55,9 +55,9 @@ class AdfConfigTestRoutine(unittest.TestCase):
         #Also check that "read_config_var" works as expected:
         basic_diag_dict = adf_test.read_config_var("diag_basic_info")
 
-        cam_case_name_val = adf_test.read_config_var("cam_case_name", conf_dict=basic_diag_dict)
+        cam_case_name_val = adf_test.read_config_var("cam_regrid_loc", conf_dict=basic_diag_dict)
 
-        self.assertEqual(cam_case_name_val, "new_best.came-run")
+        self.assertEqual(cam_case_name_val, "/some/where/you/want/to/have/regridded_files")
 
     #####
 

--- a/lib/test/unit_tests/test_adf_config.py
+++ b/lib/test/unit_tests/test_adf_config.py
@@ -143,9 +143,33 @@ class AdfConfigTestRoutine(unittest.TestCase):
 
         """
         Check that the "read_config_var"
+        method returns None when a
+        non-required variable is requested that
+        doesn't exist in the config dictionary.
+        """
+
+        #Use example config file:
+        baseline_example_file = os.path.join(_ADF_LIB_DIR, os.pardir, "config_cam_baseline_example.yaml")
+
+        #Create AdfConfig object:
+        adf_test = AdfConfig(baseline_example_file)
+
+        #Try to read non-existing variable:
+        conf_val = adf_test.read_config_var("hello")
+
+        #Check that provided value is "None":
+        self.assertEqual(conf_val, None)
+
+    #####
+
+    def test_AdfConfig_read_config_missing_required_var(self):
+
+        """
+        Check that the "read_config_var"
         method throws the correct error
         when a variable is requested that
-        doesn't exist in the config dictionary.
+        doesn't exist in the config dictionary,
+        and is required.
         """
 
         #Use example config file:
@@ -157,13 +181,13 @@ class AdfConfigTestRoutine(unittest.TestCase):
         #Set error message:
         #Note that for some reason a KeyError adds exra quotes,
         #hence the extra string quotes here
-        ermsg = '''"Variable 'hello' not found in config file. Please see 'config_cam_baseline_example.yaml'."'''
+        ermsg = '''"Required variable 'hello' not found in config file. Please see 'config_cam_baseline_example.yaml'."'''
 
         #Expect a Key error:
         with self.assertRaises(KeyError) as err:
 
             #Try to read non-existing variable:
-            _ = adf_test.read_config_var("hello")
+            _ = adf_test.read_config_var("hello", required=True)
 
         #Check that error message matches what's expected:
         self.assertEqual(ermsg, str(err.exception))
@@ -171,6 +195,29 @@ class AdfConfigTestRoutine(unittest.TestCase):
     #####
 
     def test_AdfConfig_read_config_unset_var(self):
+
+        """
+        Check that the "read_config_var"
+        method returns None when a
+        non-required variable is requested that
+        exists but hasn't been set to a value.
+        """
+
+        #Use unset var config file:
+        unset_example_file = os.path.join(_TEST_FILES_DIR, "config_cam_unset_var.yaml")
+
+        #Create AdfConfig object:
+        adf_test = AdfConfig(unset_example_file)
+
+        #Try to read non-existing variable:
+        conf_val = adf_test.read_config_var("bad_var")
+
+        #Check that provided value is "None":
+        self.assertEqual(conf_val, None)
+
+    #####
+
+    def test_AdfConfig_read_config_required_unset_var(self):
 
         """
         Check that the "read_config_var"
@@ -186,13 +233,13 @@ class AdfConfigTestRoutine(unittest.TestCase):
         adf_test = AdfConfig(unset_example_file)
 
         #Set error message:
-        ermsg = "Variable 'bad_var' has not been set to a value. Please see 'config_cam_baseline_example.yaml'."
+        ermsg = "Required variable 'bad_var' has not been set to a value. Please see 'config_cam_baseline_example.yaml'."
 
         #Expect a Value error:
         with self.assertRaises(ValueError) as err:
 
             #Try to read non-existing variable:
-            _ = adf_test.read_config_var("bad_var")
+            _ = adf_test.read_config_var("bad_var", required=True)
 
         #Check that error message matches what's expected:
         self.assertEqual(ermsg, str(err.exception))

--- a/scripts/plotting/global_latlon_map.py
+++ b/scripts/plotting/global_latlon_map.py
@@ -125,9 +125,9 @@ def global_latlon_map(case_name, model_rgrid_loc, data_name, data_loc,
                     #
 
                     #Create new dictionaries:
-                    mseasons = dict()
-                    oseasons = dict()
-                    dseasons = dict() # hold the differences
+                    mseasons = {}
+                    oseasons = {}
+                    dseasons = {} # hold the differences
 
                     #Loop over season dictionary:
                     for s in seasons:

--- a/scripts/plotting/zonal_mean.py
+++ b/scripts/plotting/zonal_mean.py
@@ -150,9 +150,9 @@ def zonal_mean(case_name, model_rgrid_loc, data_name, data_loc,
             #
 
             #Create new dictionaries:
-            mseasons = dict()
-            oseasons = dict()
-            dseasons = dict() # hold the differences
+            mseasons = {}
+            oseasons = {}
+            dseasons = {} # hold the differences
 
             #Loop over season dictionary:
             for s in seasons:


### PR DESCRIPTION
Re-arranged the expected (and example) ADF config YAML file as requested by AMP testers such that all model case-related variables (e.g. case name and climo file paths) are located in the model case subsections along with the rest of the associated case variables.

Also did some additional code modifications and clean-up to prepare for future developments, and fixed a plotting bug.

Closes #57 
Fixes #38 