### PR TITLE
make polar plots more performant by reducing array to specified domain

### DIFF
--- a/lib/adf_variable_defaults.yaml
+++ b/lib/adf_variable_defaults.yaml
@@ -153,9 +153,9 @@ SWCF:
   mpl:
     colorbar:
       label : "Wm$^{-2}$"
-  obs_file: "CERES_EBAF_Ed4.1_SWCF_climo.nc"
+  obs_file: "CERES_EBAF_Ed4.1_2001-2020.nc"
   obs_name: "CERES_EBAF_Ed4.1"
-  obs_var_name: "SWCF"
+  obs_var_name: "toa_cre_sw_mon"
 
 LWCF:
   colormap: "Blues"
@@ -168,9 +168,9 @@ LWCF:
   mpl:
     colorbar:
       label : "Wm$^{-2}$"
-  obs_file: "CERES_EBAF_Ed4.1_LWCF_climo.nc"
+  obs_file: "CERES_EBAF_Ed4.1_2001-2020.nc"
   obs_name: "CERES_EBAF_Ed4.1"
-  obs_var_name: "LWCF"
+  obs_var_name: "toa_cre_lw_mon"
 
 #-----------
 #End of File

--- a/scripts/plotting/polar_map.py
+++ b/scripts/plotting/polar_map.py
@@ -310,6 +310,11 @@ def make_polar_plot(d1:xr.DataArray, d2:xr.DataArray, difference:Optional[xr.Dat
     d2_region_mean, d2_region_max, d2_region_min = domain_stats(d2, domain)
     dif_region_mean, dif_region_max, dif_region_min = domain_stats(dif, domain)
 
+    #downsize to the specified region; makes plotting/rendering/saving much faster
+    d1 = d1.sel(lat=slice(domain[2],domain[3]))
+    d2 = d2.sel(lat=slice(domain[2],domain[3]))
+    dif = dif.sel(lat=slice(domain[2],domain[3]))
+
     # add cyclic point to the data for better-looking plot
     d1_cyclic, lon_cyclic = add_cyclic_point(d1, coord=d1.lon)
     d2_cyclic, _ = add_cyclic_point(d2, coord=d2.lon)  # since we can take difference, assume same longitude coord.


### PR DESCRIPTION
As noted in the hackathons by several people, the polar map script takes a long time to run. I did a bunch of testing to see what was going on. (No issue was ever opened for this. I started messing with the performance in response to #125, but as I mentioned, I couldn't replicate that bug.)

There seem to be two culprits. 

First is that `contourf` can be kind of slow. Switching to `pcolormesh` saves quite a bit of time, especially when plotting differences (in my testing). This PR **does not** make this change, as it probably isn't as desired as regular contour plots.

Second is that `savefig` was taking a long time, often more than half the total time. I tried a few things, but the only one that helps is to reduce the arrays that are passed into `contourf`. Since the domain being plotted is only the polar region, this PR just reduces the arrays to only contain that data. As far as I can tell, the plots look identical to the current version, but the script runs much faster. 

I am assuming the reason for this result is that `contourf` was calculating the contours for the global domain, and then matplotlib and/or cartopy have to do a lot of work to transform the resulting contours to the polar projection. Possibly "hiding" the rest of the data is a burden in that transforming step (or whatever part of it happens at render time). 

I also changed the default yaml file to point to the updated CERES files. 