### PR TITLE
Added capability to run CVDP from within ADF

### DIFF
--- a/config_cam_baseline_example.yaml
+++ b/config_cam_baseline_example.yaml
@@ -254,9 +254,9 @@ diag_cam_baseline_climo:
     #Location where time series files are (or will be) stored:
     cam_ts_loc: /some/where/you/want/to/have/baseline_time_series_files/ #MUST EDIT!
 
-#This fourth set of variables provides settings for calling the Climate Variability 
-# Diagnostics Package (CVDP). If cvdp_run is set to true the CVDP will be set up and 
-# run in background mode, likely completing after the ADF has completed. 
+#This fourth set of variables provides settings for calling the Climate Variability
+# Diagnostics Package (CVDP). If cvdp_run is set to true the CVDP will be set up and
+# run in background mode, likely completing after the ADF has completed.
 # If CVDP is to be run PSL, TREFHT, TS and PRECT (or PRECC and PRECL) should be listed
 # in the diag_var_list variable listing.
 # For more CVDP information: https://www.cesm.ucar.edu/working_groups/CVC/cvdp/
@@ -313,12 +313,12 @@ plotting_scripts:
 #List of CAM variables that will be processesd:
 #If CVDP is to be run PSL, TREFHT, TS and PRECT (or PRECC and PRECL) should be listed
 diag_var_list:
+    - SWCF
     - LWCF
     - PRECC
     - PRECL
     - PSL
     - Q
-    - SWCF
     - TREFHT
     - TS
 #<Add more variables here.>

--- a/config_cam_baseline_example.yaml
+++ b/config_cam_baseline_example.yaml
@@ -244,6 +244,30 @@ diag_cam_baseline_climo:
     #Location where time series files are (or will be) stored:
     cam_ts_loc: /some/where/you/want/to/have/baseline_time_series_files/ #MUST EDIT!
 
+#This fourth set of variables provides settings for calling the Climate Variability 
+# Diagnostics Package (CVDP). If cvdp_run is set to true the CVDP will be set up and 
+# run in background mode, likely completing after the ADF has completed. 
+# If CVDP is to be run PSL, TREFHT, TS and PRECT (or PRECC and PRECL) should be listed
+# in the diag_var_list variable listing.
+# For more CVDP information: https://www.cesm.ucar.edu/working_groups/CVC/cvdp/
+diag_cvdp_info:
+
+    # Run the CVDP on the listed run(s)?
+    cvdp_run: false
+
+    # CVDP code path, sets the location of the CVDP codebase
+    #  CGD systems path = /home/asphilli/CESM-diagnostics/CVDP/Release/v5.2.0/
+    #  CISL systems path = /glade/u/home/asphilli/CESM-diagnostics/CVDP/Release/v5.2.0/
+    #  github location = https://github.com/NCAR/CVDP-ncl
+    cvdp_codebase_loc: /glade/u/home/asphilli/CESM-diagnostics/CVDP/Release/v5.2.0/
+
+    # Location where cvdp codebase will be copied to and diagnostic plots will be stored
+    cvdp_loc: /glade/scratch/asphilli/ADF-Sandbox/cvdp/      #MUST EDIT!
+
+    # tar up CVDP results?
+    cvdp_tar: false
+
+
 #+++++++++++++++++++++++++++++++++++++++++++++++++++
 #These variables below only matter if you are using
 #a non-standard method, or are adding your own
@@ -277,11 +301,16 @@ plotting_scripts:
     - polar_map
 
 #List of CAM variables that will be processesd:
+#If CVDP is to be run PSL, TREFHT, TS and PRECT (or PRECC and PRECL) should be listed
 diag_var_list:
-    - SWCF
     - LWCF
+    - PRECC
+    - PRECL
     - PSL
     - Q
+    - SWCF
+    - TREFHT
+    - TS
 #<Add more variables here.>
 
 #END OF FILE

--- a/lib/adf_diag.py
+++ b/lib/adf_diag.py
@@ -170,6 +170,12 @@ class AdfDiag(AdfObs):
         #Expand CAM climo info variable strings:
         self.expand_references(self.__cam_climo_info)
 
+        #Add CVDP info to object:
+        self.__cvdp_info = self.read_config_var('diag_cvdp_info', required=True)
+
+        #Expand CVDP climo info variable strings:
+        self.expand_references(self.__cvdp_info)
+
         #Check if inputs are of the correct type.
         #Ideally this sort of checking should be done
         #in its own class that AdfDiag inherits from:
