### PR TITLE
Fix missing contour levs

### DIFF
--- a/lib/plotting_functions.py
+++ b/lib/plotting_functions.py
@@ -260,8 +260,15 @@ def plot_map_and_save(wks, mdlfld, obsfld, diffld, **kwargs):
             cmap = cmap1
             norm = norm1
 
-        img.append(ax[i].contourf(lons, lats, a, levels=levels, cmap=cmap, norm=norm, transform=ccrs.PlateCarree(), **contourf_opt))
-        cb.append(fig.colorbar(img[i], ax=ax[i], shrink=0.8, **colorbar_opt))
+        empty_message = "No Valid\nData Points"
+        props = dict(boxstyle='round', facecolor='wheat', alpha=0.9)
+        levs = np.unique(np.array(levels))
+        if len(levs) < 2:
+            img.append(ax[i].contourf(lons,lats,a,colors="w",transform=ccrs.PlateCarree()))
+            ax[i].text(0.4, 0.4, empty_message, transform=ax[i].transAxes, bbox=props)
+        else:
+            img.append(ax[i].contourf(lons, lats, a, levels=levels, cmap=cmap, norm=norm, transform=ccrs.PlateCarree(), **contourf_opt))
+            cb.append(fig.colorbar(img[i], ax=ax[i], shrink=0.8, **colorbar_opt))
         ax[i].set_title("AVG: {0:.3f}".format(area_avg[i]), loc='right', fontsize=tiFontSize)
         # add contour lines <- Unused for now -JN
         # TODO: add an option to turn this on -BM

