### PR TITLE
Add new observations framework to ADF

### DIFF
--- a/.github/scripts/pr_mod_file_tests.py
+++ b/.github/scripts/pr_mod_file_tests.py
@@ -141,6 +141,7 @@ def _main_prog():
     #argument, and include everything inside the "lib" directory -JN:
     testable_files = {"lib/adf_base.py",
                       "lib/adf_config.py",
+                      "lib/adf_obs.py",
                       "lib/adf_diag.py"}
 
     #+++++++++++++++++++++++

--- a/config_cam_baseline_example.yaml
+++ b/config_cam_baseline_example.yaml
@@ -65,8 +65,10 @@ diag_basic_info:
     #(usually "case_vs_obs_XXX" or "case_vs_baseline_XXX").
     create_html: true
 
-    #Location of observational climatologies (only matters if "compare_obs" is true):
-    obs_climo_loc: /glade/work/brianpm/observations/climo_files
+    #Location of observational datasets:
+    #Note: this only matters if "compare_obs" is true and the path
+    #isn't specified in the variable defaults file.
+    obs_data_loc: /glade/work/nusbaume/SE_projects/model_diagnostics/ADF_obs
 
     #Location where re-gridded CAM climatology files are stored:
     cam_regrid_loc: /some/where/you/want/to/have/regridded_files #MUST EDIT!
@@ -281,9 +283,5 @@ diag_var_list:
     - PSL
     - Q
 #<Add more variables here.>
-
-#List of observation types (filename prefixes) CAM can be compared against:
-obs_type_list:
-    - CERES_EBAF_Ed4.1
 
 #END OF FILE

--- a/lib/adf_config.py
+++ b/lib/adf_config.py
@@ -294,8 +294,11 @@ class AdfConfig(AdfBase):
             emsg += " Please see 'config_cam_baseline_example.yaml'."
             raise ValueError(emsg)
 
-        #return a copy of the variable/list/dictionary:
-        return copy.copy(var)
+        #return a copy of the variable/list/dictionary,
+        #this is done so that scripts can modify the copy
+        #without worrying about modifying the actual
+        #config variables dictionary:
+        return copy.deepcopy(var)
 
 #++++++++++++++++++++
 #End Class definition