@@ -278,6 +284,19 @@ class AdfDiag(AdfObs):
 
         return self.read_config_var(var_str,
                                     conf_dict=self.__cam_climo_info,
+                                    required=required)
+
+    #########
+
+    def get_cvdp_info(self, var_str, required=False):
+        """
+        Return the config variable from 'diag_cvdp_info' as requested by
+        the user.  This function assumes that if the user is requesting it,
+        then it must be required.
+        """
+
+        return self.read_config_var(var_str,
+                                    conf_dict=self.__cvdp_info,
                                     required=required)
 
     #########
@@ -589,12 +608,24 @@ class AdfDiag(AdfObs):
             #Use pathlib to create parent directories, if necessary.
             Path(ts_dir[case_idx]).mkdir(parents=True, exist_ok=True)
 
+            #INPUT NAME TEMPLATE: $CASE.$scomp.[$type.][$string.]$date[$ending] 
+            first_file_split = str(hist_files[0]).split(".")
+            if first_file_split[-1] == "nc":
+                time_string_start = first_file_split[-2].replace("-","")
+            else:    
+                time_string_start = first_file_split[-1].replace("-","")
+            last_file_split = str(hist_files[-1]).split(".")
+            if last_file_split[-1] == "nc":
+                time_string_finish = last_file_split[-2].replace("-","")
+            else:    
+                time_string_finish = last_file_split[-1].replace("-","")
+            time_string = "-".join([time_string_start, time_string_finish])
+
             #Loop over CAM history variables:
             for var in self.diag_var_list:
 
-                #Create full path name:
-                ts_outfil_str = ts_dir[case_idx] + os.sep + case_name + \
-                              ".ncrcat."+var+".nc"
+                #Create full path name,  file name template: $cam_case_name.h0.$variable.YYYYMM-YYYYMM.nc
+                ts_outfil_str = ts_dir[case_idx] + os.sep + ".".join([case_name, "h0", var, time_string, "nc" ])
 
                 #Check if files already exist in time series directory:
                 ts_file_list = glob.glob(ts_outfil_str)
@@ -1102,5 +1133,97 @@ class AdfDiag(AdfObs):
 
         #Notify user that script has finishedd:
         print("  ...Webpages have been generated successfully.")
