### PR TITLE
fix small typo

### DIFF
--- a/config_cam_baseline_example.yaml
+++ b/config_cam_baseline_example.yaml
@@ -214,7 +214,7 @@ diag_cam_baseline_climo:
     #Location of CAM baseline history (h0) files:
     cam_hist_loc: /glade/p/cesm/ADF/b.e20.BHIST.f09_g16.20thC.125.02/
 
-    #Location of baseline CAM cliimatologies:
+    #Location of baseline CAM climatologies:
     cam_climo_loc: /some/where/you/want/to/have/baseline_climo_files/ #MUST EDIT!
 
     #model year when time series files should start:


### PR DESCRIPTION
Correct small typo - cliimatologies to climatologies in [line 217](https://github.com/NCAR/ADF/blob/dc1dbb9bfbefb82ee0cb4351655ed47e83fb8f9d/config_cam_baseline_example.yaml#L217) 