--- a/lib/adf_obs.py
+++ b/lib/adf_obs.py
@@ -1,0 +1,249 @@
+"""
+Observations (obs) class for the Atmospheric
+Diagnostics Framework (ADF).
+This class inherits from the AdfConfig class.
+
+Currently this class does four things:
+
+1.  Initializes an instance of AdfConfig.
+
+2.  Sets the "variable_defaults" ADF variable.
+
+3.  Determines if this is a model vs obs ADF run
+
+4.  If so, then creates a dictionary of what
+    observational dataset is associated with
+    each requested variable, along with any
+    relevant observational meta-data.
+
+This class also provide methods for extracting
+the observational data and meta-data for use
+in various scripts.
+"""
+
+#++++++++++++++++++++++++++++++
+#Import standard python modules
+#++++++++++++++++++++++++++++++
+
+import copy
+
+from pathlib import Path
+
+#+++++++++++++++++++++++++++++++++++++++++++++++++
+#import non-standard python modules, including ADF
+#+++++++++++++++++++++++++++++++++++++++++++++++++
+
+import yaml
+
+#ADF modules:
+from adf_config import AdfConfig
+
+#+++++++++++++++++++
+#Define Obs class
+#+++++++++++++++++++
+
+class AdfObs(AdfConfig):
+
+    """
+    Observations class, which reads in
+    config (YAML) files and provides
+    a mechanism to process and retreive
+    relevant config variables.
+    """
+
+    def __init__(self, config_file, debug=False):
+
+        """
+        Initalize ADF Obs object.
+        """
+
+        #Initialize Config attributes:
+        super().__init__(config_file, debug=debug)
+
+        #Determine local directory:
+        _adf_lib_dir = Path(__file__).parent
+
+        #Read in "basic_info" config dictionary:
+        _basic_info = self.read_config_var('diag_basic_info', required=True)
+
+        #Expand basic info variable strings:
+        self.expand_references(_basic_info)
+
+        #Determin if variable defaults will be used:
+        self.__use_defaults = self.read_config_var('use_defaults', conf_dict=_basic_info)
+
+        # Check whether user wants to use defaults:
+        #-----------------------------------------
+        if self.__use_defaults:
+            #Determine whether to use adf defaults or custom:
+            _defaults_file = self.read_config_var('custom_defaults', conf_dict=_basic_info)
+            if _defaults_file is None:
+                _defaults_file = _adf_lib_dir/'adf_variable_defaults.yaml'
+
+            #Open YAML file:
+            with open(_defaults_file, encoding='UTF-8') as dfil:
+                self.__variable_defaults = yaml.load(dfil, Loader=yaml.SafeLoader)
+        else:
+            #Set variable_defaults to empty dictionary:
+            self.__variable_defaults = {}
+        #-----------------------------------------
+
+        #Initialize ADF variable list:
+        self.__diag_var_list = self.read_config_var('diag_var_list', required=True)
+
+        #Initialize "compare_obs" variable:
+        self.__compare_obs = self.read_config_var('compare_obs', conf_dict=_basic_info)
+
+        #Initialize observations dictionary:
+        self.__var_obs_dict = {}
+
+        #If this is not a model vs obs run, then stop here:
+        if not self.__compare_obs:
+            return
+
+        #Extract the "obs_data_loc" default observational data location:
+        obs_data_loc = self.read_config_var("obs_data_loc", conf_dict=_basic_info)
+
+        #Check that a variable defaults file exists (as it is currently needed to extract obs data):
+        if not self.__variable_defaults:
+            #Determine whether to use adf defaults or custom:
+            _defaults_file = self.read_config_var('custom_defaults', conf_dict=_basic_info)
+            if _defaults_file is None:
+                _defaults_file = _adf_lib_dir/'adf_variable_defaults.yaml'
+
+            #Open YAML file (but don't assign to object):
+            with open(_defaults_file, encoding='UTF-8') as nfil:
+                _variable_defaults = yaml.load(nfil, Loader=yaml.SafeLoader)
+        else:
+            #Set local variable to stored variable defaults dictionary:
+            _variable_defaults = self.__variable_defaults
+        #End if
+
+        #Loop over variable list:
+        for var in self.__diag_var_list:
+
+            #Check if variable is in defaults dictionary:
+            if var in _variable_defaults:
+                #Extract variable sub-dictionary:
+                default_var_dict = _variable_defaults[var]
+
+                #Check if an observations file is specified:
+                if "obs_file" in default_var_dict:
+                    #Set found variable:
+                    found = False
+
+                    #Extract path/filename:
+                    obs_file_path = Path(default_var_dict["obs_file"])
+
+                    #Check if file exists:
+                    if not obs_file_path.is_file():
+                        #If not, then check if it is in "obs_data_loc"
+                        if obs_data_loc:
+                            obs_file_path = Path(obs_data_loc)/obs_file_path
+
+                            if obs_file_path.is_file():
+                                found = True
+
+                    else:
+                        #File was found:
+                        found = True
+                    #End if
+
+                    #If found, then set observations dataset and variable names:
+                    if found:
+                        #Check if observations dataset name is specified:
+                        if "obs_name" in default_var_dict:
+                            obs_name = default_var_dict["obs_name"]
+                        else:
+                            #If not, then just use obs file name:
+                            obs_name = obs_file_path.name
+
+                        #Check if observations variable name is specified:
+                        if "obs_var_name" in default_var_dict:
+                            #If so, then set obs_var_name variable:
+                            obs_var_name = default_var_dict["obs_var_name"]
+                        else:
+                            #Assume observation variable name is the same ad model variable:
+                            obs_var_name = var
+                        #End if
+
+                        #Add variable to observations dictionary:
+                        self.__var_obs_dict[var] = \
+                            {"obs_file" : obs_file_path,
+                             "obs_name" : obs_name,
+                             "obs_var" : obs_var_name}
+
+                    else:
+                        #If not found, then print to log and skip variable:
+                        msg = f'''Unable to find obs file '{default_var_dict["obs_file"]}' '''
+                        msg += f"for variable '{var}'."
+                        self.debug_log(msg)
+                        continue
+                    #End if
+
+                else:
+                    #No observation file was specified, so print
+                    #to log and skip variable:
+                    self.debug_log(f"No observations file was listed for variable '{var}'.")
+                    continue
+            else:
+                #Variable not in defaults file, so print to log and skip variable:
+                msg = f"Variable '{var}' not found in variable defaults file: `{_defaults_file}`"
+                self.debug_log(msg)
+            #End if
+        #End for (var)
+
+        #If variable dictionary is still empty, then print warning to screen:
+        if not self.__var_obs_dict:
+            wmsg = "!!!!WARNING!!!!\n"
+            wmsg += "No observations found for any variables, but this is a model vs obs run!\n"
+            wmsg += "ADF will still calculate time series and climatologies if requested,"
+            wmsg += " but will stop there.\n"
+            wmsg += "If this result is unexpected, then run with '--debug'"
+            wmsg += " and check the log for messages.\n"
+            wmsg += "!!!!!!!!!!!!!!!\n"
+            print(wmsg)
+
+    #########
+
+    # Create property needed to return "variable_defaults" variable to user:
+    @property
+    def variable_defaults(self):
+        """Return a copy of the '__variable_defaults' string list to user if requested."""
+        #Note that a copy is needed in order to avoid having a script mistakenly
+        #modify this variable:
+        return copy.copy(self.__variable_defaults)
+
+    # Create property needed to return "use_defaults" variable to user:
+    @property
+    def use_defaults(self):
+        """Return a copy of the '__use_defaults' logical to user if requested."""
+        #Note that a copy is needed in order to avoid having a script mistakenly
+        #modify this variable:
+        return copy.copy(self.__use_defaults)
+
+    # Create property needed to return "compare_obs" logical to user:
+    @property
+    def compare_obs(self):
+        """Return the "compare_obs" logical to user if requested."""
+        return copy.copy(self.__compare_obs)
+
+    # Create property needed to return "diag_var_list" list to user:
+    @property
+    def diag_var_list(self):
+        """Return a copy of the "diag_var_list" list to user if requested."""
+        #Note that a copy is needed in order to avoid having a script mistakenly
+        #modify this variable:
+        return copy.copy(self.__diag_var_list)
+
+    #Create property needed to return "var_obs_dict" list to user:
+    @property
+    def var_obs_dict(self):
+        """Return a copy of the "var_obs_dict" list to user if requested."""
+        #Note that a copy is needed in order to avoid having a script mistakenly
+        #modify this variable:
+        return copy.copy(self.__var_obs_dict)
+
+#++++++++++++++++++++
+#End Class definition
+#++++++++++++++++++++