+
+    #########
+
+    def setup_run_cvdp(self, baseline=False):
+
+        """
+        Create CVDP directory tree, generate namelist file and edit driver.ncl needed to run CVDP. Submit CVDP diagnostics. 
+
+        """
+
+        #import needed standard modules:
+        import shutil
+        import subprocess
+
+        #Case names:
+        case_names = self.get_cam_info('cam_case_name', required=True)
+
+        #Start years (not currently required):
+        syears = self.get_cam_info('start_year')
+
+        #End year (not currently rquired):
+        eyears = self.get_cam_info('end_year')
+
+        #Timeseries locations:
+        cam_ts_loc = self.get_cam_info('cam_ts_loc')
+
+        #set CVDP directory, recursively copy cvdp codebase to the CVDP directory
+        cvdp_dir = self.get_cvdp_info('cvdp_loc', required=True)+case_names[0]
+        if not os.path.isdir(cvdp_dir):
+            shutil.copytree(self.get_cvdp_info('cvdp_codebase_loc', required=True),cvdp_dir)
+
+        #check to see if there is a CAM baseline case. If there is, read in relevant information.
+        if not self.get_basic_info('compare_obs'):
+            case_name_baseline = self.get_baseline_info('cam_case_name')
+            syears_baseline = self.get_baseline_info('start_year')
+            eyears_baseline = self.get_baseline_info('end_year')
+            baseline_ts_loc = self.get_baseline_info('cam_ts_loc')
+
+        #Loop over cases to create individual text array to be written to namelist file.
+        row_list = list()
+        for case_idx, case_name in enumerate(case_names):
+            row = [case_name,' | ',str(cam_ts_loc[case_idx]),'/ | ',str(syears[case_idx]),' | ',str(eyears[case_idx])]
+            row_list.append("".join(row))
+
+        #Create new namelist file. If CAM baseline case present add it to list. namelist file must end in a blank line.
+        f = open(cvdp_dir+"/namelist",'w')
+        for row_n, rowtext in enumerate(row_list):
+            f.write(rowtext)
+        f.write('\n\n')
+        if "baseline_ts_loc" in locals():
+            rowb_list = list()
+            rowb = [case_name_baseline,' | ',str(baseline_ts_loc),'/ | ',str(syears_baseline),' | ',str(eyears_baseline)]
+            rowb_list.append("".join(rowb))
+            for row_n, rowtextb in enumerate(rowb_list):
+                f.write(rowtextb)
+        f.write('\n\n')
+
+        #modify driver.ncl to set the proper output directory, webpage title, location of CVDP NCL scripts, 
+        #set modular = True (to run multiple CVDP scripts at once), modify the modular_list to exclude 
+        #all scripts focused solely on non-atmospheric variables, and set tar_output to True if cvdp_tar: true
+        with open(cvdp_dir+"/driver.ncl",'r') as f_in, open(cvdp_dir+"/driver."+case_names[0]+".ncl", 'w') as f_out:
+            for line in f_in:
+                if '  outdir  ' in line:
+                    line = '  outdir = "'+cvdp_dir+'/output/"' 
+                if '  webpage_title  ' in line:
+                    line = '  webpage_title = "ADF/CVDP Comparison"'  
+                if 'directory path of CVDP NCL scripts' in line:
+                    line = '  zp = "'+cvdp_dir+'/ncl_scripts/"'
+                if '  modular = ' in line:
+                    line = '  modular = "True"'
+                if '  modular_list = ' in line:
+                    line = '  modular_list = "psl.nam_nao,psl.pna_npo,tas.trends_timeseries,snd.trends,psl.trends,amo,pdo,sst.indices,pr.trends_timeseries,psl.sam_psa,sst.mean_stddev,psl.mean_stddev,pr.mean_stddev,sst.trends_timeseries,tas.mean_stddev,ipo"'
+                if self.get_cvdp_info('cvdp_tar'):
+                    if '  tar_output  ' in line:
+                        line = '  tar_output = "True"'
+                f_out.write(line)         
+
+        #Submit the CVDP driver script in background mode, send output to cvdp.out file
+        g = open(cvdp_dir+'/cvdp.out','w')
+        subpout = subprocess.Popen(['cd '+cvdp_dir+'; ncl -Q '+cvdp_dir+'/driver.'+case_names[0]+'.ncl'], shell=True, stdout=g, close_fds=True)
+        
+        print('   ')
+        print('CVDP is running in background. ADF continuing.')
+        print('CVDP terminal output is located in '+cvdp_dir+'/cvdp.out')
+        if self.get_cvdp_info('cvdp_tar'):
+            print('CVDP graphical and netCDF file output can be found here: '+cvdp_dir+'/output/cvdp.tar')
+            print('Open index.html (within cvdp.tar file) in web browser to view CVDP results.')
+        else:
+            print('CVDP graphical and netCDF file output can be found here: '+cvdp_dir+'/output/')
+            print('Open '+cvdp_dir+'/output/index.html file in web browser to view CVDP results.')
+        print('For CVDP information visit: https://www.cesm.ucar.edu/working_groups/CVC/cvdp/')
+        print('   ')
 
 ###############

--- a/lib/adf_variable_defaults.yaml
+++ b/lib/adf_variable_defaults.yaml
@@ -61,7 +61,7 @@ PS:
     colorbar:
       label : "hPa"
   obs_file: "ERAI_all_climo.nc"
-  obs_name: "ERAI"  
+  obs_name: "ERAI"
   obs_var_name: "PS"
 
 PRECC:
@@ -88,7 +88,7 @@ PRECT:
     colorbar:
       label : "mm d$^{-1}$"
   obs_file: "ERAI_all_climo.nc"
-  obs_name: "ERAI"  
+  obs_name: "ERAI"
   obs_var_name: "PRECT"
 
 TGCLDLWP:
@@ -124,7 +124,7 @@ CLDTOT:
   add_offset: 0
   new_unit: "Fraction"
   obs_file: "ERAI_all_climo.nc"
-  obs_name: "ERAI"  
+  obs_name: "ERAI"
   obs_var_name: "CLDTOT"
 
 CLDLOW:
@@ -136,7 +136,7 @@ CLDLOW:
   add_offset: 0
   new_unit: "Fraction"
   obs_file: "ERAI_all_climo.nc"
-  obs_name: "ERAI"  
+  obs_name: "ERAI"
   obs_var_name: "CLDLOW"
 
 CLDHGH:
@@ -148,7 +148,7 @@ CLDHGH:
   add_offset: 0
   new_unit: "Fraction"
   obs_file: "ERAI_all_climo.nc"
-  obs_name: "ERAI"  
+  obs_name: "ERAI"
   obs_var_name: "CLDHGH"
 
 CLDMED:
@@ -160,7 +160,7 @@ CLDMED:
   add_offset: 0
   new_unit: "Fraction"
   obs_file: "ERAI_all_climo.nc"
-  obs_name: "ERAI"  
+  obs_name: "ERAI"
   obs_var_name: "CLDMED"
 
 TMQ:
@@ -172,7 +172,7 @@ TMQ:
   add_offset: 0
   new_unit: "kg m$^{-2}$"
   obs_file: "ERAI_all_climo.nc"
-  obs_name: "ERAI"  
+  obs_name: "ERAI"
   obs_var_name: "PREH2O"
 
 CLOUD:
@@ -199,7 +199,7 @@ RELHUM:
     colorbar:
       label : "Fraction"
   obs_file: "ERAI_all_climo.nc"
-  obs_name: "ERAI"  
+  obs_name: "ERAI"
   obs_var_name: "RELHUM"
 
 U:
@@ -214,7 +214,7 @@ U:
     colorbar:
       label : "ms$^{-1}$"
   obs_file: "ERAI_all_climo.nc"
-  obs_name: "ERAI"  
+  obs_name: "ERAI"
   obs_var_name: "U"
 
 TS:
@@ -229,7 +229,7 @@ TS:
     colorbar:
       label : "K"
   obs_file: "ERAI_all_climo.nc"
-  obs_name: "ERAI"  
+  obs_name: "ERAI"
   obs_var_name: "TS"
 
 LHFLX:
@@ -244,7 +244,7 @@ LHFLX:
     colorbar:
       label : "Wm$^{-2}$"
   obs_file: "ERAI_all_climo.nc"
-  obs_name: "ERAI"  
+  obs_name: "ERAI"
   obs_var_name: "LHFLX"
 
 SWCF:
@@ -263,7 +263,7 @@ SWCF:
   obs_var_name: "toa_cre_sw_mon"
   obs_scale_factor: 1
   obs_add_offset: 0
- 
+
 LWCF:
   colormap: "Oranges"
   contour_levels_range: [-10, 100, 5]

--- a/run_adf_diag
+++ b/run_adf_diag
@@ -153,8 +153,7 @@ if __name__ == "__main__":
     if not diag.compare_obs:
         diag.create_time_series(baseline=True)
 
-    #Call the CVDP.
-
+    #Call the CVDP:
     if diag.get_cvdp_info('cvdp_run'):
        diag.setup_run_cvdp()
 

--- a/run_adf_diag
+++ b/run_adf_diag
@@ -153,6 +153,11 @@ if __name__ == "__main__":
     if not diag.compare_obs:
         diag.create_time_series(baseline=True)
 
+    #Call the CVDP.
+
+    if diag.get_cvdp_info('cvdp_run'):
+       diag.setup_run_cvdp()
+
     #Create model climatology (climo) files.
     #This call uses the "time_averaging_scripts" specified
     #in the config file:

--- a/scripts/plotting/global_latlon_map.py
+++ b/scripts/plotting/global_latlon_map.py
@@ -255,8 +255,12 @@ def global_latlon_map(adfobj):
 
                                 #Calculate monthly-weighted seasonal averages:
                                 if s == 'ANN':
-                                    mseasons[s] = (mdata * weights).sum(dim='time')
-                                    oseasons[s] = (odata * weights).sum(dim='time')
+
+                                    #Calculate annual weights (i.e. don't group by season):
+                                    weights_ann = month_length / month_length.sum()
+
+                                    mseasons[s] = (mdata * weights_ann).sum(dim='time')
+                                    oseasons[s] = (odata * weights_ann).sum(dim='time')
                                     # difference: each entry should be (lat, lon)
                                     dseasons[s] = mseasons[s] - oseasons[s]
                                 else:

--- a/scripts/plotting/polar_map.py
+++ b/scripts/plotting/polar_map.py
@@ -17,7 +17,6 @@ from cartopy.util import add_cyclic_point
 # ADF library
 import plotting_functions as pf
 
