### PR TITLE
Added PRECT defaults

### DIFF
--- a/lib/adf_variable_defaults.yaml
+++ b/lib/adf_variable_defaults.yaml
@@ -25,6 +25,15 @@ PRECC:
   add_offset: 0
   new_unit: "mm/d"
 
+PRECT:
+  colormap: "Blues"
+  contour_levels_range: [0, 20, 1]
+  diff_colormap: "seismic"
+  diff_contour_range: [-10, 10, 0.5]
+  scale_factor: 86400000
+  add_offset: 0
+  new_unit: "mm/d"
+
 TGCLDLWP:
   colormap: "Blues"
   contour_levels_range: [0, 400, 10]


### PR DESCRIPTION
Added PRECT (~identical to PRECC) option in adf_variable_defaults.yaml, to plot in mm/day. 

Links to #87 