--- a/lib/adf_variable_defaults.yaml
+++ b/lib/adf_variable_defaults.yaml
@@ -1,3 +1,42 @@
+
+#This file lists out variable-specific defaults
+#for plotting and observations.  These defaults
+#are:
+#
+# PLOTTING:
+#
+# colormap             -> The colormap that will be used for filled contour plots.
+# contour_levels       -> A list of the specific contour values that will be used for contour plots.
+#                         Cannot be used with "contour_levels_range".
+# contour_levels_range -> The contour range that will be used for plots.
+#                         Values are min, max, and stride.  Cannot be used with "contour_levels".
+# diff_colormap        -> The colormap that will be used for filled contour different plots
+# diff_contour_levels  -> A list of the specific contour values thta will be used for difference plots.
+#                         Cannot be used with "diff_contour_range".
+# diff_contour_range   -> The contour range that will be used for difference plots.
+#                         Values are min, max, and stride. Cannot be used with "diff_contour_levels".
+# scale_factor         -> Amount to scale the variable (relative to its "raw" model values).
+# add_offset           -> Amount of offset to add to the variable (relatie to its "raw" model values).
+# new_unit             -> Variable units (if not using the  "raw" model units).
+# mpl                  -> Dictionary that contains keyword arguments explicitly for matplotlib
+#
+#
+# OBSERVATIONS:
+#
+# obs_file     -> Path to observations file.  If only the file name is given, then the file is assumed to
+#                 exist in the path specified by "obs_data_loc" in the config file.
+# obs_name     -> Name of the observational dataset (mostly used for plotting and generated file naming).
+#                 If this isn't present then the obs_file name is used.
+# obs_var_name -> Variable in the observations file to compare against.  If this isn't present then the
+#                 variable name is assumed to be the same as the model variable name.
+#
+# Final Note:  Please do not modify this file unless you plan to push your changes back to the ADF repo.
+#              If you would like to modify this file for your personal ADF runs then it is recommended
+#              to make a copy of this file, make modifications in that copy, and then point the ADF to
+#              it using the "defaults_file" config variable.
+#
+#+++++++++++
+
 PSL:
   colormap: "Oranges"
   contour_levels_range: [980, 1052, 4]
