### PR TITLE
Adding ERAI variables to variable defaults

### DIFF
--- a/lib/adf_variable_defaults.yaml
+++ b/lib/adf_variable_defaults.yaml
@@ -261,6 +261,9 @@ SWCF:
   obs_file: "CERES_EBAF_Ed4.1_2001-2020.nc"
   obs_name: "CERES_EBAF_Ed4.1"
   obs_var_name: "toa_cre_sw_mon"
+  obs_scale_factor: 1
+  obs_add_offset: 0
+ 
 
 LWCF:
   colormap: "Oranges"

--- a/lib/adf_variable_defaults.yaml
+++ b/lib/adf_variable_defaults.yaml
@@ -277,5 +277,95 @@ LWCF:
   obs_name: "CERES_EBAF_Ed4.1"
   obs_var_name: "toa_cre_lw_mon"
 
+FSUTOA:
+  colormap: "Blues"
+  contour_levels_range: [-10, 180, 15]
+  diff_colormap: "BrBG"
+  diff_contour_range: [-15, 15, 1]
+  scale_factor: 1
+  add_offset: 0
+  new_unit: "Wm$^{-2}$"
+  mpl:
+    colorbar:
+      label : "Wm$^{-2}$"
+  obs_file: "CERES_EBAF_Ed4.1_2001-2020.nc"
+  obs_name: "CERES_EBAF_Ed4.1"
+  obs_var_name: "toa_sw_all_mon"
+
+FLNT:
+  colormap: "Oranges"
+  contour_levels_range: [120, 320, 10]
+  diff_colormap: "BrBG"
+  diff_contour_range: [-20, 20, 2]
+  scale_factor: 1
+  add_offset: 0
+  new_unit: "Wm$^{-2}$"
+  mpl:
+    colorbar:
+      label : "Wm$^{-2}$"
+  obs_file: "CERES_EBAF_Ed4.1_2001-2020.nc"
+  obs_name: "CERES_EBAF_Ed4.1"
+  obs_var_name: "toa_lw_all_mon"
+
+FLNTC:
+  colormap: "Oranges"
+  contour_levels_range: [120, 320, 10]
+  diff_colormap: "BrBG"
+  diff_contour_range: [-20, 20, 2]
+  scale_factor: 1
+  add_offset: 0
+  new_unit: "Wm$^{-2}$"
+  mpl:
+    colorbar:
+      label : "Wm$^{-2}$"
+  obs_file: "CERES_EBAF_Ed4.1_2001-2020.nc"
+  obs_name: "CERES_EBAF_Ed4.1"
+  obs_var_name: "toa_lw_clr_t_mon"
+
+FSNS:
+  colormap: "Blues"
+  contour_levels_range: [-10, 300, 20]
+  diff_colormap: "BrBG"
+  diff_contour_range: [-24, 24, 2]
+  scale_factor: 1
+  add_offset: 0
+  new_unit: "Wm$^{-2}$"
+  mpl:
+    colorbar:
+      label : "Wm$^{-2}$"
+  obs_file: "CERES_EBAF_Ed4.1_2001-2020.nc"
+  obs_name: "CERES_EBAF_Ed4.1"
+  obs_var_name: "sfc_net_sw_all_mon"
+
+FSNSC:
+  colormap: "Blues"
+  contour_levels_range: [-10, 300, 20]
+  diff_colormap: "BrBG"
+  diff_contour_range: [-24, 24, 2]
+  scale_factor: 1
+  add_offset: 0
+  new_unit: "Wm$^{-2}$"
+  mpl:
+    colorbar:
+      label : "Wm$^{-2}$"
+  obs_file: "CERES_EBAF_Ed4.1_2001-2020.nc"
+  obs_name: "CERES_EBAF_Ed4.1"
+  obs_var_name: "sfc_net_sw_clr_t_mon"
+
+FLDS:
+  colormap: "Oranges"
+  contour_levels_range: [100, 500, 25]
+  diff_colormap: "BrBG"
+  diff_contour_range: [-20, 20, 2]
+  scale_factor: 1
+  add_offset: 0
+  new_unit: "Wm$^{-2}$"
+  mpl:
+    colorbar:
+      label : "Wm$^{-2}$"
+  obs_file: "CERES_EBAF_Ed4.1_2001-2020.nc"
+  obs_name: "CERES_EBAF_Ed4.1"
+  obs_var_name: "sfc_lw_down_all_mon"
+
 #-----------
 #End of File

--- a/lib/adf_variable_defaults.yaml
+++ b/lib/adf_variable_defaults.yaml
@@ -258,12 +258,12 @@ SWCF:
   mpl:
     colorbar:
       label : "Wm$^{-2}$"
