### PR TITLE
Faster timeseries and climos

### DIFF
--- a/config_cam_baseline_example.yaml
+++ b/config_cam_baseline_example.yaml
@@ -101,6 +101,13 @@ diag_basic_info:
     #given the same weight:
     weight_season: True
 
+    #Number of processors on which to run the ADF.
+    #If this config variable isn't present then
+    #the ADF defaults to one processor.  Also, if
+    #you set it to "*" then it will default
+    #to all of the processors on a single node:
+    num_procs: '*'
+
 #This second set of variables provides info for the CAM simulation(s) being diagnosed:
 diag_cam_climo:
 
@@ -286,12 +293,12 @@ diag_cvdp_info:
 
 #Note:  If you want to pass arguments to a particular script, you can
 #do it like so (using the "averaging_example" script in this case):
-# - {averaging_example: {kwargs: {clobber: true}}}
+# - {create_climo_files: {kwargs: {clobber: true}}}
 
 #Name of time-averaging scripts being used to generate climatologies.
 #These scripts must be located in "scripts/averaging":
 time_averaging_scripts:
-    - averaging_example
+    - create_climo_files
 
 #Name of regridding scripts being used.
 #These scripts must be located in "scripts/regridding":

--- a/config_cam_baseline_example.yaml
+++ b/config_cam_baseline_example.yaml
@@ -105,7 +105,8 @@ diag_basic_info:
     #If this config variable isn't present then
     #the ADF defaults to one processor.  Also, if
     #you set it to "*" then it will default
-    #to all of the processors on a single node:
+    #to all of the processors available on a
+    #single node/machine:
     num_procs: '*'
 
 #This second set of variables provides info for the CAM simulation(s) being diagnosed:

--- a/lib/adf_diag.py
+++ b/lib/adf_diag.py
@@ -466,14 +466,12 @@ class AdfDiag(AdfObs):
 
         global call_ncrcat
         def call_ncrcat(cmd):
-            '''this is an internal function to `create_time_series` 
+            '''this is an internal function to `create_time_series`
             It just wraps the subprocess.call() function, so it can be
             used with the multiprocessing Pool that is constructed below.