@@ -114,6 +153,9 @@ SWCF:
   mpl:
     colorbar:
       label : "Wm$^{-2}$"
+  obs_file: "CERES_EBAF_Ed4.1_SWCF_climo.nc"
+  obs_name: "CERES_EBAF_Ed4.1"
+  obs_var_name: "SWCF"
 
 LWCF:
   colormap: "Blues"
@@ -126,3 +168,9 @@ LWCF:
   mpl:
     colorbar:
       label : "Wm$^{-2}$"
+  obs_file: "CERES_EBAF_Ed4.1_LWCF_climo.nc"
+  obs_name: "CERES_EBAF_Ed4.1"
+  obs_var_name: "LWCF"
+
+#-----------
+#End of File

--- a/lib/test/pylintrc
+++ b/lib/test/pylintrc
@@ -177,7 +177,7 @@ score=yes
 [REFACTORING]
 
 # Maximum number of nested blocks for function / method body
-max-nested-blocks=5
+max-nested-blocks=10
 
 # Complete name of functions that never returns. When checking for
 # inconsistent-return-statements if a never returning function is called then

--- a/run_adf_diag
+++ b/run_adf_diag
@@ -158,6 +158,12 @@ if __name__ == "__main__":
     #in the config file:
     diag.create_climo()
 
+    #If a user is doing a model vs obs comparison, but
+    #no observations were found, then stop here:
+    if diag.compare_obs and not diag.var_obs_dict:
+        print('ADF diagnostics has completed successfully.')
+        sys.exit(0)
+
     #Regrid model climatology files to match either
     #observations or CAM baseline climatologies.
     #This call uses the "regridding_scripts" specified

--- a/scripts/plotting/global_latlon_map.py
+++ b/scripts/plotting/global_latlon_map.py
@@ -68,9 +68,15 @@ def global_latlon_map(adfobj):
     # Until those are both treated the same (via intake-esm or similar)
     # we will do a simple check and switch options as needed:
     if adfobj.get_basic_info("compare_obs"):
-        data_name = "obs"  # does not get used, is just here as a placemarker
-        data_list = adfobj.read_config_var("obs_type_list")  # Double caution!
-        data_loc  = adfobj.get_basic_info("obs_climo_loc", required=True)
+
+        #Extract variable-obs dictionary:
+        var_obs_dict = adfobj.var_obs_dict
+
+        #If dictionary is empty, then  there are no observations to regrid to,
+        #so quit here:
+        if not var_obs_dict:
+            print("No observations found to regrid to, so no re-gridding will be done.")
+            return
 
     else:
         data_name = adfobj.get_baseline_info("cam_case_name", required=True) # does not get used, is just here as a placemarker
@@ -90,8 +96,9 @@ def global_latlon_map(adfobj):
 
     #Set data path variables:
     #-----------------------
-    dclimo_loc    = Path(data_loc)
     mclimo_rg_loc = Path(model_rgrid_loc)
+    if not adfobj.compare_obs:
+        dclimo_loc  = Path(data_loc)
     #-----------------------
 
     #Set seasonal ranges:
@@ -104,6 +111,26 @@ def global_latlon_map(adfobj):
 
     # probably want to do this one variable at a time:
     for var in var_list:
+
+        if adfobj.compare_obs:
+            #Check if obs exist for the variable:
+            if var in var_obs_dict:
+                #Note: In the future these may all be lists, but for
+                #now just convert the target_list.
+                #Extract target file:
+                dclimo_loc = var_obs_dict[var]["obs_file"]
+                #Extract target list (eventually will be a list, for now need to convert):
+                data_list = [var_obs_dict[var]["obs_name"]]
+                #Extract target variable name:
+                data_var = var_obs_dict[var]["obs_var"]
+            else:
+                dmsg = f"No obs found for variable `{var}`, lat/lon map plotting skipped."
+                adfobj.debug_log(dmsg)
+                continue
+        else:
+            #Set "data_var" for consistent use below:
+            data_var = var
+        #End if
 
         #Notify user of variable being plotted:
         print("\t \u231B lat/lon maps for {}".format(var))