-  obs_file: "CERES_EBAF_Ed4.1_SWCF_climo.nc"
+  obs_file: "CERES_EBAF_Ed4.1_2001-2020.nc"
   obs_name: "CERES_EBAF_Ed4.1"
-  obs_var_name: "SWCF"
+  obs_var_name: "toa_cre_sw_mon"
 
 LWCF:
-  colormap: "Blues"
+  colormap: "Oranges"
   contour_levels_range: [-10, 100, 5]
   diff_colormap: "BrBG"
   diff_contour_range: [-15, 15, 1]
@@ -273,9 +273,9 @@ LWCF:
   mpl:
     colorbar:
       label : "Wm$^{-2}$"
-  obs_file: "CERES_EBAF_Ed4.1_LWCF_climo.nc"
+  obs_file: "CERES_EBAF_Ed4.1_2001-2020.nc"
   obs_name: "CERES_EBAF_Ed4.1"
-  obs_var_name: "LWCF"
+  obs_var_name: "toa_cre_lw_mon"
 
 #-----------
 #End of File

--- a/lib/adf_variable_defaults.yaml
+++ b/lib/adf_variable_defaults.yaml
@@ -60,6 +60,9 @@ PS:
   mpl:
     colorbar:
       label : "hPa"
+  obs_file: "ERAI_all_climo.nc"
+  obs_name: "ERAI"  
+  obs_var_name: "PS"
 
 PRECC:
   colormap: "Greens"
@@ -84,6 +87,9 @@ PRECT:
   mpl:
     colorbar:
       label : "mm d$^{-1}$"
+  obs_file: "ERAI_all_climo.nc"
+  obs_name: "ERAI"  
+  obs_var_name: "PRECT"
 
 TGCLDLWP:
   colormap: "Blues"
@@ -111,12 +117,63 @@ TGCLDIWP:
 
 CLDTOT:
   colormap: "Oranges"
-  contour_levels_range: [0, 105, 5]
+  contour_levels_range: [0, 1.05, 0.05]
   diff_colormap: "BrBG"
-  diff_contour_range: [-15, 15, 2]
-  scale_factor: 100
+  diff_contour_range: [-0.4, 0.4, 0.05]
+  scale_factor: 1.
   add_offset: 0
-  new_unit: "Percent"
+  new_unit: "Fraction"
+  obs_file: "ERAI_all_climo.nc"
+  obs_name: "ERAI"  
+  obs_var_name: "CLDTOT"
+
+CLDLOW:
+  colormap: "Oranges"
+  contour_levels_range: [0, 1.05, 0.05]
+  diff_colormap: "BrBG"
+  diff_contour_range: [-0.4, 0.4, 0.05]
+  scale_factor: 1.
+  add_offset: 0
+  new_unit: "Fraction"
+  obs_file: "ERAI_all_climo.nc"
+  obs_name: "ERAI"  
+  obs_var_name: "CLDLOW"
+
+CLDHGH:
+  colormap: "Oranges"
+  contour_levels_range: [0, 1.05, 0.05]
+  diff_colormap: "BrBG"
+  diff_contour_range: [-0.4, 0.4, 0.05]
+  scale_factor: 1.
+  add_offset: 0
+  new_unit: "Fraction"
+  obs_file: "ERAI_all_climo.nc"
+  obs_name: "ERAI"  
+  obs_var_name: "CLDHGH"
+
+CLDMED:
+  colormap: "Oranges"
+  contour_levels_range: [0, 1.05, 0.05]
+  diff_colormap: "BrBG"
+  diff_contour_range: [-0.4, 0.4, 0.05]
+  scale_factor: 1.
+  add_offset: 0
+  new_unit: "Fraction"
+  obs_file: "ERAI_all_climo.nc"
+  obs_name: "ERAI"  
+  obs_var_name: "CLDMED"
+
+TMQ:
+  colormap: "Oranges"
+  contour_levels_range: [0, 75.0, 5.0]
+  diff_colormap: "BrBG"
+  diff_contour_range: [-10, 10, 0.5]
+  scale_factor: 1.
+  add_offset: 0
+  new_unit: "kg m$^{-2}$"
+  obs_file: "ERAI_all_climo.nc"
+  obs_name: "ERAI"  
+  obs_var_name: "PREH2O"
 
 CLOUD:
   colormap: "Blues"
@@ -130,6 +187,21 @@ CLOUD:
     colorbar:
       label : "Percent"
 
+RELHUM:
+  colormap: "Blues"
+  contour_levels_range: [0, 105, 5]
+  diff_colormap: "BrBG"
+  diff_contour_range: [-15, 15, 2]
+  scale_factor: 1
+  add_offset: 0
+  new_unit: "Fraction"
+  mpl:
+    colorbar:
+      label : "Fraction"
+  obs_file: "ERAI_all_climo.nc"
+  obs_name: "ERAI"  
+  obs_var_name: "RELHUM"
+
 U:
   colormap: "Blues"
   contour_levels_range: [-10, 90, 5]
