### PR TITLE
Add the ability to plot 3-D variables on a 2-D lat/lon map

### DIFF
--- a/config_cam_baseline_example.yaml
+++ b/config_cam_baseline_example.yaml
@@ -90,6 +90,16 @@ diag_basic_info:
     #if not using the one in ADF/lib:
   #  defaults_file: /some/path/to/defaults/file
 
+    #Vertical pressure levels (in hPa) on which to plot 3-D variables
+    #when using horizontal (e.g. lat/lon) map projections.
+    #If this config option is missing, then no 3-D variables will be plotted on
+    #horizontal maps:
+    plot_press_levels: [200,850]
+
+    #Apply monthly weights to seasonal averages.
+    #If False or missing, then all months are
+    #given the same weight:
+    weight_season: True
 
 #This second set of variables provides info for the CAM simulation(s) being diagnosed:
 diag_cam_climo:

--- a/lib/adf_diag.py
+++ b/lib/adf_diag.py
@@ -887,6 +887,14 @@ class AdfDiag(AdfObs):
         #Set preferred order of plot types:
         plot_type_order = ["LatLon", "Zonal", "NHPolar", "SHPolar"]
 
+        #Also add pressure level Lat-Lon plots, if applicable:
+        pres_levs = self.get_basic_info("plot_press_levels")
+        if pres_levs:
+            for pres in pres_levs:
+                plot_type_order.append(f"Lev_{pres}hpa_LatLon")
+            #End for
+        #End if
+
         #Set path to Jinja2 template files:
         jinja_template_dir = Path(_LOCAL_PATH, 'website_templates')
 

--- a/scripts/plotting/global_latlon_map.py
+++ b/scripts/plotting/global_latlon_map.py
@@ -36,6 +36,7 @@ def global_latlon_map(adfobj):
     # data loading / analysis
     import xarray as xr
     import numpy as np
+    import pandas as pd
 
     #CAM diagnostic plotting functions:
     import plotting_functions as pf
@@ -100,6 +101,14 @@ def global_latlon_map(adfobj):
     if not adfobj.compare_obs:
         dclimo_loc  = Path(data_loc)
     #-----------------------
