### PR TITLE
Change central longitude

### DIFF
--- a/config_cam_baseline_example.yaml
+++ b/config_cam_baseline_example.yaml
@@ -96,6 +96,11 @@ diag_basic_info:
     #horizontal maps:
     plot_press_levels: [200,850]
 
+    #Longitude line on which to center all lat/lon maps.
+    #If this config option is missing then the central
+    #longitude will default to 180 degrees E.
+    central_longitude: 180
+
     #Apply monthly weights to seasonal averages.
     #If False or missing, then all months are
     #given the same weight:

--- a/lib/adf_config.py
+++ b/lib/adf_config.py
@@ -5,7 +5,7 @@ This class inherits from the AdfBase class.
 
 Currently this class does three things:
 
-1.  Initializes and instance of AdfBase.
+1.  Initializes an instance of AdfBase.
 
 2.  Reads in a config (YAML) file.
 

--- a/lib/plotting_functions.py
+++ b/lib/plotting_functions.py
@@ -77,17 +77,20 @@ def get_central_longitude(*args):
        This allows a script to, for example, allow a config file to specify, but also have a preference:
        get_central_longitude(AdfObj, 30.0)
     """
+    chk_for_adf = [isinstance(a, AdfDiag) for a in args]
+    # preference is to get value from AdfDiag:
+    if any(chk_for_adf):
+        for a in args:
+            if isinstance(a, AdfDiag):
+                result = a.get_basic_info('central_longitude', required=False)
+                if (result >= -180) and (result <= 360):
+                    return result
+                else:
+                    continue # keep looking
+    # 2nd pass through arguments, look for numbers:
     for a in args:
-        if isinstance(a, AdfDiag):
-            result = a.get_basic_info('central_longitude', required=False)
-            if (result >= -180) and (result <= 360):
-                return result
-            else:
-                continue # keep looking
-        elif (isinstance(a, float) or isinstance(a, int)) and ((a >= -180) and (a <= 360)):
+        if (isinstance(a, float) or isinstance(a, int)) and ((a >= -180) and (a <= 360)):
             return a
-        else:
-            continue
     else:
         # this is the `else` on the for loop --> if non of the arguments meet the criteria, do this.
         print("No valid central longitude specified. Defaults to 180.")

--- a/scripts/plotting/global_latlon_map.py
+++ b/scripts/plotting/global_latlon_map.py
@@ -87,6 +87,11 @@ def global_latlon_map(adfobj):
     res = adfobj.variable_defaults # will be dict of variable-specific plot preferences
     # or an empty dictionary if use_defaults was not specified in YAML.
 
+    # For global maps, also set the central longitude:
+    # can be specified in adfobj basic info as 'central_longitude' or supplied as a number,
+    # otherwise defaults to 180
+    res['central_longitude'] = pf.get_central_longitude(adfobj)
+
     #Set plot file type:
     # -- this should be set in basic_info_dict, but is not required
     # -- So check for it, and default to png

--- a/scripts/plotting/global_latlon_map.py
+++ b/scripts/plotting/global_latlon_map.py
@@ -91,11 +91,6 @@ def global_latlon_map(adfobj):
     res = adfobj.variable_defaults # will be dict of variable-specific plot preferences
     # or an empty dictionary if use_defaults was not specified in YAML.
 
-    # For global maps, also set the central longitude:
-    # can be specified in adfobj basic info as 'central_longitude' or supplied as a number,
-    # otherwise defaults to 180
-    res['central_longitude'] = pf.get_central_longitude(adfobj)
-
     #Set plot file type:
     # -- this should be set in basic_info_dict, but is not required
     # -- So check for it, and default to png
@@ -161,6 +156,12 @@ def global_latlon_map(adfobj):
 
         else:
             vres = {}
+        #End if
+
+        # For global maps, also set the central longitude:
+        # can be specified in adfobj basic info as 'central_longitude' or supplied as a number,
+        # otherwise defaults to 180
+        vres['central_longitude'] = pf.get_central_longitude(adfobj)
 
         #loop over different data sets to plot model against:
         for data_src in data_list:

--- a/scripts/plotting/global_latlon_vect_map.py
+++ b/scripts/plotting/global_latlon_vect_map.py
@@ -148,6 +148,11 @@ def global_latlon_vect_map(adfobj):
         skip_vars.add(var)
         skip_vars.add(var_pair)
 
+        # For global maps, also set the central longitude:
+        # can be specified in adfobj basic info as 'central_longitude' or supplied as a number,
+        # otherwise defaults to 180
+        vres['central_longitude'] = pf.get_central_longitude(adfobj)
+
         #Determine observations to compare against:
         if adfobj.compare_obs:
             #Check if obs exist for the variable:


### PR DESCRIPTION
This addresses https://github.com/NCAR/ADF/issues/163

Adds a function in `plotting_functions` called `get_central_longitude`. This function takes an arbitrary number of arguments, but is expected to get one or two. If any arguments are AdfDiag objects, they are checked in order for  `central_longitude` in the basic info section. If no AdfDiag object is found or none of them have `central_longitude` specified, check the arguments for scalar values in [-180, 360]. Take the first valid value as the answer. If none of the arguments make a valid central longitude, use 180 as the default.

`get_central_longitude` can be used by scripts to set the longitude.

This PR also includes a modification to `plot_map_and_save` to look in the `kwargs` for `central_longitude`. The intention here is that a script using `plot_map_and_save` would use `get_central_longitude` and provide the result as a keyword. If it doesn't find the keyword argument, it defaults to using 180 anyway.

Independent from the longitude, this PR corrects/improves the tick marks and labels for the maps. 

The script `get_latlon_map.py` is modified to use `get_central_longitude` and send it to `plot_map_and_save`. 