@@ -121,7 +148,11 @@ def global_latlon_map(adfobj):
         for data_src in data_list:
 
             # load data (observational) commparison files (we should explore intake as an alternative to having this kind of repeated code):
-            oclim_fils = sorted(list(dclimo_loc.glob("{}_{}_*.nc".format(data_src, var))))
+            if adfobj.compare_obs:
+                #For now, only grab one file (but convert to list for use below)
+                oclim_fils = [dclimo_loc]
+            else:
+                oclim_fils = sorted(list(dclimo_loc.glob("{}_{}_*.nc".format(data_src, var))))
 
             if len(oclim_fils) > 1:
                 oclim_ds = xr.open_mfdataset(oclim_fils, combine='by_coords')
@@ -154,16 +185,20 @@ def global_latlon_map(adfobj):
                     mclim_ds = xr.open_dataset(mclim_fils[0])
 
                 #Extract variable of interest
-                odata = oclim_ds[var].squeeze()  # squeeze in case of degenerate dimensions
+                odata = oclim_ds[data_var].squeeze()  # squeeze in case of degenerate dimensions
                 mdata = mclim_ds[var].squeeze()
 
                 # APPLY UNITS TRANSFORMATION IF SPECIFIED:
-                odata = odata * vres.get("scale_factor",1) + vres.get("add_offset", 0)
+                # NOTE: looks like our climo files don't have all their metadata
                 mdata = mdata * vres.get("scale_factor",1) + vres.get("add_offset", 0)
                 # update units
-                # NOTE: looks like our climo files don't have all their metadata
-                odata.attrs['units'] = vres.get("new_unit", odata.attrs.get('units', 'none'))
                 mdata.attrs['units'] = vres.get("new_unit", mdata.attrs.get('units', 'none'))
+
+                # Do the same for the baseline case if need be:
+                if not adfobj.compare_obs:
+                    odata = odata * vres.get("scale_factor",1) + vres.get("add_offset", 0)
+                    # update units
+                    odata.attrs['units'] = vres.get("new_unit", odata.attrs.get('units', 'none'))
 
                 #Determine dimensions of variable:
                 has_dims = pf.lat_lon_validate_dims(odata)

--- a/scripts/plotting/global_latlon_map.py
+++ b/scripts/plotting/global_latlon_map.py
@@ -75,7 +75,7 @@ def global_latlon_map(adfobj):
         #If dictionary is empty, then  there are no observations to regrid to,
         #so quit here:
         if not var_obs_dict:
-            print("No observations found to regrid to, so no re-gridding will be done.")
+            print("No observations found to plot against, so no lat/lon maps will be generated.")
             return
 
     else:

--- a/scripts/plotting/polar_map.py
+++ b/scripts/plotting/polar_map.py
@@ -58,7 +58,7 @@ def polar_map(adfobj):
         #If dictionary is empty, then  there are no observations to regrid to,
         #so quit here:
         if not var_obs_dict:
-            print("No observations found to regrid to, so no re-gridding will be done.")
+            print("No observations found to plot against, so no polar maps will be generated..")
             return
 
     else:

--- a/scripts/plotting/zonal_mean.py
+++ b/scripts/plotting/zonal_mean.py
@@ -70,7 +70,7 @@ def zonal_mean(adfobj):
         #If dictionary is empty, then  there are no observations to regrid to,
         #so quit here:
         if not var_obs_dict:
-            print("No observations found to regrid to, so no re-gridding will be done.")
+            print("No observations found to plot against, so no zonal-mean maps will be generated.")
             return
 
     else:

--- a/scripts/plotting/zonal_mean.py
+++ b/scripts/plotting/zonal_mean.py
@@ -63,9 +63,15 @@ def zonal_mean(adfobj):
     # Until those are both treated the same (via intake-esm or similar)
     # we will do a simple check and switch options as needed:
     if adfobj.get_basic_info("compare_obs"):
-        data_name = "obs"  # does not get used, is just here as a placemarker
-        data_list = adfobj.read_config_var("obs_type_list")  # Double caution!
-        data_loc = adfobj.get_basic_info("obs_climo_loc", required=True)
+
+        #Extract variable-obs dictionary:
+        var_obs_dict = adfobj.var_obs_dict
+
+        #If dictionary is empty, then  there are no observations to regrid to,
+        #so quit here:
+        if not var_obs_dict:
+            print("No observations found to regrid to, so no re-gridding will be done.")
+            return
 
     else:
         data_name = adfobj.get_baseline_info("cam_case_name", required=True) # does not get used, is just here as a placemarker