--- a/lib/plotting_functions.py
+++ b/lib/plotting_functions.py
@@ -559,13 +559,24 @@ def plot_zonal_mean_and_save(wks, adata, apsurf, ahya, ahyb, bdata, bpsurf, bhya
 
         # Generate zonal plot:
         fig, ax = plt.subplots(nrows=3, constrained_layout=True, sharex=True, sharey=True,**subplots_opt)
-        img0, ax[0] = zonal_plot(adata['lat'], azm, ax=ax[0], norm=norm1,cmap=cmap1,levels=levels1,**contourf_opt)
-        img1, ax[1] = zonal_plot(bdata['lat'], bzm, ax=ax[1], norm=norm1,cmap=cmap1,levels=levels1,**contourf_opt)
-        img2, ax[2] = zonal_plot(adata['lat'], diff, ax=ax[2], norm=normdiff,cmap=cmapdiff,levels=levelsdiff,**contourf_opt)
+        levs = np.unique(np.array(levels1))
+        if len(levs) < 2:
+            empty_message = "No Valid\nData Points"
+            props = dict(boxstyle='round', facecolor='wheat', alpha=0.9)
+            img0, ax[0] = zonal_plot(adata['lat'], azm, ax=ax[0])
+            ax[0].text(0.4, 0.4, empty_message, transform=ax[0].transAxes, bbox=props)
+            img1, ax[1] = zonal_plot(bdata['lat'], bzm, ax=ax[1])
+            ax[1].text(0.4, 0.4, empty_message, transform=ax[1].transAxes, bbox=props)
+            img2, ax[2] = zonal_plot(adata['lat'], diff, ax=ax[2])
+            ax[2].text(0.4, 0.4, empty_message, transform=ax[2].transAxes, bbox=props)
+        else:
+            img0, ax[0] = zonal_plot(adata['lat'], azm, ax=ax[0], norm=norm1,cmap=cmap1,levels=levels1,**contourf_opt)
+            img1, ax[1] = zonal_plot(bdata['lat'], bzm, ax=ax[1], norm=norm1,cmap=cmap1,levels=levels1,**contourf_opt)
+            img2, ax[2] = zonal_plot(adata['lat'], diff, ax=ax[2], norm=normdiff,cmap=cmapdiff,levels=levelsdiff,**contourf_opt)
+            cb0 = fig.colorbar(img0, ax=ax[0], location='right',**colorbar_opt)
+            cb1 = fig.colorbar(img1, ax=ax[1], location='right',**colorbar_opt)
+            cb2 = fig.colorbar(img2, ax=ax[2], location='right',**colorbar_opt)
         # style the plot:
-        cb0 = fig.colorbar(img0, ax=ax[0], location='right',**colorbar_opt)
-        cb1 = fig.colorbar(img1, ax=ax[1], location='right',**colorbar_opt)
-        cb2 = fig.colorbar(img2, ax=ax[2], location='right',**colorbar_opt)
         ax[-1].set_xlabel("LATITUDE")
         fig.text(-0.03, 0.5, 'PRESSURE [hPa]', va='center', rotation='vertical')
     else:

--- a/lib/plotting_functions.py
+++ b/lib/plotting_functions.py
@@ -389,7 +389,9 @@ def plot_map_and_save(wks, mdlfld, obsfld, diffld, **kwargs):
         else:
             img.append(ax[i].contourf(lons, lats, a, levels=levels, cmap=cmap, norm=norm, transform=ccrs.PlateCarree(), **contourf_opt))
             cb.append(fig.colorbar(img[i], ax=ax[i], shrink=0.8, **colorbar_opt))
+        #End if
         ax[i].set_title("AVG: {0:.3f}".format(area_avg[i]), loc='right', fontsize=tiFontSize)
+
         # add contour lines <- Unused for now -JN
         # TODO: add an option to turn this on -BM
         #cs.append(ax[i].contour(lon2, lat2, fields[i], transform=ccrs.PlateCarree(), colors='k', linewidths=1))
@@ -632,6 +634,7 @@ def plot_zonal_mean_and_save(wks, adata, apsurf, ahya, ahyb, bdata, bpsurf, bhya
             cmap1 = kwargs['colormap']
         else:
             cmap1 = 'coolwarm'
+        #End if
 
         if 'contour_levels' in kwargs:
             levels1 = kwargs['contour_levels']
@@ -643,6 +646,7 @@ def plot_zonal_mean_and_save(wks, adata, apsurf, ahya, ahyb, bdata, bpsurf, bhya
         else:
             levels1 = np.linspace(minval, maxval, 12)
             norm1 = mpl.colors.Normalize(vmin=minval, vmax=maxval)
+        #End if
 
 
         if ('colormap' not in kwargs) and ('contour_levels' not in kwargs):
@@ -650,12 +654,15 @@ def plot_zonal_mean_and_save(wks, adata, apsurf, ahya, ahyb, bdata, bpsurf, bhya
                 norm1 = normfunc(vmin=minval, vmax=maxval, vcenter=0.0)
             else:
                 norm1 = mpl.colors.Normalize(vmin=minval, vmax=maxval)
+            #End if
+        #End if
 
     # Difference options -- Check in kwargs for colormap and levels
         if "diff_colormap" in kwargs:
             cmapdiff = kwargs["diff_colormap"]
         else:
             cmapdiff = 'coolwarm'
+        #End if
 
         if "diff_contour_levels" in kwargs:
             levelsdiff = kwargs["diff_contour_levels"]  # a list of explicit contour levels
@@ -667,12 +674,14 @@ def plot_zonal_mean_and_save(wks, adata, apsurf, ahya, ahyb, bdata, bpsurf, bhya
             absmaxdif = np.max(np.abs(diff))
             # set levels for difference plot:
             levelsdiff = np.linspace(-1*absmaxdif, absmaxdif, 12)
+        #End if
 
     # color normalization for difference
         if ((np.min(levelsdiff) < 0) and (0 < np.max(levelsdiff))) and mplv > 2:
             normdiff = normfunc(vmin=np.min(levelsdiff), vmax=np.max(levelsdiff), vcenter=0.0)
         else:
             normdiff = mpl.colors.Normalize(vmin=np.min(levelsdiff), vmax=np.max(levelsdiff))
+        #End if
 
         subplots_opt = {}
         contourf_opt = {}
@@ -683,6 +692,7 @@ def plot_zonal_mean_and_save(wks, adata, apsurf, ahya, ahyb, bdata, bpsurf, bhya
             subplots_opt.update(kwargs['mpl'].get('subplots',{}))
             contourf_opt.update(kwargs['mpl'].get('contourf',{}))
             colorbar_opt.update(kwargs['mpl'].get('colorbar',{}))
+        #End if
 
         # Generate zonal plot:
         fig, ax = plt.subplots(nrows=3, constrained_layout=True, sharex=True, sharey=True,**subplots_opt)
@@ -703,6 +713,8 @@ def plot_zonal_mean_and_save(wks, adata, apsurf, ahya, ahyb, bdata, bpsurf, bhya
             cb0 = fig.colorbar(img0, ax=ax[0], location='right',**colorbar_opt)
             cb1 = fig.colorbar(img1, ax=ax[1], location='right',**colorbar_opt)
             cb2 = fig.colorbar(img2, ax=ax[2], location='right',**colorbar_opt)
+        #End if
+
         # style the plot:
         ax[-1].set_xlabel("LATITUDE")
         fig.text(-0.03, 0.5, 'PRESSURE [hPa]', va='center', rotation='vertical')
@@ -719,6 +731,9 @@ def plot_zonal_mean_and_save(wks, adata, apsurf, ahya, ahyb, bdata, bpsurf, bhya
                 a.label_outer()
             except:
                 pass
+            #End except
+        #End for
+    #End if
 
     #Write the figure to provided workspace/file:
     fig.savefig(wks, bbox_inches='tight', dpi=300)

--- a/scripts/plotting/global_latlon_map.py
+++ b/scripts/plotting/global_latlon_map.py
@@ -1,3 +1,16 @@
+
+#Import standard modules:
+from pathlib import Path
+import numpy as np
+import xarray as xr
+import warnings  # use to warn user about missing files.
+
+#Format warning messages:
+def my_formatwarning(msg, *args, **kwargs):
+    # ignore everything except the message
+    return str(msg) + '\n'
+warnings.formatwarning = my_formatwarning
+
 def global_latlon_map(adfobj):
     """
     This script/function is designed to generate global
@@ -27,11 +40,6 @@ def global_latlon_map(adfobj):
 
     #Import necessary modules:
     #------------------------
-    from pathlib import Path  # python standard library
-
-    # data loading / analysis
-    import xarray as xr
-    import numpy as np
     import pandas as pd
 
     #CAM diagnostic plotting functions:
@@ -451,6 +459,22 @@ def global_latlon_map(adfobj):
 
     #Notify user that script has ended:
     print("  ...lat/lon maps have been generated successfully.")
+
+#########
+# Helpers
+#########
+
+def _load_dataset(fils):
+    if len(fils) == 0:
+        warnings.warn(f"Input file list is empty.")
+        return None
+    elif len(fils) > 1:
+        return xr.open_mfdataset(fils, combine='by_coords')
+    else:
+        sfil = str(fils[0])
+        return xr.open_dataset(sfil)
+    #End if
+#End def
 
 ##############
 #END OF SCRIPT

--- a/scripts/plotting/polar_map.py
+++ b/scripts/plotting/polar_map.py
@@ -402,17 +402,29 @@ def make_polar_plot(d1:xr.DataArray, d2:xr.DataArray, difference:Optional[xr.Dat
     ax2 = plt.subplot(gs[0, 2:], projection=proj)
     ax3 = plt.subplot(gs[1, 1:3], projection=proj)
 
-    img1 = ax1.contourf(lons, lats, d1_cyclic, transform=ccrs.PlateCarree(), cmap=cmap1, norm=norm1, levels=levels1)
-    ax1.set_title(f"{d1.name} [{d1.units}]")
+    empty_message = "No Valid\nData Points"
+    props = dict(boxstyle='round', facecolor='wheat', alpha=0.9)
+    levs = np.unique(np.array(levels1))
+    if len(levs) < 2:
+        img1 = ax1.contourf(lons, lats, d1_cyclic, transform=ccrs.PlateCarree(), colors="w", norm=norm1)
+        ax1.text(0.4, 0.4, empty_message, transform=ax1.transAxes, bbox=props)
+
+        img2 = ax2.contourf(lons, lats, d2_cyclic, transform=ccrs.PlateCarree(), colors="w", norm=norm1)
+        ax2.text(0.4, 0.4, empty_message, transform=ax2.transAxes, bbox=props)
+
+        img3 = ax3.contourf(lons, lats, dif_cyclic, transform=ccrs.PlateCarree(), colors="w", norm=dnorm)
+        ax3.text(0.4, 0.4, empty_message, transform=ax3.transAxes, bbox=props)
+    else:
+        img1 = ax1.contourf(lons, lats, d1_cyclic, transform=ccrs.PlateCarree(), cmap=cmap1, norm=norm1, levels=levels1)
+        img2 = ax2.contourf(lons, lats, d2_cyclic, transform=ccrs.PlateCarree(), cmap=cmap1, norm=norm1, levels=levels1)
+        img3 = ax3.contourf(lons, lats, dif_cyclic, transform=ccrs.PlateCarree(), cmap=cmapdiff, norm=dnorm, levels=levelsdiff)
+
     ax1.text(-0.2, -0.10, f"Mean: {d1_region_mean:5.2f}\nMax: {d1_region_max:5.2f}\nMin: {d1_region_min:5.2f}", transform=ax1.transAxes)
-
-    img2 = ax2.contourf(lons, lats, d2_cyclic, transform=ccrs.PlateCarree(), cmap=cmap1, norm=norm1, levels=levels1)
-    ax2.set_title(f"{d2.name} [{d2.units}]")
+    ax1.set_title(f"{d1.name} [{d1.units}]")
     ax2.text(-0.2, -0.10, f"Mean: {d2_region_mean:5.2f}\nMax: {d2_region_max:5.2f}\nMin: {d2_region_min:5.2f}", transform=ax2.transAxes)
-
-    img3 = ax3.contourf(lons, lats, dif_cyclic, transform=ccrs.PlateCarree(), cmap=cmapdiff, norm=dnorm, levels=levelsdiff)
-    ax3.set_title(f"Difference [{dif.units}]", loc='left')
+    ax2.set_title(f"{d2.name} [{d2.units}]")
     ax3.text(-0.2, -0.10, f"Mean: {dif_region_mean:5.2f}\nMax: {dif_region_max:5.2f}\nMin: {dif_region_min:5.2f}", transform=ax3.transAxes)
+    ax3.set_title(f"Difference [{dif.units}]", loc='left')
 
     [a.set_extent(domain, ccrs.PlateCarree()) for a in [ax1, ax2, ax3]]
     [a.coastlines() for a in [ax1, ax2, ax3]]


### PR DESCRIPTION
Closes  #152 

When plotting with less than two levels, ```contour``` and ````contourf```` fail. This checks to see how many unique plotting levels are available and plots an empty map with a warning text (similar to NCL) when not enough levels are available. 

Example [here](https://project.cgd.ucar.edu/projects/ADF/bad-contour/f.e21.FHIST.ne30_L48_BL10_cam6_3_019_plus_CESM2.2.001_zm2.hf_vs_f.e21.FWscHIST.ne30_L48_BL10_cam6_3_019_plus_CESM2.2.001_zm2.hf_1980_1989/html_img/plot_page_SFH2O2_JJA_LatLon.html)
<img width="578" alt="Screen Shot 2022-04-28 at 11 39 24 AM" src="https://user-images.githubusercontent.com/56696811/165814397-5b9f0830-dfda-4c65-be3b-dc143b472b3d.png">

