### PR TITLE
Allow for website generation if no plotting scripts are assigned

### DIFF
--- a/lib/adf_diag.py
+++ b/lib/adf_diag.py
@@ -1106,11 +1106,16 @@ class AdfDiag(AdfObs):
 
         #Grab the plot type functions form user
         plot_func_names = self.__plotting_scripts
-
-        #Since polar has more than one plot type name, make a list of lists
-        #that grab all the paths and names
-        ptype_html = sorted([ptype_html_dict[x] for x in plot_func_names if x in ptype_html_dict])
-        ptype_order = sorted([ptype_order_dict[x] for x in plot_func_names if x in ptype_order_dict])
+        
+        if plot_func_names == None:
+            print("No plotting scripts declared in config file")
+            ptype_html = []
+            ptype_order = []
+        else:
+            #Since polar has more than one plot type name, make a list of lists
+            #that grab all the paths and names
+            ptype_html = sorted([ptype_html_dict[x] for x in plot_func_names if x in ptype_html_dict])
+            ptype_order = sorted([ptype_order_dict[x] for x in plot_func_names if x in ptype_order_dict])
 
         #Flatten the list of lists into a regular list
         ptype_html_list = list(itertools.chain.from_iterable(ptype_html))


### PR DESCRIPTION
Closes #194

If no plotting functions are listed in the config file, the script crashes upon website creation.

This will check and make empty lists for the html page generation and allow the website to continue.