### PR TITLE
Fixed map_plot_and_save attributes passing and example

### DIFF
--- a/lib/adf_variable_defaults.yaml
+++ b/lib/adf_variable_defaults.yaml
@@ -24,6 +24,9 @@ PRECC:
   scale_factor: 86400000
   add_offset: 0
   new_unit: "mm/d"
+  mpl:
+    colorbar:
+      label : "mm/d"
 
 TGCLDLWP:
   colormap: "Blues"

--- a/lib/plotting_functions.py
+++ b/lib/plotting_functions.py
@@ -202,14 +202,15 @@ def plot_map_and_save(wks, mdlfld, obsfld, diffld, **kwargs):
     else:
         normdiff = mpl.colors.Normalize(vmin=np.min(levelsdiff), vmax=np.max(levelsdiff))
     
+    subplots_opt = {}
+    contourf_opt = {}
+    colorbar_opt = {}
 
     # extract any MPL kwargs that should be passed on:
     if 'mpl' in kwargs:
-        subplots_opt = kwargs['mpl'].get('subplots')
-        contourf_opt = kwargs['mpl'].get('contourf')
-        colorbar_opt = kwargs['mpl'].get('colorbar')
-    else:
-        subplots_opt = contourf_opt = colorbar_opt = {}
+        subplots_opt.update(kwargs['mpl'].get('subplots',{}))
+        contourf_opt.update(kwargs['mpl'].get('contourf',{}))
+        colorbar_opt.update(kwargs['mpl'].get('colorbar',{}))
 
     fig, ax = plt.subplots(figsize=(6,12), nrows=3, subplot_kw={"projection":ccrs.PlateCarree()}, **subplots_opt)
     img = [] # contour plots


### PR DESCRIPTION
This Closes #84 

I modified the plotting_functions.py code for the map_plot_and_save to fix an error in being able to assign matplotlib (mpl) attributes. This is implemented with a sample label on the colorbar for a particular variable.

It fixes a bug. Not an ideal solution (would be better to perhaps pass units for any variable? But this is needed for the mpl functionality to work....