### PR TITLE
Use specified year bounds for climo calculation

### DIFF
--- a/lib/adf_diag.py
+++ b/lib/adf_diag.py
@@ -468,6 +468,20 @@ class AdfDiag(AdfObs):
                                                   required=True)
             ts_dir        = self.read_config_var('cam_ts_loc', conf_dict=cam_climo_dict,
                                                   required=True)
+            overwrite_ts  = self.read_config_var('cam_overwrite_ts', conf_dict=cam_climo_dict)
+
+            #If variables weren't provided in config file, then make them a list
+            #containing only None-type entries:
+            if not cam_ts_done:
+                cam_ts_done = [None]*len(case_names)
+            if not overwrite_ts:
+                overwrite_ts = [None]*len(case_names)
+            if not start_years:
+                start_years = [None]*len(case_names)
+            if not end_years:
+                end_years = [None]*len(case_names)
+            #End if
+
             #Also rename case name list:
             case_name_list = case_names
         else:
@@ -479,6 +493,8 @@ class AdfDiag(AdfObs):
                                                   required=True)]
             ts_dir        = [self.read_config_var('cam_ts_loc', conf_dict=cam_climo_dict,
                                                    required=True)]
+            overwrite_ts  = [self.read_config_var('cam_overwrite_ts', conf_dict=cam_climo_dict)]
+
             #Also convert  case_names to list:
             case_name_list = [case_names]
         #End if
@@ -548,7 +564,7 @@ class AdfDiag(AdfObs):
                 files_list = sorted(list(starting_location.glob('*.cam.h0.*.nc')))
             else:
                 #Create empty list:
-                files_list = list()
+                files_list = []
 
                 #For now make sure both year values are present:
                 if start_year == "*" or end_year == "*":
@@ -585,12 +601,12 @@ class AdfDiag(AdfObs):
 
                 #If files exist, then check if over-writing is allowed:
                 if ts_file_list:
-                    if not cam_climo_dict['cam_overwrite_ts']:
+                    if not overwrite_ts[case_idx]:
                         #If not, then simply skip this variable:
                         continue
 
                 #Notify user of new time series file:
-                print("\t \u231B time series for {}".format(var))
+                print("\t - time series for {}".format(var))
 
                 #Run "ncrcat" command to generate time series file:
                 cmd = ["ncrcat", "-O", "-4", "-h", "-v", f"{var},hyam,hybm,hyai,hybi,PS"] + \

--- a/lib/plotting_functions.py
+++ b/lib/plotting_functions.py
@@ -40,8 +40,8 @@ def use_this_norm():
 def get_difference_colors(values):
     """Provide a color norm and colormap assuming this is a difference field.
 
-       Values can be either the data field or a set of specified contour levels. 
-    
+       Values can be either the data field or a set of specified contour levels.
+
        Uses 'OrRd' colormap for positive definite, 'BuPu_r' for negative definite,
        and 'RdBu_r' centered on zero if there are values of both signs.
     """

--- a/scripts/analysis/amwg_table.py
+++ b/scripts/analysis/amwg_table.py
@@ -166,7 +166,7 @@ def amwg_table(adf):
         for var in var_list:
 
             #Notify users of variable being added to table:
-            print("\t \u25B6 Variable '{}' being added to table".format(var))
+            print("\t - Variable '{}' being added to table".format(var))
 
             #Create list of time series files present for variable:
             ts_filenames = '{}.*.{}.*nc'.format(case_name, var)

--- a/scripts/averaging/averaging_example.py
+++ b/scripts/averaging/averaging_example.py
@@ -185,11 +185,11 @@ def averaging_example(adf, clobber=False, search=None):
             #start year:
             if check_syr:
                 if check_syr < 1000:
-                    if check_syr > 100:
+                    if check_syr >= 100:
                         syr = f"0{check_syr}"
-                    elif check_syr > 10:
+                    elif check_syr >= 10:
                         syr = f"00{check_syr}"
-                    elif check_syr > 1:
+                    elif check_syr >= 1:
                         syr = f"000{check_syr}"
                     else:
                         errmsg = " 'start_year' values must be positive whole numbers"
@@ -207,11 +207,11 @@ def averaging_example(adf, clobber=False, search=None):
             #end year:
             if check_eyr:
                 if check_eyr < 1000:
-                    if check_eyr > 100:
+                    if check_eyr >= 100:
                         eyr = f"0{check_eyr}"
-                    elif check_eyr > 10:
+                    elif check_eyr >= 10:
                         eyr = f"00{check_eyr}"
-                    elif check_eyr > 1:
+                    elif check_eyr >= 1:
                         eyr = f"000{check_eyr}"
                     else:
                         errmsg = " 'end_year' values must be positive whole numbers"
@@ -227,6 +227,7 @@ def averaging_example(adf, clobber=False, search=None):
             #End if
             #------------------
 
+            #Extract data subset using provided year bounds:
             cam_ts_data = cam_ts_data.sel(time=slice(syr, eyr))
 
             #Group time series values by month, and average those months together:

--- a/scripts/plotting/global_latlon_map.py
+++ b/scripts/plotting/global_latlon_map.py
@@ -133,7 +133,7 @@ def global_latlon_map(adfobj):
         #End if
 
         #Notify user of variable being plotted:
-        print("\t \u231B lat/lon maps for {}".format(var))
+        print("\t - lat/lon maps for {}".format(var))
 
         # Check res for any variable specific options that need to be used BEFORE going to the plot:
         if var in res:
@@ -250,11 +250,11 @@ def global_latlon_map(adfobj):
                             pf.plot_map_and_save(plot_name, mseasons[s], oseasons[s], dseasons[s], **vres)
 
                     else: #mdata dimensions check
-                        print("\t \u231B skipping lat/lon map for {} as it doesn't have only lat/lon dims.".format(var))
+                        print("\t - skipping lat/lon map for {} as it doesn't have only lat/lon dims.".format(var))
                     #End if (dimensions check)
 
                 else: #odata dimensions check
-                     print("\t \u231B skipping lat/lon map for {} as it doesn't have only lat/lon dims.".format(var))
+                     print("\t - skipping lat/lon map for {} as it doesn't have only lat/lon dims.".format(var))
 
                 #End if (dimensions check)
             #End for (case loop)

--- a/scripts/plotting/polar_map.py
+++ b/scripts/plotting/polar_map.py
@@ -116,7 +116,7 @@ def polar_map(adfobj):
         #End if
 
         #Notify user of variable being plotted:
-        print("\t \u231B polar maps for {}".format(var))
+        print("\t - polar maps for {}".format(var))
 
         # Check res for any variable specific options that need to be used BEFORE going to the plot:
         if var in res:
@@ -249,11 +249,11 @@ def polar_map(adfobj):
                             plt.close(shfig)
 
                     else: #mdata dimensions check
-                        print("\t \u231B skipping polar map for {} as it doesn't have only lat/lon dims.".format(var))
+                        print("\t - skipping polar map for {} as it doesn't have only lat/lon dims.".format(var))
                     #End if (dimensions check)
 
                 else: #odata dimensions check
-                     print("\t \u231B skipping polar map for {} as it doesn't have only lat/lon dims.".format(var))
+                     print("\t - skipping polar map for {} as it doesn't have only lat/lon dims.".format(var))
 
                 #End if (dimensions check)
             #End for (case loop)

--- a/scripts/plotting/zonal_mean.py
+++ b/scripts/plotting/zonal_mean.py
@@ -129,7 +129,7 @@ def zonal_mean(adfobj):
         #End if
 
         #Notify user of variable being plotted:
-        print("\t \u231B zonal mean plots for {}".format(var))
+        print("\t - zonal mean plots for {}".format(var))
 
         # Check res for any variable specific options that need to be used BEFORE going to the plot:
         if var in res:
@@ -196,7 +196,7 @@ def zonal_mean(adfobj):
                     print("{} has lev dimension.".format(var))
                     # need hyam, hybm, PS, P0 for both datasets
                     if 'hyam' not in mclim_ds:
-                        print("\u2757 PROBLEM -- NO hyam, skipping to next case/obs data")
+                        print("!! PROBLEM -- NO hyam, skipping to next case/obs data")
                         print(mclim_ds)
                         continue
                     mhya = mclim_ds['hyam']

--- a/scripts/regridding/regrid_example.py
+++ b/scripts/regridding/regrid_example.py
@@ -46,9 +46,6 @@ def regrid_example(adf):
     case_names = adf.get_cam_info("cam_case_name", required=True)
     input_climo_locs = adf.get_cam_info("cam_climo_loc", required=True)
 
-    print(case_names)
-    print(input_climo_locs)
-
     #Regrid target variables (either obs or a baseline run):
     if adf.compare_obs:
 
@@ -108,7 +105,7 @@ def regrid_example(adf):
                     continue
 
             #Notify user of variable being regridded:
-            print("\t [\u25B6] regridding {} (known targets: {})".format(var, len(target_list)))
+            print("\t - regridding {} (known targets: {})".format(var, len(target_list)))
 
             #loop over regridding targets:
             for target in target_list:
@@ -141,7 +138,7 @@ def regrid_example(adf):
                         #Combine all target files together into a single data set:
                         tclim_ds = xr.open_mfdataset(tclim_fils, combine='by_coords')
                     elif len(tclim_fils) == 0:
-                        print("\t [\u25B6] regridding {} failed, no file. Continuing to next variable.".format(var))
+                        print("\t - regridding {} failed, no file. Continuing to next variable.".format(var))
                         continue
                     else:
                         #Open single file as new xarray dataset:


### PR DESCRIPTION
This fixes #107
This fixes #115
This fixes #120 

In `averaging_example.py` this change is to check whether year bounds for the climatology calculation are provided in the configuration file. Just takes those years if so. 

Also checks whether to overwrite climo files. This seemed necessary because a use case would be to change the years used for the climo files and re-run ADF. 

From @nusbaume:

Also fixed bug with `cam_overwrite_ts` and replace some special print characters with just `-` and `!` in order to avoid issues with terminal corruption.
