### PR TITLE
Add new conda env for intake-esm

### DIFF
--- a/env/conda_environment.yaml
+++ b/env/conda_environment.yaml
@@ -14,4 +14,8 @@ dependencies:
   - netcdf4
   - geocat-comp
   - python=3.9
+  - pip
+  - pip:
+      - git+https://github.com/intake/intake-esm.git
+      - git+https://github.com/NCAR/ecgtools.git
 prefix: /glade/u/home/brianpm/miniconda3/envs/adf_diag


### PR DESCRIPTION
Add the development versions of `intake-esm` and `ecgtools` to the intake-esm branch