### PR TITLE
Taylor casename fix

### DIFF
--- a/lib/adf_diag.py
+++ b/lib/adf_diag.py
@@ -1116,6 +1116,11 @@ class AdfDiag(AdfObs):
         ptype_html_list = list(itertools.chain.from_iterable(ptype_html))
         ptype_order_list = list(itertools.chain.from_iterable(ptype_order))
 
+        if self.compare_obs:
+            if ['TaylorDiag'] in ptype_order:
+                ptype_html_list.remove("html_img/mean_diag_TaylorDiag.html")
+                ptype_order_list.remove("TaylorDiag")
+
         #Make dictionary for plot type names and html paths
         plot_type_html = dict(zip(ptype_order_list, ptype_html_list))
 

--- a/scripts/plotting/cam_taylor_diagram.py
+++ b/scripts/plotting/cam_taylor_diagram.py
@@ -263,7 +263,7 @@ def get_tropical_ocean_precip(adf, casename, location, **kwargs):
                          attrs=prect.attrs)
     return prect.sel(lat=slice(-30,30))
 
-def get_surface_pressure(dset, location):
+def get_surface_pressure(dset, casename, location):
 
     #Find surface pressure (PS):
     if 'PS' in dset.variables:
@@ -296,7 +296,7 @@ def get_var_at_plev(adf, casename, location, variable, plev):
     dset = _retrieve(adf, variable, casename, location, return_dataset=True)
 
     # Try and extract surface pressure:
-    ps = get_surface_pressure(dset, location)
+    ps = get_surface_pressure(dset, casename, location)
 
     vplev = gc.interp_hybrid_to_pressure(dset['U'], ps, dset['hyam'], dset['hybm'],
                                          new_levels=np.array([100. * plev]), lev_dim='lev')
@@ -319,7 +319,7 @@ def get_vertical_average(adf, casename, location, varname):
         else:
             raise NotImplementedError("Need to deal with mult-file case.")
     # Try and extract surface pressure:
-    ps = get_surface_pressure(ds, location)
+    ps = get_surface_pressure(ds, casename, location)
     # If the climo file is made by ADF, then hyam and hybm will be with VARIABLE:
     return vertical_average(ds[varname], ps, ds['hyam'], ds['hybm'])
 


### PR DESCRIPTION
When running Taylor Diagrams, there was a missing casename argument for the ```get_surface_pressure``` function in the ```cam_taylor_diagram.py``` script.

This has been fixed as well as a check for Taylor Diagram with Obs scenario. The website would still generate a broken link to the Taylor Diagram if it was included in the config file. This PR checks for that and removes it from the list of HTML generated links.