+
+    #Determine if user wants to plot 3-D variables on
+    #pressure levels:
+    pres_levs = adfobj.get_basic_info("plot_press_levels")
+
+    #Determine if user wants monthly weights to be applied
+    #to the seasonal averages:
+    weight_season = adfobj.get_basic_info("weight_season")
 
     #Set seasonal ranges:
     seasons = {"ANN": np.arange(1,13,1),
@@ -199,12 +208,10 @@ def global_latlon_map(adfobj):
                     odata = odata * vres.get("scale_factor",1) + vres.get("add_offset", 0)
                     # update units
                     odata.attrs['units'] = vres.get("new_unit", odata.attrs.get('units', 'none'))
-                # Or for observations: 
+                # Or for observations:
                 else:
                     odata = odata * vres.get("obs_scale_factor",1) + vres.get("obs_add_offset", 0)
-                   # Note: we are going to assume that the specification ensures the conversion makes the units the same. Doesn't make sense to add a different unit. 
-
-
+                   # Note: we are going to assume that the specification ensures the conversion makes the units the same. Doesn't make sense to add a different unit.
 
                 #Determine dimensions of variable:
                 has_dims = pf.lat_lon_validate_dims(odata)
@@ -232,10 +239,41 @@ def global_latlon_map(adfobj):
 
                         #Loop over season dictionary:
                         for s in seasons:
-                            mseasons[s] = mdata.sel(time=seasons[s]).mean(dim='time')
-                            oseasons[s] = odata.sel(time=seasons[s]).mean(dim='time')
-                            # difference: each entry should be (lat, lon)
-                            dseasons[s] = mseasons[s] - oseasons[s]
+
+                            if weight_season:
+                                #Add date-stamp to time dimension:
+                                #Note: For now using made-up dates, but in the future
+                                #it might be good to extract this info from the files
+                                #themselves.
+                                timefix = pd.date_range(start='1/1/1980', end='12/1/1980', freq='MS')
+                                mdata['time']=timefix
+                                odata['time']=timefix
+
+                                #Calculate monthly weights based on number of days:
+                                month_length = mdata.time.dt.days_in_month
+                                weights = (month_length.groupby("time.season") / month_length.groupby("time.season").sum())
+
+                                #Calculate monthly-weighted seasonal averages:
+                                if s == 'ANN':
+                                    mseasons[s] = (mdata * weights).sum(dim='time')
+                                    oseasons[s] = (odata * weights).sum(dim='time')
+                                    # difference: each entry should be (lat, lon)
+                                    dseasons[s] = mseasons[s] - oseasons[s]
+                                else:
+                                    #this is inefficient because we do same calc over and over
+                                    mseasons[s] =(mdata * weights).groupby("time.season").sum(dim="time").sel(season=s)
+                                    oseasons[s] =(odata * weights).groupby("time.season").sum(dim="time").sel(season=s)
+                                    # difference: each entry should be (lat, lon)
+                                    dseasons[s] = mseasons[s] - oseasons[s]
+                                #End if
+
+                            else:
+                                #Just average months as-is:
+                                mseasons[s] = mdata.sel(time=seasons[s]).mean(dim='time')
+                                oseasons[s] = odata.sel(time=seasons[s]).mean(dim='time')
+                                # difference: each entry should be (lat, lon)
+                                dseasons[s] = mseasons[s] - oseasons[s]
+                            #End if
 
                             # time to make plot; here we'd probably loop over whatever plots we want for this variable
                             # I'll just call this one "LatLon_Mean"  ... would this work as a pattern [operation]_[AxesDescription] ?
@@ -256,11 +294,155 @@ def global_latlon_map(adfobj):
                             pf.plot_map_and_save(plot_name, mseasons[s], oseasons[s], dseasons[s], **vres)
 
                     else: #mdata dimensions check
-                        print("\t - skipping lat/lon map for {} as it doesn't have only lat/lon dims.".format(var))
+                        print(f"\t - skipping lat/lon map for {var} as it doesn't have only lat/lon dims.")
                     #End if (dimensions check)
 
+                elif pres_levs: #Is the user wanting to interpolate to a specific pressure level?
+
+                    #For now, there is no easy way to use observations with specified pressure levels, so
+                    #bail out here:
+                    if adfobj.compare_obs:
+                        print(f"\t - plot_press_levels currently doesn't work with observations, so skipping variable '{var}'.")
+
+                    else:
+
+                        #Check that case inputs have the correct dimensions (including "lev"):
+                        _, has_lev = pf.zm_validate_dims(mdata)
+
+                        if has_lev:
+
+                            #Next check if the data set contains CAM hybrid level info:
+                            if 'hyam' in mclim_ds:
+                                mhya = mclim_ds['hyam']
+                                mhyb = mclim_ds['hybm']
+                                if 'time' in mhya.dims:
+                                    mhya = mhya.isel(time=0).squeeze()
+                                if 'time' in mhyb.dims:
+                                    mhyb = mhyb.isel(time=0).squeeze()
+                                if 'P0' in mclim_ds:
+                                    P0 = mclim_ds['P0']
+                                else:
+                                    P0 = 100000.0  # Pa
+                                #End if
+                                if 'PS' in mclim_ds:
+                                    mps = mclim_ds['PS']
+                                else:
+                                    # look for the file (this isn't great b/c we'd have to constantly re-load)
+                                    mps_files = sorted(mclimo_rg_loc.glob(f"{data_src}_{case_name}_PS_*.nc"))
+                                    if len(mps_files) > 0:
+                                        mps_ds = _load_dataset(mps_files)
+                                        mps = mps_ds['PS']
+                                    else:
+                                        continue  # what else could we do?
+                                    #End if
+                                #End if
+
+                                # We need a way to check whether 'obs' or 'baseline' here:
+                                # (and/or a way to specify pressure levels or hybrid levels)
+                                ohya = oclim_ds['hyam']
+                                ohyb = oclim_ds['hybm']
+                                if 'time' in ohya.dims:
+                                    ohya = ohya.isel(time=0).squeeze()
+                                if 'time' in ohyb.dims:
+                                    ohyb = ohyb.isel(time=0).squeeze()
+                                if 'PS' in oclim_ds:
+                                    ops = oclim_ds['PS']
+                                else:
+                                    # look for the file (this isn't great b/c we'd have to constantly re-load)
+                                    ops_files = sorted(dclimo_loc.glob(f"{data_src}_PS_*.nc"))
+                                    if len(ops_files) > 0:
+                                        ops_ds = _load_dataset(ops_files)
+                                        ops = ops_ds['PS']
+                                    else:
+                                        continue  # what else could we do?
+                                    #End if
+                                #End if
+
+                                #Interpolate variable to provided pressure levels:
+                                mdata_i = pf.lev_to_plev(mdata, mps, mhya, mhyb, P0=P0, new_levels=np.array(np.array(pres_levs)*100,dtype='float32'), \
+                                                         convert_to_mb=True)
+
+                                odata_i = pf.lev_to_plev(odata, ops, ohya, ohyb, P0=P0, new_levels=np.array(np.array(pres_levs)*100,dtype='float32'), \
+                                                         convert_to_mb=True)
+
+                                #Calculate monthly weights (if applicable):
+                                if weight_season:
+                                    #Add date-stamp to time dimension:
+                                    #Note: For now using made-up dates, but in the future
+                                    #it might be good to extract this info from the files
+                                    #themselves.
+                                    timefix = pd.date_range(start='1/1/1980', end='12/1/1980', freq='MS')
+                                    mdata_i['time']=timefix
+                                    odata_i['time']=timefix
+
+                                    #Calculate monthly weights based on number of days:
+                                    month_length = mdata_i.time.dt.days_in_month
+                                    weights = (month_length.groupby("time.season") / month_length.groupby("time.season").sum())
+                                #End if
+
+                                #Loop over pressure levels:
+                                for pres in pres_levs:
+
+                                    #Create new dictionaries:
+                                    mseasons = {}
+                                    oseasons = {}
+                                    dseasons = {}
+
+                                    #Loop over seasons:
+                                    for s in seasons:
+
+                                        #If requested, then calculate the monthly-weighted seasona averages:
+                                        if weight_season:
+                                            if s == 'ANN':
+                                                mseasons[s] = (mdata_i * weights).sum(dim='time').sel(lev=pres)
+                                                oseasons[s] = (odata_i * weights).sum(dim='time').sel(lev=pres)
+                                                # difference: each entry should be (lat, lon)
+                                                dseasons[s] = mseasons[s] - oseasons[s]
+                                            else:
+                                                #this is inefficient because we do same calc over and over
+                                                mseasons[s] =(mdata_i * weights).groupby("time.season").sum(dim="time").sel(season=s,lev=pres)
+                                                oseasons[s] =(odata_i * weights).groupby("time.season").sum(dim="time").sel(season=s,lev=pres)
+                                                # difference: each entry should be (lat, lon)
+                                                dseasons[s] = mseasons[s] - oseasons[s]
+                                            #End if
+                                        else:
+                                            #Just average months as-is:
+                                            mseasons[s] = mdata.sel(time=seasons[s], lev=pres).mean(dim='time')
+                                            oseasons[s] = odata.sel(time=seasons[s], lev=pres).mean(dim='time')
+                                            # difference: each entry should be (lat, lon)
+                                            dseasons[s] = mseasons[s] - oseasons[s]
+                                        #End if
+
+                                        # time to make plot; here we'd probably loop over whatever plots we want for this variable
+                                        # I'll just call this one "LatLon_Mean"  ... would this work as a pattern [operation]_[AxesDescription] ?
+                                        plot_name = plot_loc / f"{var}_{s}_Lev_{pres}hpa_LatLon_Mean.{plot_type}"
+
+                                        #Remove old plot, if it already exists:
+                                        if plot_name.is_file():
+                                            plot_name.unlink()
+
+                                        #Create new plot:
+                                        # NOTE: send vres as kwarg dictionary.  --> ONLY vres, not the full res
+                                        # This relies on `plot_map_and_save` knowing how to deal with the options
+                                        # currently knows how to handle:
+                                        #   colormap, contour_levels, diff_colormap, diff_contour_levels, tiString, tiFontSize, mpl
+                                        #   *Any other entries will be ignored.
+                                        # NOTE: If we were doing all the plotting here, we could use whatever we want from the provided YAML file.
+                                        pf.plot_map_and_save(plot_name, mseasons[s], oseasons[s], dseasons[s], **vres)
+
+                                    #End for (seasons)
+                                #End for (pressure levels)
+
+                            else:
+                                print(f"\t - plot_pres_levels currently only works with hybrid coordinates, so skipping '{var}'.")
+                            #End if (hyam)
+
+                        else:
+                            print(f"\t - variable '{var}' has no vertical dimension but is not just time/lat/lon, so skipping.")
+                        #End if (has_lev)
+
                 else: #odata dimensions check
-                     print("\t - skipping lat/lon map for {} as it doesn't have only lat/lon dims.".format(var))
+                     print(f"\t - skipping lat/lon map for {var} as it doesn't have only lat/lon dims.")
 
                 #End if (dimensions check)
             #End for (case loop)

--- a/scripts/plotting/zonal_mean.py
+++ b/scripts/plotting/zonal_mean.py
@@ -191,7 +191,7 @@ def zonal_mean(adfobj):
                 # Or for observations
                 else:
                     odata = odata * vres.get("obs_scale_factor",1) + vres.get("obs_add_offset", 0)
-                    # Note: we are going to assume that the specification ensures the conversion makes the units the same. Doesn't make sense to add a different unit. 
+                    # Note: we are going to assume that the specification ensures the conversion makes the units the same. Doesn't make sense to add a different unit.
 
 
                 # determine whether it's 2D or 3D


### PR DESCRIPTION
Along with the title, this PR also adds the ability to apply monthly weights to the seasonal averages used in the lat/lon maps and statistics.  Credit goes to @WillyChap for doing the actual development.

Please note that for now the 3-D plotting only works with CAM vs CAM comparisons, as the ability to process 3-D observations hasn't been developed yet.

Addresses #121 
Addresses #132 

Closes #130 

## Tests run:

Ran a single CAM vs CAM ADF run, a multi-case  CAM vs. CAM ADF run, and a single CAM vs. Obs ADF run, all of which behaved as expected.  Used `Q` and `U` as the 3-D variables during testing. 
