### PR TITLE
Remake index.html every time

### DIFF
--- a/.github/workflows/ADF_unit_tests.yaml
+++ b/.github/workflows/ADF_unit_tests.yaml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       matrix:
         #All of these python versions will be used to run tests:
-        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
       fail-fast: false
     steps:
     # Acquire github action routines:

--- a/lib/adf_web.py
+++ b/lib/adf_web.py
@@ -390,7 +390,6 @@ class AdfWeb(AdfObs):
         #Set climo years format for html file headers
         case_yrs=f"{syear_cases[0]} - {eyear_cases[0]}"
 
-
         #Extract variable defaults dictionary (for categories):
         var_defaults_dict = self.variable_defaults
 
@@ -694,30 +693,28 @@ class AdfWeb(AdfObs):
             index_html_file = \
                 self.__case_web_paths[web_data.case]['website_dir'] / "index.html"
 
-            if not index_html_file.exists():
+            #Re-et plot types list:
+            if web_data.case == 'multi-case':
+                plot_types = multi_plot_type_html
+            else:
+                plot_types = plot_type_html
+            #End if
 
-                #Re-et plot types list:
-                if web_data.case == 'multi-case':
-                    plot_types = multi_plot_type_html
-                else:
-                    plot_types = plot_type_html
-                #End if
+            #Construct index.html
+            index_title = "AMP Diagnostics Prototype"
+            index_tmpl = jinenv.get_template('template_index.html')
+            index_rndr = index_tmpl.render(title=index_title,
+                                            case1=web_data.case,
+                                            case2=data_name,
+                                            case_yrs=case_yrs,
+                                            baseline_yrs=baseline_yrs,
+                                            plot_types=plot_types)
 
-                #Construct index.html
-                index_title = "AMP Diagnostics Prototype"
-                index_tmpl = jinenv.get_template('template_index.html')
-                index_rndr = index_tmpl.render(title=index_title,
-                                               case1=web_data.case,
-                                               case2=data_name,
-                                               case_yrs=case_yrs,
-                                               baseline_yrs=baseline_yrs,
-                                               plot_types=plot_types)
+            #Write Mean diagnostics index HTML file:
+            with open(index_html_file, 'w', encoding='utf-8') as ofil:
+                ofil.write(index_rndr)
+            #End with
 
-                #Write Mean diagnostics index HTML file:
-                with open(index_html_file, 'w', encoding='utf-8') as ofil:
-                    ofil.write(index_rndr)
-                #End with
-            #End if (mean_index exists)
         #End for (web data loop)
 
         #If this is a multi-case instance, then copy website to "main" directory:


### PR DESCRIPTION
** Impacts only for website generation **

If changing ADF after an initial run, the user currently has to delete the index.html before re-running ADF to make an updated index.html file in order for the changes to be reflected on the website.

This is a huge gotcha that would be good to eliminate and won't cost much in terms of computation. It will guarantee all changes to subsequent ADF runs will be reflected in the webpage. 