-
 def polar_map(adfobj):
     """
     This script/function generates polar maps of model fields with continental overlays.
@@ -184,7 +183,7 @@ def polar_map(adfobj):
                     odata = odata * vres.get("scale_factor",1) + vres.get("add_offset", 0)
                     # update units
                     odata.attrs['units'] = vres.get("new_unit", odata.attrs.get('units', 'none'))
-                # or for observations. 
+                # or for observations.
                 else:
                     odata = odata * vres.get("obs_scale_factor",1) + vres.get("obs_add_offset", 0)
                     # Note: assume obs are set to have same untis as model.
@@ -237,6 +236,7 @@ def polar_map(adfobj):
                             # NOTE: If we were doing all the plotting here, we could use whatever we want from the provided YAML file.
 
                             # pf.plot_map_and_save(plot_name, mseasons[s], oseasons[s], dseasons[s], **vres)
+
                             nhfig = make_polar_plot(mseasons[s], oseasons[s], dseasons[s], hemisphere="NH", **vres)
                             shfig = make_polar_plot(mseasons[s], oseasons[s], dseasons[s], hemisphere="SH", **vres)
 
@@ -327,8 +327,9 @@ def make_polar_plot(d1:xr.DataArray, d2:xr.DataArray, difference:Optional[xr.Dat
     # -- deal with optional plotting arguments that might provide variable-dependent choices
 
     # determine levels & color normalization:
-    minval = np.min([np.min(d1), np.min(d2)])
-    maxval = np.max([np.max(d1), np.max(d2)])
+    minval    = np.min([np.min(d1), np.min(d2)])
+    maxval    = np.max([np.max(d1), np.max(d2)])
+    absmaxdif = np.max(np.abs(dif))
 
     if 'colormap' in kwargs:
         cmap1 = kwargs['colormap']
@@ -355,10 +356,32 @@ def make_polar_plot(d1:xr.DataArray, d2:xr.DataArray, difference:Optional[xr.Dat
             assert len(kwargs['diff_contour_range']) == 3, "diff_contour_range must have exactly three entries: min, max, step"
             levelsdiff = np.arange(*kwargs['diff_contour_range'])
     else:
-        # set a symmetric color bar for diff:
-        absmaxdif = np.max(np.abs(dif))
-        # set levels for difference plot:
+        # set levels for difference plot (with a symmetric color bar):
         levelsdiff = np.linspace(-1*absmaxdif, absmaxdif, 12)
+    #End if
+
+    #NOTE: Sometimes the contour levels chosen in the defaults file
+    #can result in the "contourf" software stack generating a
+    #'TypologyException', which should manifest itself as a
+    #"PredicateError", but due to bugs in the stack itself
+    #will also sometimes raise an AttributeError.
+
+    #To prevent this from happening, the poloar max and min values
+    #are calculated, and if the default contour values are significantly
+    #larger then the min-max values, then the min-max values are used instead:
+    #-------------------------------
+    if max(levels1) > 10*maxval:
+        levels1 = np.linspace(minval, maxval, 12)
+        norm1 = mpl.colors.Normalize(vmin=minval, vmax=maxval)
+    elif minval < 0 and min(levels1) < 10*minval:
+        levels1 = np.linspace(minval, maxval, 12)
+        norm1 = mpl.colors.Normalize(vmin=minval, vmax=maxval)
+    #End if
+
+    if max(abs(levelsdiff)) > 10*absmaxdif:
+        levelsdiff = np.linspace(-1*absmaxdif, absmaxdif, 12)
+    #End if
+    #-------------------------------
 
     # Difference options -- Check in kwargs for colormap and levels
     if "diff_colormap" in kwargs:
@@ -366,6 +389,7 @@ def make_polar_plot(d1:xr.DataArray, d2:xr.DataArray, difference:Optional[xr.Dat
         dnorm, _ = pf.get_difference_colors(levelsdiff)  # color map output ignored
     else:
         dnorm, cmapdiff = pf.get_difference_colors(levelsdiff)
+    #End if
 
     # -- end options
 


### PR DESCRIPTION
Added capability to run CVDP from within ADF, and modified output ADF timeseries names to match CESM standards. 

The CVDP can now easily be called from within the ADF config YAML file. Every run specified in cam_case_name (for both diag_cam_climo and diag_cam_baseline_climo sets) will be analyzed and compared to the default stack of 4 sets of observations. The years that the user set to be analyzed (set via start_year and end_year) are what the CVDP will use. Observational datasets time periods are set to whatever the current default namelist_obs has in it. Currently with CVDP v5.2.0 two observational sets run from 1920-2018, and two run from 1979-2018. 

There are four CVDP settings within the config yaml file:
- cvdp_run. (true or false).  Setting this to true copies over the necessary CVDP code, sets up the necessary files, and submits the CVDP in the background. This allows the ADAF to proceed, but also means the CVDP will likely finish after the ADF is completed. 
- cvdp_codebase_loc. This is the directory path where the CVDP codebase is located. 
- cvdp_loc. This is where the CVDP directory will be created for use by the ADF. The CVDP code will be copied from cvdp_codebase_loc to this location, and the following files will be automatically modified: driver.ncl and namelist. 
- cvdp_tar. (true or false). Setting this to true will result in all CVDP output being tarred up.

CVDP output will be placed in cvdp_loc/$case_name[0]/output.

In order to allow the CVDP to be called from the ADF, the ADF now creates timeseries (from history files) whose names end in "YYYYMM-YYYYMM.nc". Altering the timeseries naming in this way brings the ADF created timeseries up to the current CESM naming standard.

Fixes #17 
Fixes #77