### PR TITLE
Output directory name for both case climo years

### DIFF
--- a/lib/adf_diag.py
+++ b/lib/adf_diag.py
@@ -765,6 +765,12 @@ class AdfDiag(AdfObs):
         else:
             data_name = self.get_baseline_info('cam_case_name', required=True)
 
+        #Start years (not currently required):
+        syears_baseline = self.get_baseline_info('start_year')
+
+        #End year (not currently rquired):
+        eyears_baseline = self.get_baseline_info('end_year')
+
         #Set "plot_location" variable, if it doesn't exist already, and save value in diag object.
         #Please note that this is also assumed to be the output location for the analyses scripts:
         if not self.__plot_location:
@@ -786,7 +792,7 @@ class AdfDiag(AdfObs):
 
                 #Check if case has start and end years:
                 if syears[case_idx] and eyears[case_idx]:
-                    direc_name = f"{case_name}_vs_{data_name}_{syears[case_idx]}_{eyears[case_idx]}"
+                    direc_name = f"{case_name}_{syears[case_idx]}_{eyears[case_idx]}_vs_{data_name}_{syears_baseline}_{eyears_baseline}"
                     self.__plot_location.append(os.path.join(plot_dir, direc_name))
                 else:
                     direc_name = f"{case_name}_vs_{data_name}"

--- a/lib/adf_diag.py
+++ b/lib/adf_diag.py
@@ -836,6 +836,12 @@ class AdfDiag(AdfObs):
         else:
             data_name = self.get_baseline_info('cam_case_name', required=True)
 
+        #Start years (not currently required):
+        syears_baseline = self.get_baseline_info('start_year')
+
+        #End year (not currently rquired):
+        eyears_baseline = self.get_baseline_info('end_year')
+
         #Set "plot_location" variable, if it doesn't exist already, and save value in diag object:
         if not self.__plot_location:
 
@@ -856,7 +862,7 @@ class AdfDiag(AdfObs):
 
                 #Check if case has start and end years:
                 if syears[case_idx] and eyears[case_idx]:
-                    direc_name = f"{case_name}_vs_{data_name}_{syears[case_idx]}_{eyears[case_idx]}"
+                    direc_name = f"{case_name}_{syears[case_idx]}_{eyears[case_idx]}_vs_{data_name}_{syears_baseline}_{eyears_baseline}"
                     self.__plot_location.append(os.path.join(plot_dir, direc_name))
                 else:
                     direc_name = f"{case_name}_vs_{data_name}"


### PR DESCRIPTION
### Closes 

Issue #150 

### Files changed

```lib/adf_diag.py```

Pull in the years from ```get_baseline_info()``` and add them to the output directory name.

Example:  [f.c6_3_41.FWscHIST.ne30_L58_exner.001_1980_1989_vs_f.e21.FWscHIST.ne30_L48_BL10_cam6_3_041_control.hf.001_1982_1987/](https://project.cgd.ucar.edu/projects/ADF/f.c6_3_41.FWscHIST.ne30_L58_exner.001_1980_1989_vs_f.e21.FWscHIST.ne30_L48_BL10_cam6_3_041_control.hf.001_1982_1987/)