@@ -141,6 +213,39 @@ U:
   mpl:
     colorbar:
       label : "ms$^{-1}$"
+  obs_file: "ERAI_all_climo.nc"
+  obs_name: "ERAI"  
+  obs_var_name: "U"
+
+TS:
+  colormap: "Blues"
+  contour_levels_range: [220,320, 5]
+  diff_colormap: "BrBG"
+  diff_contour_range: [-10, 10, 1]
+  scale_factor: 1
+  add_offset: 0
+  new_unit: "K"
+  mpl:
+    colorbar:
+      label : "K"
+  obs_file: "ERAI_all_climo.nc"
+  obs_name: "ERAI"  
+  obs_var_name: "TS"
+
+LHFLX:
+  colormap: "Blues"
+  contour_levels_range: [0, 220, 10]
+  diff_colormap: "BrBG"
+  diff_contour_range: [-45, 45, 5]
+  scale_factor: 1
+  add_offset: 0
+  new_unit: "Wm$^{-2}$"
+  mpl:
+    colorbar:
+      label : "Wm$^{-2}$"
+  obs_file: "ERAI_all_climo.nc"
+  obs_name: "ERAI"  
+  obs_var_name: "LHFLX"
 
 SWCF:
   colormap: "Blues"

--- a/scripts/plotting/global_latlon_map.py
+++ b/scripts/plotting/global_latlon_map.py
@@ -199,6 +199,12 @@ def global_latlon_map(adfobj):
                     odata = odata * vres.get("scale_factor",1) + vres.get("add_offset", 0)
                     # update units
                     odata.attrs['units'] = vres.get("new_unit", odata.attrs.get('units', 'none'))
+                # Or for observations: 
+                else:
+                    odata = odata * vres.get("obs_scale_factor",1) + vres.get("obs_add_offset", 0)
+                   # Note: we are going to assume that the specification ensures the conversion makes the units the same. Doesn't make sense to add a different unit. 
+
+
 
                 #Determine dimensions of variable:
                 has_dims = pf.lat_lon_validate_dims(odata)

--- a/scripts/plotting/polar_map.py
+++ b/scripts/plotting/polar_map.py
@@ -184,6 +184,10 @@ def polar_map(adfobj):
                     odata = odata * vres.get("scale_factor",1) + vres.get("add_offset", 0)
                     # update units
                     odata.attrs['units'] = vres.get("new_unit", odata.attrs.get('units', 'none'))
+                # or for observations. 
+                else:
+                    odata = odata * vres.get("obs_scale_factor",1) + vres.get("obs_add_offset", 0)
+                    # Note: assume obs are set to have same untis as model.
 
                 #Determine dimensions of variable:
                 has_dims = pf.lat_lon_validate_dims(odata)

--- a/scripts/plotting/zonal_mean.py
+++ b/scripts/plotting/zonal_mean.py
@@ -188,6 +188,11 @@ def zonal_mean(adfobj):
                     odata = odata * vres.get("scale_factor",1) + vres.get("add_offset", 0)
                     # update units
                     odata.attrs['units'] = vres.get("new_unit", odata.attrs.get('units', 'none'))
+                # Or for observations
+                else:
+                    odata = odata * vres.get("obs_scale_factor",1) + vres.get("obs_add_offset", 0)
+                    # Note: we are going to assume that the specification ensures the conversion makes the units the same. Doesn't make sense to add a different unit. 
+
 
                 # determine whether it's 2D or 3D
                 # 3D triggers search for surface pressure


### PR DESCRIPTION
Greetings,

Results of my hackathon work today. Added the following variable observations from ERAI (and the variable where it did not exist in variable defaults) to the adf_variable_defaults.yaml file. 

TS 
LHFLX 
TMQ
CLDTOT
CLDHGH
CLDMED
CLDLOW
TS
PRECT

All 2D. Tested with zonal mean and lat lon plots to get decent ranges.

The file associated with this is: 
/glade/p/cgd/amp/andrew/adf/obs/ERAI_all_climo.nc

And can be added to the 
/glade/work/nusbaume/SE_projects/model_diagnostics/ADF_obs

directory.

For traceability the ERAI file was built with these commands:

`ncrcat /glade/p/cesm/amwg/amwg_data/obs_data/ERAI_[0-1]* ERAI_all_climo_orig.nc
ncap2 -s "time=float(time)+1" ERAI_all_climo_orig.nc ERAI_all_climo.nc
ncatted -a units,time,d,, ERAI_all_climo.nc`

The time variable cannot have a units attribute and needs to be months 1-12. 