@@ -86,8 +92,9 @@ def zonal_mean(adfobj):
 
     #Set data path variables:
     #-----------------------
-    dclimo_loc    = Path(data_loc)
     mclimo_rg_loc = Path(model_rgrid_loc)
+    if not adfobj.compare_obs:
+        dclimo_loc  = Path(data_loc)
     #-----------------------
 
     #Set seasonal ranges:
@@ -100,6 +107,27 @@ def zonal_mean(adfobj):
     #Loop over variables:
     for var in var_list:
 
+        if adfobj.compare_obs:
+            #Check if obs exist for the variable:
+            if var in var_obs_dict:
+                #Note: In the future these may all be lists, but for
+                #now just convert the target_list.
+                #Extract target file:
+                dclimo_loc = var_obs_dict[var]["obs_file"]
+                #Extract target list (eventually will be a list, for now need to convert):
+                data_list = [var_obs_dict[var]["obs_name"]]
+                #Extract target variable name:
+                data_var = var_obs_dict[var]["obs_var"]
+            else:
+                dmsg = f"No obs found for variable `{var}`, zonal mean plotting skipped."
+                adfobj.debug_log(dmsg)
+                continue
+            #End if
+        else:
+            #Set "data_var" for consistent use below:
+            data_var = var
+        #End if
+
         #Notify user of variable being plotted:
         print("\t \u231B zonal mean plots for {}".format(var))
 
@@ -111,12 +139,18 @@ def zonal_mean(adfobj):
 
         else:
             vres = {}
+        #End if
 
         #loop over different data sets to plot model against:
         for data_src in data_list:
             # load data (observational) comparison files
             # (we should explore intake as an alternative to having this kind of repeated code):
-            oclim_fils = sorted(list(dclimo_loc.glob("{}_{}_*.nc".format(data_src, var))))
+            if adfobj.compare_obs:
+                #For now, only grab one file (but convert to list for use below)
+                oclim_fils = [dclimo_loc]
+            else:
+                oclim_fils = sorted(list(dclimo_loc.glob("{}_{}_*.nc".format(data_src, var))))
+            #End if
             oclim_ds = _load_dataset(oclim_fils)
 
             #Loop over model cases:
@@ -140,16 +174,20 @@ def zonal_mean(adfobj):
                     continue
 
                 #Extract variable of interest
-                odata = oclim_ds[var].squeeze()  # squeeze in case of degenerate dimensions
+                odata = oclim_ds[data_var].squeeze()  # squeeze in case of degenerate dimensions
                 mdata = mclim_ds[var].squeeze()
 
                 # APPLY UNITS TRANSFORMATION IF SPECIFIED:
-                odata = odata * vres.get("scale_factor",1) + vres.get("add_offset", 0)
+                # NOTE: looks like our climo files don't have all their metadata
                 mdata = mdata * vres.get("scale_factor",1) + vres.get("add_offset", 0)
                 # update units
-                # NOTE: looks like our climo files don't have all their metadata
-                odata.attrs['units'] = vres.get("new_unit", odata.attrs.get('units', 'none'))
                 mdata.attrs['units'] = vres.get("new_unit", mdata.attrs.get('units', 'none'))
+
+                # Do the same for the baseline case if need be:
+                if not adfobj.compare_obs:
+                    odata = odata * vres.get("scale_factor",1) + vres.get("add_offset", 0)
+                    # update units
+                    odata.attrs['units'] = vres.get("new_unit", odata.attrs.get('units', 'none'))
 
                 # determine whether it's 2D or 3D
                 # 3D triggers search for surface pressure


### PR DESCRIPTION
This PR adds the ability to specify observational data sets for a particular variable via the "variable defaults" YAML file.  It also adds some ADF infrastructure which should help in the processing of observational files, particularly in the future when more varied observational datasets will need to be managed by the ADF.

closes #100
closes #102

## Tests run:

Tested with `compare_obs` set to both `true` and `false` for both single and mutli-case ADF runs using observations specified for `SWCF` and `LWCF` that were originally created by @brianpm. 