### PR TITLE
checks history files for variable before running ncrcat

### DIFF
--- a/lib/adf_diag.py
+++ b/lib/adf_diag.py
@@ -584,13 +584,20 @@ class AdfDiag(AdfObs):
 
             #Create ordered list of CAM history files:
             hist_files = sorted(files_list)
-
+            #Get a list of data variables in the 1st hist file:
+            hist_file_var_list = list(xr.open_dataset(hist_files[0], decode_cf=False, decode_times=False).data_vars)
+            #Note: could use `open_mfdataset`, but that can become very slow;
+            #      This approach effectively assumes that all files contain the same variables.
+            
             #Check if time series directory exists, and if not, then create it:
             #Use pathlib to create parent directories, if necessary.
             Path(ts_dir[case_idx]).mkdir(parents=True, exist_ok=True)
 
             #Loop over CAM history variables:
             for var in self.diag_var_list:
+                if var not in hist_file_var_list:
+                    print(f"WARNING: {var} is not in the file {hist_files[1]}. No time series will be generated.")
+                    continue
 
                 #Create full path name:
                 ts_outfil_str = ts_dir[case_idx] + os.sep + case_name + \


### PR DESCRIPTION
Fixes https://github.com/NCAR/ADF/issues/94

In `create_time_series()` this change opens the first file in the list `hist_files` and gets the `data_vars`. Then it checks each of the config file's variables against that list. If the variable isn't found, a warning is emitted (well, printed), and then the the function will go to the next variable. 

Downside seems to be that the file has to be accessed, but I specify `decode_cf=False` to make it as fast as possible. This also makes the assumption that all history files will be alike, but I think that is a good assumption (?). 

Closes #151 