-            It is declared as global to avoid AttributeError. 
+            It is declared as global to avoid AttributeError.
             '''
             return subprocess.run(cmd, shell=False)
-        
-        number_of_cpu = mp.cpu_count()  # Max number of processes is set to how many CPUs we have.
 
         #Check if baseline time-series files are being created:
         if baseline:
@@ -663,14 +661,15 @@ class AdfDiag(AdfObs):
                 cmd = ["ncrcat", "-O", "-4", "-h", "-v", f"{var},hyam,hybm,hyai,hybi,PS"] + \
                        hist_files + ["-o", ts_outfil_str]
 
+                #Add to command list for use in multi-processing pool:
                 list_of_commands.append(cmd)
 
-            with mp.Pool(processes=number_of_cpu) as p:
-                result = p.map(call_ncrcat, list_of_commands)
-
-            print("DONE WITH TIME SERIES GENERATOR")
-        
             #End variable loop
+
+            #Now run the "ncrcat" subprocesses in parallel:
+            with mp.Pool(processes=self.num_procs) as p:
+                result = p.map(call_ncrcat, list_of_commands)
+            #End with
 
         #End cases loop
 

--- a/lib/adf_diag.py
+++ b/lib/adf_diag.py
@@ -474,7 +474,6 @@ class AdfDiag(AdfObs):
             return subprocess.run(cmd, shell=False)
         
         number_of_cpu = mp.cpu_count()  # Max number of processes is set to how many CPUs we have.
-        pool = mp.Pool(processes=number_of_cpu)  # Sets up a pool for the calls to ncrcat.
 
         #Check if baseline time-series files are being created:
         if baseline:
@@ -663,9 +662,10 @@ class AdfDiag(AdfObs):
                 #Run "ncrcat" command to generate time series file:
                 cmd = ["ncrcat", "-O", "-4", "-h", "-v", f"{var},hyam,hybm,hyai,hybi,PS"] + \
                        hist_files + ["-o", ts_outfil_str]
+
                 list_of_commands.append(cmd)
 
-            with pool as p:
+            with mp.Pool(processes=number_of_cpu) as p:
                 result = p.map(call_ncrcat, list_of_commands)
 
             print("DONE WITH TIME SERIES GENERATOR")

--- a/lib/adf_obs.py
+++ b/lib/adf_obs.py
@@ -105,7 +105,7 @@ class AdfObs(AdfConfig):
         else:
             #Check if variable is a string and matches keyword:
             if isinstance(temp_num_procs, str) and \
-               temp_num_procs == "*":
+               temp_num_procs.strip() == "*":
 
                 #Set number of processors to total number of CPUs
                 #on the node.  Please note that at some point this

--- a/lib/adf_obs.py
+++ b/lib/adf_obs.py
@@ -26,6 +26,7 @@ in various scripts.
 #++++++++++++++++++++++++++++++
 
 import copy
+import os
 
 from pathlib import Path
 
@@ -93,6 +94,64 @@ class AdfObs(AdfConfig):
 
         #Initialize "compare_obs" variable:
         self.__compare_obs = self.read_config_var('compare_obs', conf_dict=_basic_info)
+
+        #Initialize "num_procs" variable:
+        #-----------------------------------------
+        temp_num_procs = self.read_config_var('num_procs', conf_dict=_basic_info)
+
+        if not temp_num_procs:
+            #Variable not present, so set to a single processor:
+            self.__num_procs = 1
+        else:
+            #Check if variable is a string and matches keyword:
+            if isinstance(temp_num_procs, str) and \
+               temp_num_procs == "*":
+
+                #Set number of processors to total number of CPUs
+                #on the node.  Please note that at some point this
+                #may need to be replaced with a DASK implementation
+                #instead:
+
+                #First try to get CPUs allowed by OS for process to use:
+                try:
+                    self.__num_procs = len(os.sched_getaffinity(0))
+                except AttributeError:
+                    #Operating system doesn't support getaffinity, so try
+                    #straight CPU number:
+                    if os.cpu_count():
+                        self.__num_procs = os.cpu_count()
+                    else:
+                        #Something is weird with this Operating System,
+                        #so warn user and then try to run in serial mode:
+                        wmsg = "WARNING!!!! ADF unable to determine how"
+                        wmsg += " many processors are availble on this system,"
+                        wmsg += " so defaulting to a single process/core."
+                        print(wmsg)
+                        self.__num_procs = 1
+                    #End if
+                #End except
+
+            else:
+                #If anything else, then try to convert to integer:
+                try:
+                    self.__num_procs = int(temp_num_procs)
+                except ValueError:
+                    #This variable has been set to something that
+                    #can't be converted into an integer, so warn
+                    #user and then try to run in serial mode:
+                    wmsg = "WARNING!!!!  The 'num_procs' variable"
+                    wmsg += f" has been set to '{temp_num_procs}'"
+                    wmsg += " which cannot be converted to an integer."
+                    wmsg += "\nThe ADF will now default to a single core"
+                    wmsg += " and attempt to run."
+                    print(wmsg)
+                    self.__num_procs = 1
+                #End except
+            #End if
+        #End if
+        #Print number of processors being used to debug log (if requested):
+        self.debug_log(f"ADF is running with {self.__num_procs} processors.")
+        #-----------------------------------------
 
         #Initialize observations dictionary:
         self.__var_obs_dict = {}
@@ -209,40 +268,44 @@ class AdfObs(AdfConfig):
     # Create property needed to return "variable_defaults" variable to user:
     @property
     def variable_defaults(self):
-        """Return a copy of the '__variable_defaults' string list to user if requested."""
+        """Return a copy of the '__variable_defaults' dictionary to the user if requested."""
         #Note that a copy is needed in order to avoid having a script mistakenly
-        #modify this variable:
+        #modify this variable, as it is mutable and thus passed by reference:
         return copy.copy(self.__variable_defaults)
 
     # Create property needed to return "use_defaults" variable to user:
     @property
     def use_defaults(self):
-        """Return a copy of the '__use_defaults' logical to user if requested."""
-        #Note that a copy is needed in order to avoid having a script mistakenly
-        #modify this variable:
-        return copy.copy(self.__use_defaults)
+        """Return the '__use_defaults' logical to the user if requested."""
+        return self.__use_defaults
 
     # Create property needed to return "compare_obs" logical to user:
     @property
     def compare_obs(self):
-        """Return the "compare_obs" logical to user if requested."""
-        return copy.copy(self.__compare_obs)
+        """Return the "compare_obs" logical to the user if requested."""
+        return self.__compare_obs
 
     # Create property needed to return "diag_var_list" list to user:
     @property
     def diag_var_list(self):
-        """Return a copy of the "diag_var_list" list to user if requested."""
+        """Return a copy of the "diag_var_list" list to the user if requested."""
         #Note that a copy is needed in order to avoid having a script mistakenly
-        #modify this variable:
+        #modify this variable, as it is mutable and thus passed by reference:
         return copy.copy(self.__diag_var_list)
 
-    #Create property needed to return "var_obs_dict" list to user:
+    # Create property needed to return "var_obs_dict" dictionary to user:
     @property
     def var_obs_dict(self):
-        """Return a copy of the "var_obs_dict" list to user if requested."""
+        """Return a copy of the "var_obs_dict" list to the user if requested."""
         #Note that a copy is needed in order to avoid having a script mistakenly
-        #modify this variable:
+        #modify this variable, as it is mutable and thus passed by reference:
         return copy.copy(self.__var_obs_dict)
+
+    # Create property needed to return "num_procs" to user:
+    @property
+    def num_procs(self):
+        """Return the "num_procs" logical to the user if requested."""
+        return self.__num_procs
 
 #++++++++++++++++++++
 #End Class definition

--- a/scripts/averaging/create_climo_files.py
+++ b/scripts/averaging/create_climo_files.py
@@ -23,7 +23,7 @@ def create_climo_files(adf, clobber=False, search=None):
     This is an example function showing
     how to set-up a time-averaging method
     for calculating climatologies from
-    CAM time series files using 
+    CAM time series files using
     multiprocessing for parallelization.
 
     Description of needed inputs from ADF:
@@ -52,10 +52,8 @@ def create_climo_files(adf, clobber=False, search=None):
     #Notify user that script has started:
     print("  Calculating CAM climatologies...")
 
-    # Set up multiprocessing pool to parallelize writing climo files.            
-    number_of_cpu = mp.cpu_count()  # Max number of processes is set to how many CPUs we have.
-
-    print(f"\t MULTIPROCESSING SAYS YOU HAVE {number_of_cpu} CPUs AVAILABLE.")
+    # Set up multiprocessing pool to parallelize writing climo files.
+    number_of_cpu = adf.num_procs  # Get number of available processors from the ADF
 
     #Extract needed quantities from ADF object:
     #-----------------------------------------
@@ -167,7 +165,7 @@ def create_climo_files(adf, clobber=False, search=None):
                 #  end_diag_script(errmsg) # Previously we would kill the run here.
                 warnings.warn(errmsg)
                 continue
-            
+
             list_of_arguments.append((ts_files, syr, eyr, output_file))
         #End of var_list loop
         #--------------------

--- a/scripts/averaging/create_climo_files.py
+++ b/scripts/averaging/create_climo_files.py
@@ -1,0 +1,262 @@
+##################
+#Warnings function
+##################
+
+import warnings  # use to warn user about missing files.
+def my_formatwarning(msg, *args, **kwargs):
+    # ignore everything except the message
+    return str(msg) + '\n'
+warnings.formatwarning = my_formatwarning
+
+
+import xarray as xr  # module-level import so all functions can get to it.
+
+import multiprocessing as mp
+
+
+##############
+#Main function
+##############
+
+def create_climo_files(adf, clobber=False, search=None):
+    """
+    This is an example function showing
+    how to set-up a time-averaging method
+    for calculating climatologies from
+    CAM time series files using 
+    multiprocessing for parallelization.
+
+    Description of needed inputs from ADF:
+
+    case_name    -> Name of CAM case provided by "cam_case_name"
+    input_ts_loc -> Location of CAM time series files provided by "cam_ts_loc"
+    output_loc   -> Location to write CAM climo files to, provided by "cam_climo_loc"
+    var_list     -> List of CAM output variables provided by "diag_var_list"
+
+    Optional keyword arguments:
+
+        clobber -> whether to overwrite existing climatology files. Defaults to False (do not delete).
+
+        search  -> optional; if supplied requires a string used as a template to find the time series files
+                using {CASE} and {VARIABLE} and otherwise an arbitrary shell-like globbing pattern:
+                example 1: provide the string "{CASE}.*.{VARIABLE}.*.nc" this is the default
+                example 2: maybe CASE is not necessary because post-process destroyed the info "post_process_text-{VARIABLE}.nc"
+                example 3: order does not matter "{VARIABLE}.{CASE}.*.nc"
+                Only CASE and VARIABLE are allowed because they are arguments to the averaging function
+    """
+
+    #Import necessary modules:
+    from pathlib import Path
+    from adf_base import AdfError
+
+    #Notify user that script has started:
+    print("  Calculating CAM climatologies...")
+
+    # Set up multiprocessing pool to parallelize writing climo files.            
+    number_of_cpu = mp.cpu_count()  # Max number of processes is set to how many CPUs we have.
+
+    print(f"\t MULTIPROCESSING SAYS YOU HAVE {number_of_cpu} CPUs AVAILABLE.")
+
+    #Extract needed quantities from ADF object:
+    #-----------------------------------------
+    var_list = adf.diag_var_list
+
+    #CAM simulation variables (These quantities are always lists):
+    case_names    = adf.get_cam_info("cam_case_name", required=True)
+    input_ts_locs = adf.get_cam_info("cam_ts_loc", required=True)
+    output_locs   = adf.get_cam_info("cam_climo_loc", required=True)
+    calc_climos   = adf.get_cam_info("calc_cam_climo")
+    overwrite     = adf.get_cam_info("cam_overwrite_climo")
+    start_year    = adf.get_cam_info("start_year")
+    end_year      = adf.get_cam_info("end_year")
+
+    #If variables weren't provided in config file, then make them a list
+    #containing only None-type entries:
+    if not calc_climos:
+        calc_climos = [None]*len(case_names)
+    if not overwrite:
+        overwrite = [None]*len(case_names)
+    if not start_year:
+        start_year = [None]*len(case_names)
+    if not end_year:
+        end_year = [None]*len(case_names)
+    #End if
+
+    #Check if a baseline simulation is also being used:
+    if not adf.get_basic_info("compare_obs"):
+        #Extract CAM baseline variaables:
+        baseline_name     = adf.get_baseline_info("cam_case_name", required=True)
+        input_ts_baseline = adf.get_baseline_info("cam_ts_loc", required=True)
+        output_bl_loc     = adf.get_baseline_info("cam_climo_loc", required=True)
+        calc_bl_climos    = adf.get_baseline_info("calc_cam_climo")
+        ovr_bl            = adf.get_baseline_info("cam_overwrite_climo")
+        bl_syr            = adf.get_baseline_info("start_year")
+        bl_eyr            = adf.get_baseline_info("end_year")
+
+        #Append to case lists:
+        case_names.append(baseline_name)
+        input_ts_locs.append(input_ts_baseline)
+        output_locs.append(output_bl_loc)
+        calc_climos.append(calc_bl_climos)
+        overwrite.append(ovr_bl)
+        start_year.append(bl_syr)
+        end_year.append(bl_eyr)
+    #-----------------------------------------
+
+    # Check whether averaging interval is supplied
+    # -> using only years takes from the beginning of first year to end of second year.
+    # -> slice('1991','1998') will get all of [1991,1998].
+    # -> slice(None,None) will use all times.
+
+
+    #Loop over CAM cases:
+    for case_idx, case_name in enumerate(case_names):
+
+        #Check if climatology is being calculated.
+        #If not then just continue on to the next case:
+        if not calc_climos[case_idx]:
+            continue
+
+        #Notify user of model case being processed:
+        print(f"\t Calculating climatologies for case '{case_name}' :")
+
+        #Create "Path" objects:
+        input_location  = Path(input_ts_locs[case_idx])
+        output_location = Path(output_locs[case_idx])
+
+        #Whether to overwrite existing climo files
+        clobber = overwrite[case_idx]
+
+        #Check that time series input directory actually exists:
+        if not input_location.is_dir():
+            errmsg = f"Time series directory '{input_ts_loc}' not found.  Script is exiting."
+            raise AdfError(errmsg)
+
+        #Check if climo directory exists, and if not, then create it:
+        if not output_location.is_dir():
+            print(f"    {output_location} not found, making new directory")
+            output_location.mkdir(parents=True)
+
+        #Time series file search
+        if search is None:
+            search = "{CASE}*.{VARIABLE}.*nc"  # NOTE: maybe we should not care about the file extension part at all, but check file type later?
+
+        syr, eyr = check_averaging_interval(start_year[case_idx], end_year[case_idx])
+
+        #Loop over CAM output variables:
+        list_of_arguments = []
+        for var in var_list:
+
+            # Create name of climatology output file (which includes the full path)
+            # and check whether it is there (don't do computation if we don't want to overwrite):
+            output_file = output_location / f"{case_name}_{var}_climo.nc"
+            if (not clobber) and (output_file.is_file()):
+                print(f"INFO: Found climo file and clobber is False, so skipping {var} and moving to next variable.")
+                continue
+            elif (clobber) and (output_file.is_file()):
+                print(f"INFO: Climo file exists for {var}, but clobber is {clobber}, so will OVERWRITE it.")
+
+            #Create list of time series files present for variable:
+            ts_filenames = search.format(CASE=case_name, VARIABLE=var)
+            ts_files = sorted(list(input_location.glob(ts_filenames)))
+
+            #If no files exist, try to move to next variable. --> Means we can not proceed with this variable, and it'll be problematic later.
+            if not ts_files:
+                errmsg = "Time series files for variable '{}' not found.  Script will continue to next variable.".format(var)
+                print(f"The input location searched was: {input_location}. The glob pattern was {ts_filenames}.")
+                #  end_diag_script(errmsg) # Previously we would kill the run here.
+                warnings.warn(errmsg)
+                continue
+            
+            list_of_arguments.append((ts_files, syr, eyr, output_file))
+        #End of var_list loop
+        #--------------------
+
+        # Parallelize the computation using multiprocessing pool:
+        with mp.Pool(processes=number_of_cpu) as p:
+            result = p.starmap(process_variable, list_of_arguments)
+
+    #End of model case loop
+    #----------------------
+
+    #Notify user that script has ended:
+    print("  ...CAM climatologies have been calculated successfully.")
+
+
+#
+# Local functions
+#
+def process_variable(ts_files, syr, eyr, output_file):
+    '''
+    Compute and save the climatology file.
+    '''
+    #Read in files via xarray (xr):
+    if len(ts_files) == 1:
+        cam_ts_data = xr.open_dataset(ts_files[0], decode_times=True)
+    else:
+        cam_ts_data = xr.open_mfdataset(ts_files, decode_times=True, combine='by_coords')
+    #Average time dimension over time bounds, if bounds exist:
+    if 'time_bnds' in cam_ts_data:
+        time = cam_ts_data['time']
+        # NOTE: force `load` here b/c if dask & time is cftime, throws a NotImplementedError:
+        time = xr.DataArray(cam_ts_data['time_bnds'].load().mean(dim='nbnd').values, dims=time.dims, attrs=time.attrs)
+        cam_ts_data['time'] = time
+        cam_ts_data.assign_coords(time=time)
+        cam_ts_data = xr.decode_cf(cam_ts_data)
+    #Extract data subset using provided year bounds:
+    cam_ts_data = cam_ts_data.sel(time=slice(syr, eyr))
+    #Group time series values by month, and average those months together:
+    cam_climo_data = cam_ts_data.groupby('time.month').mean(dim='time')
+    #Rename "months" to "time":
+    cam_climo_data = cam_climo_data.rename({'month':'time'})
+    #Set netCDF encoding method (deal with getting non-nan fill values):
+    enc_dv = {xname: {'_FillValue': None, 'zlib': True, 'complevel': 4} for xname in cam_climo_data.data_vars}
+    enc_c  = {xname: {'_FillValue': None} for xname in cam_climo_data.coords}
+    enc    = {**enc_c, **enc_dv}
+    #Output variable climatology to NetCDF-4 file:
+    cam_climo_data.to_netcdf(output_file, format='NETCDF4', encoding=enc)
+    return 1  # All funcs return something. Could do error checking with this if needed.
+
+
+def check_averaging_interval(syear_in, eyear_in):
+    #For now, make sure year inputs are integers or None,
+    #in order to allow for the zero additions done below:
+    if syear_in:
+        check_syr = int(syear_in)
+    else:
+        check_syr = None
+    #end if
+
+    if eyear_in:
+        check_eyr = int(eyear_in)
+    else:
+        check_eyr = None
+
+    #Need to add zeros if year values aren't long enough:
+    #------------------
+    #start year:
+    if check_syr:
+        assert check_syr >= 0, 'Sorry, values must be positive whole numbers.'
+        try:
+            syr = f"{check_syr:04d}"
+        except:
+            errmsg = " 'start_year' values must be positive whole numbers"
+            errmsg += f"not '{syear_in}'."
+            raise AdfError(errmsg)
+    else:
+        syr = None
+    #End if
+
+    #end year:
+    if check_eyr:
+        assert check_eyr >= 0, 'Sorry, end_year values must be positive whole numbers.'
+        try:
+            eyr = f"{check_eyr:04d}"
+        except:
+            errmsg = " 'end_year' values must be positive whole numbers"
+            errmsg += f"not '{eyear_in}'."
+            raise AdfError(errmsg)
+    else:
+        eyr = None
+    #End if
+    return syr, eyr


### PR DESCRIPTION
This PR addresses https://github.com/NCAR/ADF/issues/92

Uses `multiprocessing` in `adf_diag` to speed up generation of time series files. This should help in situations where many variables are being processed because separate processes were being initiated for each variable (potentially bogging down system). Using `multiprocessing.Pool` sets up the processes to wait until previous ones are done. As @justin-richling showed at the hackathon, this dramatically decreases the time to generate time series files. 

Introduces `create_climo_files` as a drop-in replacement for `averaging_example`. This case is a little bit more of a change, but the same principle. Introduces a function that deals with calculating and saving a climo file for an individual variable. The list of arguments for all variables is collected and then the function is called in parallel using `multiprocessing.Pool`. Testing on a small set of variables, I was able to cut the time for ADF (time series generation + climo generation + nominal remapping (but no plots)) from about 12-13 minutes down to 2.5-3 minutes (on a Casper login node). 

In both cases, I just let multiprocessing use all the available CPUs. It would be easy to check for a user-specified number to control this from the config file. 