### PR TITLE
Enhance multiple case diagnostics

### DIFF
--- a/config_cam_baseline_example.yaml
+++ b/config_cam_baseline_example.yaml
@@ -151,6 +151,11 @@ diag_cam_climo:
     #Name of CAM case (or CAM run name):
     cam_case_name: b.e20.BHIST.f09_g17.20thC.297_05
 
+    #Case nickname
+    #If left blank, it will default to cam_case_name
+    # ** NOTE: if nickname starts with a zero, the string must be in quotes! **
+    case_nickname: ${diag_cam_climo.cam_case_name}
+
     #Location of CAM history (h0) files:
     #Example test files
     cam_hist_loc: /glade/p/cesm/ADF/${diag_cam_climo.cam_case_name}
@@ -200,6 +205,10 @@ diag_cam_climo:
     #cam_case_name:
     #    - b.e20.BHIST.f09_g17.20thC.297_05
     #    - b1850.f19_g17.validation_mct.004
+
+    #case_nickname: 
+    #    - nickname 1
+    #    - "026c"
 
     #calc_cam_climo:
     #    - true
@@ -258,6 +267,11 @@ diag_cam_baseline_climo:
 
     #Name of CAM baseline case:
     cam_case_name: b.e20.BHIST.f09_g16.20thC.125.02
+
+    #Case nickname
+    #If left blank, it will default to baseline cam_case_name
+    # ** NOTE: if nickname starts with a zero, the string must be in quotes! **
+    case_nickname: ${diag_cam_baseline_climo.cam_case_name}
 
     #Location of CAM baseline history (h0) files:
     #Example test files
@@ -376,6 +390,15 @@ diag_var_list:
     - LANDFRAC
 
 #<Add more variables here.>
+
+# Make mulit-plot comparison image for specified plots types
+# This will only run if there are more than one specified test cases declared above
+# NOTE: These plot types also need to be present above in the plotting_scripts section (for now) and variables in the diag_var_list
+# NOTE: Only global LatLon multi-case plots are available at this time - more are coming. JR
+multi_case_plots:
+    global_latlon_map:
+        - SST
+        - PSL
 
 # Options for multi-case regional contour plots (./plotting/regional_map_multicase.py)
 # region_multicase:

--- a/lib/adf_diag.py
+++ b/lib/adf_diag.py
@@ -169,6 +169,9 @@ class AdfDiag(AdfWeb):
             self.expand_references(self.__cvdp_info)
         #End if
 
+        #Add multi plots info to object:
+        self.__multi_case_plots = self.read_config_var('multi_case_plots')
+
         #Add averaging script names:
         self.__time_averaging_scripts = self.read_config_var('time_averaging_scripts')
 
@@ -195,6 +198,16 @@ class AdfDiag(AdfWeb):
 
         return self.read_config_var(var_str,
                                     conf_dict=self.__cvdp_info,
+                                    required=required)
+
+    def get_multi_case_info(self, var_str, required=False):
+        """
+        Return the config variable from 'multi_case_plots' as requested by
+        the user.
+        """
+
+        return self.read_config_var(var_str,
+                                    conf_dict=self.__multi_case_plots,
                                     required=required)
 
     #########

--- a/lib/plotting_functions.py
+++ b/lib/plotting_functions.py
@@ -1635,5 +1635,133 @@ def square_contour_difference(fld1, fld2, **kwargs):
     cb2 = fig.colorbar(img3, cax=cbax_bot, orientation='horizontal')
     return fig
 
+#####
+
+###############################
+# Multi-Case Multi-Plot Section
+###############################
+
+def multi_latlon_plots(wks, ptype, case_names, nicknames, multi_dict, adfobj):
+    """ This is a multi-case comparison of test minus baseline for each test case:
+        wks: path for saved image.
+                Should be assets directory inside of the main_website directory
+
+        ptype: ADF shortname for plot type.
+                For this plot it will be either LatLon or LatLon_Vector
+
+        case_names: list of test case names only
+
+        nicknames: list of test case nicknames
+                First entry of list will be list of test case nicknames
+                Second entry will be string object of baseline nickname
+
+        multi_dict: ordered dictionary of difference data for each var, test case, and season
+                multi_dict[var][case_name][s]
+
+        adfobj: ADF object
+                Needed to test if redo_plot is called in config yaml file
+    """
+
+    ncols = 3
+    nplots = len(nicknames[0])
+
+    #Try and format spacing based on number of cases
+    # NOTE: ** this will have to change if figsize or dpi change **
+    if nplots < 4:
+        hspace = -1.0
+    else:
+        hspace = -0.85
+
+    nrows = int(np.ceil(nplots/ncols))
+    if nrows < 2:
+        nrows = 2
+
+    # specify the central longitude for the plot
+    central_longitude = 180
+    proj = ccrs.PlateCarree(central_longitude=central_longitude)
+    # formatting for tick labels
+    lon_formatter = LongitudeFormatter(number_format='0.0f',
+                                        degree_symbol='',
+                                        dateline_direction_label=False)
+    lat_formatter = LatitudeFormatter(number_format='0.0f',
+                                        degree_symbol='')
+
+    for var in multi_dict.keys():
+        for j in multi_dict[var].keys():
+            for season in multi_dict[var][j].keys():
+                from pathlib import Path
+                # Check redo_plot. If set to True: remove old plot, if it already exists:
+                redo_plot = adfobj.get_basic_info('redo_plot')
+                if (not redo_plot) and Path(wks / f"{var}_{season}_{ptype}_multi_plot.png").is_file():
+                    #Continue to next iteration:
+                    continue
+                elif (redo_plot) or (not Path(wks / f"{var}_{season}_{ptype}_multi_plot.png").is_file()):
+                    fig_width = 15
+                    fig_height = 15+(3*nrows) #try and dynamically create size of fig based off number of cases (therefore rows)
+                    fig, axs = plt.subplots(nrows=nrows,ncols=ncols,figsize=(fig_width,fig_height), facecolor='w', edgecolor='k',
+                                            sharex=True,
+                                            sharey=True,
+                                            subplot_kw={"projection": proj})
+
+                    #Set figure title
+                    plt.suptitle(f'All Case Comparison (Test - Baseline)  {var}: {season}\n', fontsize=16,y=0.325)
+                    axs[0,1].set_title("$\mathbf{Baseline}:$"+f'{nicknames[1]}\n', fontsize=12)
+                    
+                    count = 0
+                    img = []
+                    titles = []
+                    for r in range(0,nrows):
+                        for c in range(0,ncols):
+                            if count < nplots:
+                                mdlfld = multi_dict[var][case_names[count]][season]["diff_data"]
+                                lat = mdlfld['lat']
+                                mwrap, lon = add_cyclic_point(mdlfld, coord=mdlfld['lon'])
+
+                                # mesh for plots:
+                                lons, lats = np.meshgrid(lon, lat)
+
+                                levelsdiff = multi_dict[var][case_names[count]][season]["vres"]["diff_contour_range"]
+                                levelsdiff = np.arange(levelsdiff[0],levelsdiff[1]+levelsdiff[-1],levelsdiff[-1])
+                                    
+                                normfunc, mplv = use_this_norm()
+
+                                # color normalization for difference
+                                if ((np.min(levelsdiff) < 0) and (0 < np.max(levelsdiff))) and mplv > 2:
+                                    normdiff = normfunc(vmin=np.min(levelsdiff), vmax=np.max(levelsdiff), vcenter=0.0)
+                                else:
+                                    normdiff = mpl.colors.Normalize(vmin=np.min(levelsdiff), vmax=np.max(levelsdiff))
+
+                                cmap = multi_dict[var][case_names[count]][season]["vres"]['diff_colormap']
+
+                                img.append(axs[r,c].contourf(lons, lats, mwrap, levels=levelsdiff, 
+                                                cmap=cmap, norm=normdiff, 
+                                                transform=ccrs.PlateCarree()))
+
+                                #Set individual plot titles (case name/nickname)
+                                titles.append(axs[r,c].set_title("$\mathbf{Test}:$"+f" {nicknames[0][count]}",loc='left',fontsize=8))
+
+                                axs[r,c].spines['geo'].set_linewidth(1.5) #cartopy's recommended method
+                                axs[r,c].coastlines()
+                                axs[r,c].set_xticks(np.linspace(-180, 120, 6), crs=ccrs.PlateCarree())
+                                axs[r,c].set_yticks(np.linspace(-90, 90, 7), crs=ccrs.PlateCarree())
+                                axs[r,c].tick_params('both', length=5, width=1.5, which='major')
+                                axs[r,c].tick_params('both', length=5, width=1.5, which='minor')
+                                axs[r,c].xaxis.set_major_formatter(lon_formatter)
+                                axs[r,c].yaxis.set_major_formatter(lat_formatter)
+
+                            else:
+                                #Clear left over subplots if they don't fill the row x column matrix
+                                axs[r,c].set_visible(False)
+                            count = count + 1
+                    # __COLORBARS__
+                    fig.colorbar(img[-1],  ax=axs.ravel().tolist(), orientation='horizontal',aspect=20,shrink=.5,location="bottom",anchor=(0.5,-0.3),extend='both')
+                        
+                    plt.subplots_adjust(wspace=0.3, hspace=hspace)
+                    fig.savefig(wks / f"{var}_{season}_{ptype}_multi_plot.png", bbox_inches='tight', dpi=300)
+
+                    #Close plots:
+                    plt.close()
+
+
 #####################
 #END HELPER FUNCTIONS

--- a/lib/website_templates/template.html
+++ b/lib/website_templates/template.html
@@ -1,9 +1,7 @@
-
-
 <!DOCTYPE html>
 <html>
   <head>
-    <title>ADF {{var_title}}</title>
+    <title>ADF {{ var_title }}</title>
     <link rel="stylesheet" href="../templates/adf_diag.css">
   </head>
   <body>
@@ -13,7 +11,10 @@
           <div class="center">
             <nav role="navigation" class="primary-navigation">
             <ul>
-              <li><a href="../index.html">Case Home</a></li>
+              <li><a href="../">Case Home</a></li>
+              {% if multi==True %}
+              <li><a href="../../">Multi-Case Home</a></li>
+              {% endif %}
               <li><a href="#">Plots &dtrif;</a>
                 <ul class="dropdown">
                   {% for type, html_file in plot_types.items() %}
@@ -42,10 +43,10 @@
     <div class="center">
       <div class="float-container">
         <div class="float-child">
-          <div><h1>{{plottype_title}} - {{var_title}}</h1></div>
+          <div><h1>{{ plottype_title }} - {{ var_title }}</h1></div>
         </div><!--float-child-->
         <div class="float-child">
-          <div><button><a href="mean_diag_{{plottype_title}}.html">Back to {{plottype_title}}</a></button><button><a href="../index.html">Back to Plot Types</a></button></div>
+          <div><button><a href="mean_diag_{{ plottype_title }}.html">Back to {{ plottype_title }}</a></button><button><a href="../">Back to Plot Types</a></button></div>
         </div><!--float-child-->
       </div><!--float-container-->
     </div><!--center-->

--- a/lib/website_templates/template_index.html
+++ b/lib/website_templates/template_index.html
@@ -11,7 +11,10 @@
           <div class="center">
             <nav role="navigation" class="primary-navigation">
             <ul>
-              <li><a href="index.html">Case Home</a></li>
+              <li><a href=".">Case Home</a></li>
+              {% if multi==True %}
+              <li><a href="../">Multi-Case Home</a></li>
+              {% endif %}
               <li><a href="#">Links &dtrif;</a>
                 <ul class="dropdown">
                   <li><a href="https://www.cesm.ucar.edu">CESM</a></li>

--- a/lib/website_templates/template_mean_diag.html
+++ b/lib/website_templates/template_mean_diag.html
@@ -11,11 +11,14 @@
           <div class="center">
             <nav role="navigation" class="primary-navigation">
             <ul>
-              <li><a href="../index.html">Case Home</a></li>
+              <li><a href="../">Case Home</a></li>
+              {% if multi==True %}
+              <li><a href="../../">Multi-Case Home</a></li>
+              {% endif %}
               <li><a href="#">Plots &dtrif;</a>
                 <ul class="dropdown">
                   {% for type, html_file in plot_types.items() %}
-                    <li><a href=../{{html_file}}> &nbsp; {{ type }}</a></li>
+                    <li><a href=../{{ html_file }}> &nbsp; {{ type }}</a></li>
                   {% endfor %}
                 </ul>
               </li>
@@ -44,7 +47,7 @@
     <div class="grid-container" >
       {% for category, var_seas in mydata.items() %}
       <div class="grid-item">
-        <div class="dropdown-vars">
+        <div class="dropdown-vars" style="position: relative; display: inline-block;">
           <h3 class="block">{{ category }}</h3>
             <div class="grid-container" style="column-gap: 5px; row-gap: 5px; padding:2px">
               {% for var_name, ptype_seas in var_seas.items() %}
@@ -58,7 +61,6 @@
       </div><!--grid-item-->
       {% endfor %}
     </div><!--grid-container-ptype-->
-
 
   </body>
 </html>

--- a/lib/website_templates/template_multi_case.html
+++ b/lib/website_templates/template_multi_case.html
@@ -1,26 +1,24 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title>ADF Mean Tables</title>
+    <title>ADF {{ var_title }}</title>
     <link rel="stylesheet" href="../templates/adf_diag.css">
   </head>
-  <body >
+  <body>
     <div class="header">
-      <div id="screenFiller" style="background:url(../templates/NCAR.gif) top right no-repeat; border:5px solid #555;">
-        <div class="center"><h1> {{ title }}</h1></div>
+        <div id="screenFiller" style="background:url(../templates/NCAR.gif) top right no-repeat; border:5px solid #555;">
+            <div class="center"><h1> {{ title }}</h1></div>
           <div class="center">
             <nav role="navigation" class="primary-navigation">
             <ul>
-              {% if multi_head==True %}
-              <li><a href="../../">Multi-Case Home</a></li>
               <li><a href="../">Case Home</a></li>
-              {% else %}
-              <li><a href="../">Case Home</a></li>
+              {% if multi==True %}
+              <li><a href="../">Multi-Case Home</a></li>
               {% endif %}
               <li><a href="#">Plots &dtrif;</a>
                 <ul class="dropdown">
                   {% for type, html_file in plot_types.items() %}
-                    <li><a href=../{{ html_file }}> &nbsp; {{ type }}</a></li>
+                    <li><a href=../{{html_file}}> &nbsp; {{ type }}</a>
                   {% endfor %}
                 </ul>
               </li>
@@ -36,7 +34,6 @@
             </ul>
           </nav>
         </div><!--center-->
-        {% if multi==True %}
         <div><h3> Click on case name for that ADF vs baseline page</h3></div>
         {% for case_name, case_dtls in case_sites.items() %}
         <h2 style="display:inline; color:black;"> Test Case {{ loop.index }}: </h2><h2 style="display:inline;">
@@ -46,27 +43,42 @@
         <h2 style="display:inline; color:black;"> Baseline Case: </h2><h2 style="display:inline;">
           {{ base_name }}</h2>
           <h2 style="display:inline; color:black;"> - years: {{ baseline_yrs }}</h2>
-        {% else %}
-        <br>
-        <h2 style="display:inline; color:black;"> Test Case: </h2><h2 style="display:inline;">{{ case1 }}</h2><h2 style="display:inline; color:black;"> - years: {{ case_yrs }}</h2><br>
-        <h2 style="display:inline; color:black;"> Baseline Case: </h2><h2 style="display:inline;">{{ case2 }}</h2><h2 style="display:inline; color:black;"> - years: {{ baseline_yrs }}</h2>
-        {% endif %}
-      </div><!--screenFiller-->
     </div><!--header-->
 
     <div class="center">
-      <h1>AMWG Tables</h1>
-    </div>
+      <div class="float-container">
+        <div class="float-child">
+          <div><h1>{{ plottype_title }} - {{ var_title }}</h1></div>
+        </div><!--float-child-->
+        <div class="float-child">
+          <div><button><a href="multi_case_mean_diag_{{ plottype_title }}.html">Back to {{ plottype_title }}</a></button><button><a href="../">Back to Plot Types</a></button></div>
+        </div><!--float-child-->
+      </div><!--float-container-->
+    </div><!--center-->
 
-    <div style="width: 100%;">
-      <table class="big-table">
-        {% for case_name, html_file in amwg_tables.items() %}
-          <tr>
-            <td><a id="amwg_table" href="{{ html_file }}">{{ case_name }}</a></td>
-          </tr>
+    <div style="width: 100%;"> <!-- main div-->
+      <div class="grid-container-template" style="border: 3px solid black">
+        {% for category, var_seas in mydata.items() %}
+        {% for var_name, seas_files in var_seas.items() %}
+        {% if var_name == var_title %}
+        {% for season_name, file_name in seas_files.items() %}
+        <div class="grid-item">
+          <a href="../html_img/{{ file_name }}">{{ season_name }}</a>
+        </div><!--grid-item-->
         {% endfor %}
-      </table>
-    </div>
+        {% endif %}
+        {% endfor %}
+        {% endfor %}
+      </div><!--grid-container-->
+
+      <div id="footer">
+        <div class="center"><!--bottom div -->
+          <a href="{{ imgs[0] }}" target="_blank">
+            <img src="{{ imgs[0] }}" alt="{{ imgs[1] }}"></img>
+          </a>
+        </div> <!-- end bottom div -->
+      </div><!--footer-->
+    </div> <!-- end main div -->
 
   </body>
 </html>

--- a/lib/website_templates/template_multi_case_index.html
+++ b/lib/website_templates/template_multi_case_index.html
@@ -1,35 +1,52 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title>ADF diagnostics</title>
+    <title>ADF Diagnostics - Multi-Case</title>
     <link rel="stylesheet" href="./templates/adf_diag.css">
   </head>
   <body >
+    <div class="header">
+      <div id="screenFiller" style="background:url(../templates/NCAR.gif) top right no-repeat; border:5px solid #555;">
+        <div class="center"><h1> {{ title }}</h1></div><!--center-->
+          <div class="center">
+            <nav role="navigation" class="primary-navigation">
+            <ul>
+              <li><a href=".">Multi-Case Home</a></li>
+              <li><a href="#">Links &dtrif;</a>
+                <ul class="dropdown">
+                  <li><a href="https://www.cesm.ucar.edu">CESM</a></li>
+                  <li><a href="https://www.cesm.ucar.edu/working_groups/Atmosphere/?ref=nav">AMWG</a></li>
+                  <li><a href="https://www.cgd.ucar.edu/amp/">AMP</a></li>
+                </ul>
+              </li>
+              <li><a href="https://github.com/NCAR/ADF">About</a></li>
+              <li><a href="https://github.com/NCAR/ADF/discussions">Contact</a></li>
+            </ul>
+          </nav>
+        </div><!--center-->
+        <div><h3> Click on case name for that ADF vs baseline page</h3></div>
+        {% for case_name, case_dtls in case_sites.items() %}
+        <h2 style="display:inline; color:black;"> Test Case {{ loop.index }}: </h2><h2 style="display:inline;">
+          <a href="{{ case_dtls[0] }}">{{ case_name }}</a></h2>
+          <h2 style="display:inline; color:black;"> - years: {{ case_dtls[1] }} - {{ case_dtls[2] }}</h2><br>
+        {% endfor %}
+        <h2 style="display:inline; color:black;"> Baseline Case: </h2><h2 style="display:inline;">
+          {{ base_name }}</h2>
+          <h2 style="display:inline; color:black;"> - years: {{ baseline_yrs }}</h2>
+      </div><!--screenFiller-->
+    </div><!--header-->
 
-    <nav role="navigation" class="primary-navigation">
-      <ul>
-        <li><a href=".">Home</a></li>
-        <li><a href="#">Links &dtrif;</a>
-          <ul class="dropdown">
-            <li><a href="https://www.cesm.ucar.edu">CESM</a></li>
-            <li><a href="https://www.cesm.ucar.edu/working_groups/Atmosphere/?ref=nav">AMWG</a></li>
-            <li><a href="https://www.cgd.ucar.edu/amp/">AMP</a></li>
-          </ul>
-        </li>
-        <li><a href="https://github.com/NCAR/ADF">About</a></li>
-        <li><a href="https://github.com/NCAR/ADF/discussions">Contact</a></li>
-      </ul>
-    </nav>
+    <div class="center">
+      <h1>All Case Comparison Plot Types</h1>
+    </div>
 
-    <h1> {{title}} </h1>
-
-    <table class="big-table">
-      {% for case_name, case_path in case_sites.items() %}
-        <tr>
-          <td><a href="{{ case_path }}">{{ case_name }}</a></td>
-        </tr>
+    <div class="grid-container">
+      {% for type, html_file in multi_plots.items() %}
+      <div class="grid-item">
+        <a href={{ html_file }} style="font-size: 30px;"> &nbsp; {{ type }} </a>
+      </div><!--grid-item-->
       {% endfor %}
-    </table>
+    </div><!--grid-container-ptype-->
 
   </body>
 </html>

--- a/lib/website_templates/template_multi_case_mean_diag.html
+++ b/lib/website_templates/template_multi_case_mean_diag.html
@@ -1,26 +1,21 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title>ADF Mean Tables</title>
+    <title>ADF Mean Plots</title>
     <link rel="stylesheet" href="../templates/adf_diag.css">
   </head>
   <body >
     <div class="header">
-      <div id="screenFiller" style="background:url(../templates/NCAR.gif) top right no-repeat; border:5px solid #555;">
-        <div class="center"><h1> {{ title }}</h1></div>
+        <div id="screenFiller" style="background:url(../templates/NCAR.gif) top right no-repeat; border:5px solid #555;">
+            <div class="center"><h1> {{ title }}</h1></div>
           <div class="center">
             <nav role="navigation" class="primary-navigation">
             <ul>
-              {% if multi_head==True %}
-              <li><a href="../../">Multi-Case Home</a></li>
-              <li><a href="../">Case Home</a></li>
-              {% else %}
-              <li><a href="../">Case Home</a></li>
-              {% endif %}
+              <li><a href="../">Multi-Case Home</a></li>
               <li><a href="#">Plots &dtrif;</a>
                 <ul class="dropdown">
                   {% for type, html_file in plot_types.items() %}
-                    <li><a href=../{{ html_file }}> &nbsp; {{ type }}</a></li>
+                    <li><a href=../{{html_file}}> &nbsp; {{ type }}</a></li>
                   {% endfor %}
                 </ul>
               </li>
@@ -36,7 +31,6 @@
             </ul>
           </nav>
         </div><!--center-->
-        {% if multi==True %}
         <div><h3> Click on case name for that ADF vs baseline page</h3></div>
         {% for case_name, case_dtls in case_sites.items() %}
         <h2 style="display:inline; color:black;"> Test Case {{ loop.index }}: </h2><h2 style="display:inline;">
@@ -46,27 +40,30 @@
         <h2 style="display:inline; color:black;"> Baseline Case: </h2><h2 style="display:inline;">
           {{ base_name }}</h2>
           <h2 style="display:inline; color:black;"> - years: {{ baseline_yrs }}</h2>
-        {% else %}
-        <br>
-        <h2 style="display:inline; color:black;"> Test Case: </h2><h2 style="display:inline;">{{ case1 }}</h2><h2 style="display:inline; color:black;"> - years: {{ case_yrs }}</h2><br>
-        <h2 style="display:inline; color:black;"> Baseline Case: </h2><h2 style="display:inline;">{{ case2 }}</h2><h2 style="display:inline; color:black;"> - years: {{ baseline_yrs }}</h2>
-        {% endif %}
       </div><!--screenFiller-->
     </div><!--header-->
 
     <div class="center">
-      <h1>AMWG Tables</h1>
+      <h1>All Case Comparison - {{ curr_type }} Plots</h1>
     </div>
 
-    <div style="width: 100%;">
-      <table class="big-table">
-        {% for case_name, html_file in amwg_tables.items() %}
-          <tr>
-            <td><a id="amwg_table" href="{{ html_file }}">{{ case_name }}</a></td>
-          </tr>
-        {% endfor %}
-      </table>
-    </div>
+    <div class="grid-container">
+      {% for category, var_seas in mydata.items() %}
+      <div class="grid-item">
+        <div class="dropdown-vars" style="position: relative; display: inline-block;">
+          <h3 class="block">{{ category }}</h3>
+            <div class="grid-container" style="column-gap: 5px; row-gap: 5px; padding:2px">
+              {% for var_name, ptype_seas in var_seas.items() %}
+                <div class="grid-item-diag">
+                  <a href="../html_img/plot_page_multi_case_{{ var_name }}_{{ curr_type }}.html"> {{ var_name }} </a><br>
+                </div><!--grid-item2-->
+              {% endfor %}
+            </div><!--grid-container-->
+            <script type="text/html"> </div></script>
+        </div><!--dropdown-vars-->
+      </div><!--grid-item-->
+      {% endfor %}
+    </div><!--grid-container-ptype-->
 
   </body>
 </html>

--- a/lib/website_templates/template_multi_case_var.html
+++ b/lib/website_templates/template_multi_case_var.html
@@ -1,22 +1,17 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title>ADF Mean Tables</title>
+    <title>ADF {{ var_title }}</title>
     <link rel="stylesheet" href="../templates/adf_diag.css">
   </head>
-  <body >
+  <body>
     <div class="header">
-      <div id="screenFiller" style="background:url(../templates/NCAR.gif) top right no-repeat; border:5px solid #555;">
+        <div id="screenFiller" style="background:url(../templates/NCAR.gif) top right no-repeat; border:5px solid #555;">
         <div class="center"><h1> {{ title }}</h1></div>
           <div class="center">
             <nav role="navigation" class="primary-navigation">
             <ul>
-              {% if multi_head==True %}
-              <li><a href="../../">Multi-Case Home</a></li>
-              <li><a href="../">Case Home</a></li>
-              {% else %}
-              <li><a href="../">Case Home</a></li>
-              {% endif %}
+              <li><a href="../">Multi-Case Home</a></li>
               <li><a href="#">Plots &dtrif;</a>
                 <ul class="dropdown">
                   {% for type, html_file in plot_types.items() %}
@@ -24,7 +19,7 @@
                   {% endfor %}
                 </ul>
               </li>
-              <li><a href="#">Links &dtrif;</a>
+                  <li><a href="#">Links &dtrif;</a>
                 <ul class="dropdown">
                   <li><a href="https://www.cesm.ucar.edu">CESM</a></li>
                   <li><a href="https://www.cesm.ucar.edu/working_groups/Atmosphere/?ref=nav">AMWG</a></li>
@@ -36,37 +31,44 @@
             </ul>
           </nav>
         </div><!--center-->
-        {% if multi==True %}
         <div><h3> Click on case name for that ADF vs baseline page</h3></div>
         {% for case_name, case_dtls in case_sites.items() %}
-        <h2 style="display:inline; color:black;"> Test Case {{ loop.index }}: </h2><h2 style="display:inline;">
+        <h2 style="display:inline; color:black;"> Test Case {{loop.index}}: </h2><h2 style="display:inline;">
           <a href="../{{ case_dtls[0] }}">{{ case_name }}</a></h2>
           <h2 style="display:inline; color:black;"> - years: {{ case_dtls[1] }} - {{ case_dtls[2] }}</h2><br>
         {% endfor %}
         <h2 style="display:inline; color:black;"> Baseline Case: </h2><h2 style="display:inline;">
           {{ base_name }}</h2>
           <h2 style="display:inline; color:black;"> - years: {{ baseline_yrs }}</h2>
-        {% else %}
-        <br>
-        <h2 style="display:inline; color:black;"> Test Case: </h2><h2 style="display:inline;">{{ case1 }}</h2><h2 style="display:inline; color:black;"> - years: {{ case_yrs }}</h2><br>
-        <h2 style="display:inline; color:black;"> Baseline Case: </h2><h2 style="display:inline;">{{ case2 }}</h2><h2 style="display:inline; color:black;"> - years: {{ baseline_yrs }}</h2>
-        {% endif %}
       </div><!--screenFiller-->
     </div><!--header-->
 
     <div class="center">
-      <h1>AMWG Tables</h1>
-    </div>
+      <div class="float-container">
+        <div class="float-child">
+          <div><h1>Multi-Case Comparison: {{ plottype_title }} - {{ var_title }}</h1></div>
+        </div><!--float-child-->
+        <div class="float-child">
+          <div><button><a href="multi_case_mean_diag_{{ plottype_title }}.html">Back to {{ plottype_title }}</a></button><button><a href="../">Back to Plot Types</a></button></div>
+        </div><!--float-child-->
+      </div><!--float-container-->
+    </div><!--center-->
 
-    <div style="width: 100%;">
-      <table class="big-table">
-        {% for case_name, html_file in amwg_tables.items() %}
-          <tr>
-            <td><a id="amwg_table" href="{{ html_file }}">{{ case_name }}</a></td>
-          </tr>
+    <div style="width: 100%;"> <!-- main div-->
+      <div class="grid-container-template" style="border: 3px solid black">
+        {% for category, var_seas in mydata.items() %}
+        {% for var_name, seas_files in var_seas.items() %}
+        {% if var_name == var_title %}
+        {% for season_name, file_name in seas_files.items() %}
+        <div class="grid-item">
+          <a href="../html_img/{{ file_name }}">{{ season_name }}</a>
+        </div><!--grid-item-->
         {% endfor %}
-      </table>
-    </div>
+        {% endif %}
+        {% endfor %}
+        {% endfor %}
+      </div><!--grid-container-->
+    </div><!--main div-->
 
   </body>
 </html>

--- a/lib/website_templates/template_table.html
+++ b/lib/website_templates/template_table.html
@@ -7,15 +7,20 @@
   <body >
     <div class="header">
       <div id="screenFiller" style="background:url(../templates/NCAR.gif) top right no-repeat; border:5px solid #555;">
-        <div class="center"><h1> {{ title }}</h1></div>
+          <div class="center"><h1> {{ title }}</h1></div>
           <div class="center">
             <nav role="navigation" class="primary-navigation">
             <ul>
-              <li><a href="../index.html">Case Home</a></li>
+              {% if multi_head==True %}
+              <li><a href="../../">Multi-Case Home</a></li>
+              <li><a href="../">Case Home</a></li>
+              {% else %}
+              <li><a href="../">Case Home</a></li>
+              {% endif %}
               <li><a href="#">Plots &dtrif;</a>
                 <ul class="dropdown">
                   {% for type, html_file in plot_types.items() %}
-                    <li><a href=../{{html_file}}> &nbsp; {{ type }}</a></li>
+                    <li><a href=../{{ html_file }}> &nbsp; {{ type }}</a></li>
                   {% endfor %}
                 </ul>
               </li>
@@ -31,9 +36,21 @@
             </ul>
           </nav>
         </div><!--center-->
+        {% if multi==True %}
+        <div><h3> Click on case name for that ADF vs baseline page</h3></div>
+        {% for case_name, case_dtls in case_sites.items() %}
+        <h2 style="display:inline; color:black;"> Test Case {{ loop.index }}: </h2><h2 style="display:inline;">
+          <a href="../{{ case_dtls[0] }}">{{ case_name }}</a></h2>
+          <h2 style="display:inline; color:black;"> - years: {{ case_dtls[1] }} - {{ case_dtls[2] }}</h2><br>
+        {% endfor %}
+        <h2 style="display:inline; color:black;"> Baseline Case: </h2><h2 style="display:inline;">
+          {{ base_name }}</h2>
+          <h2 style="display:inline; color:black;"> - years: {{ baseline_yrs }}</h2>
+        {% else %}
         <br>
         <h2 style="display:inline; color:black;"> Test Case: </h2><h2 style="display:inline;">{{ case1 }}</h2><h2 style="display:inline; color:black;"> - years: {{ case_yrs }}</h2><br>
         <h2 style="display:inline; color:black;"> Baseline Case: </h2><h2 style="display:inline;">{{ case2 }}</h2><h2 style="display:inline; color:black;"> - years: {{ baseline_yrs }}</h2>
+        {% endif %}
       </div><!--screenFiller-->
     </div><!--header-->
 
@@ -42,13 +59,13 @@
     </div>
 
     <div style="width: 100%;">
-        <table class="big-table">
-          {% for case_name, html_file in amwg_tables.items() %}
-            <tr>
-              <td><a id="amwg_table" href="{{ html_file }}">{{ case_name }}</a></td>
-            </tr>
-          {% endfor %}
-        </table>
+      <table class="big-table">
+        {% for case_name, html_file in amwg_tables.items() %}
+          <tr>
+            <td><a id="amwg_table" href="{{ html_file }}">{{ case_name }}</a></td>
+          </tr>
+        {% endfor %}
+      </table>
 
         <!-- Main Table HTML -->
         <h3> {{ table_name }} </h3>

--- a/lib/website_templates/template_var.html
+++ b/lib/website_templates/template_var.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title>ADF {{var_title}}</title>
+    <title>ADF {{ var_title }}</title>
     <link rel="stylesheet" href="../templates/adf_diag.css">
   </head>
   <body>
@@ -11,11 +11,14 @@
           <div class="center">
             <nav role="navigation" class="primary-navigation">
             <ul>
-              <li><a href="../index.html">Case Home</a></li>
+              <li><a href="../">Case Home</a></li>
+              {% if multi==True %}
+              <li><a href="../../">Multi-Case Home</a></li>
+              {% endif %}
               <li><a href="#">Plots &dtrif;</a>
                 <ul class="dropdown">
                   {% for type, html_file in plot_types.items() %}
-                    <li><a href=../{{html_file}}> &nbsp; {{ type }}</a></li>
+                    <li><a href=../{{ html_file }}> &nbsp; {{ type }}</a></li>
                   {% endfor %}
                 </ul>
               </li>
@@ -43,7 +46,7 @@
           <div><h1>{{ plottype_title }} - {{ var_title }}</h1></div>
         </div><!--float-child-->
         <div class="float-child">
-          <div><button><a href="mean_diag_{{ plottype_title }}.html">Back to {{ plottype_title }}</a></button><button><a href="../index.html">Back to Plot Types</a></button></div>
+          <div><button><a href="mean_diag_{{ plottype_title }}.html">Back to {{ plottype_title }}</a></button><button><a href="../">Back to Plot Types</a></button></div>
         </div><!--float-child-->
       </div><!--float-container-->
     </div><!--center-->

--- a/scripts/analysis/amwg_table.py
+++ b/scripts/analysis/amwg_table.py
@@ -113,6 +113,15 @@ def amwg_table(adf):
 
     #CAM simulation variables (these quantities are always lists):
     case_names    = adf.get_cam_info("cam_case_name", required=True)
+
+    #Grab test case nickname(s)
+    test_nicknames = adf.get_cam_info('case_nickname')
+    print("test_nicknames",test_nicknames,"\n")
+    for idx,nick_name in enumerate(test_nicknames):
+        if nick_name == None:
+            test_nicknames[idx] = case_names[idx]
+    print("test_nicknames",test_nicknames,"\n")
+
     input_ts_locs = adf.get_cam_info("cam_ts_loc", required=True)
 
     #Check if a baseline simulation is also being used:
@@ -121,6 +130,12 @@ def amwg_table(adf):
         baseline_name     = adf.get_baseline_info("cam_case_name", required=True)
         input_ts_baseline = adf.get_baseline_info("cam_ts_loc", required=True)
 
+        #Grab baseline case nickname
+        base_nickname = adf.get_baseline_info('case_nickname')
+        if base_nickname == None:
+            base_nickname = baseline_name
+        test_nicknames += [base_nickname]
+        print("test_nicknames",test_nicknames,"\n")
         if "CMIP" in baseline_name:
             print("CMIP files detected, skipping AMWG table (for now)...")
 
@@ -137,6 +152,9 @@ def amwg_table(adf):
     #residual top of model (RESTOM) radiation calculation:
     restom_dict = {}
 
+    #Hold output paths for csv files
+    csv_locs = []
+
     #Loop over CAM cases:
     for case_idx, case_name in enumerate(case_names):
 
@@ -145,6 +163,9 @@ def amwg_table(adf):
 
         #Generate input file path:
         input_location = Path(input_ts_locs[case_idx])
+        
+        #Add output paths for csv files
+        csv_locs.append(output_locs[case_idx])
 
         #Check that time series input directory actually exists:
         if not input_location.is_dir():
@@ -287,6 +308,8 @@ def amwg_table(adf):
     #End of model case loop
     #----------------------
 
+    #Check if observations are being comapred to, if so skip table comparison...
+    test_case_names = adf.get_cam_info("cam_case_name", required=True)
 
     #Notify user that script has ended:
     print("  ...AMWG variable table has been generated successfully.")
@@ -296,10 +319,20 @@ def amwg_table(adf):
         if "CMIP" in baseline_name:
             print("CMIP case detected, skipping comparison table...")
         else:
-            #Create comparison table for both cases
-            print("\n  Making comparison table...")
-            _df_comp_table(adf, output_location, case_names)
-            print("  ... Comparison table has been generated successfully")
+
+            if len(test_case_names) == 1:
+                #Create comparison table for both cases
+                print("\n  Making comparison table...")
+                _df_comp_table(adf, output_location, Path(output_locs[0]), case_names)
+                print("  ... Comparison table has been generated successfully")
+
+            if len(test_case_names) > 1:
+                print("\n  Making comparison table for multiple cases...")
+                _df_multi_comp_table(adf, csv_locs, case_names, test_nicknames)
+                print("\n  Making comparison table for each case...")
+                for idx,case in enumerate(case_names[0:-1]):
+                    _df_comp_table(adf, Path(output_locs[idx]), Path(output_locs[0]), [case,baseline_name])
+                print("  ... Multi-case comparison table has been generated successfully")
         #End if
     else:
         print(" Comparison table currently doesn't work with obs, so skipping...")
@@ -366,16 +399,12 @@ def _get_row_vals(data):
 
 #####
 
-def _df_comp_table(adf, output_location, case_names):
-    import pandas as pd
-
+def _df_comp_table(adf, output_location, base_output_location ,case_names):
+    
     output_csv_file_comp = output_location / "amwg_table_comp.csv"
 
-    # * * * * * * * * * * * * * * * * * * * * * * * * * * * *
-    #This will be for single-case for now (case_names[0]),
-    #will need to change to loop as multi-case is introduced
     case = output_location/f"amwg_table_{case_names[0]}.csv"
-    baseline = output_location/f"amwg_table_{case_names[-1]}.csv"
+    baseline = base_output_location/f"amwg_table_{case_names[-1]}.csv"
 
     #Read in test case and baseline dataframes:
     df_case = pd.read_csv(case)
@@ -394,11 +423,61 @@ def _df_comp_table(adf, output_location, case_names):
     df_comp['diff'] = [f'{i:.3g}' if np.abs(i) < 1 else f'{i:.3f}' for i in diffs]
 
     #Write the comparison dataframe to a new CSV file:
-    cols_comp = ['variable', 'unit', 'test', 'control', 'diff']
+    cols_comp = ['variable', 'unit', 'test', 'baseline', 'diff']
     df_comp.to_csv(output_csv_file_comp, header=cols_comp, index=False)
 
     #Add comparison table dataframe to website (if enabled):
-    adf.add_website_data(df_comp, "Case Comparison", case_names[0], plot_type="Tables")
+    adf.add_website_data(df_comp, "case_comparison", case_names[0], plot_type="Tables")
+
+#####
+
+def _df_multi_comp_table(adf, csv_locs, case_names, test_nicknames):
+
+    main_site_path = Path(adf.get_basic_info('cam_diag_plot_loc', required=True))
+    output_csv_file_comp = main_site_path / "amwg_table_comp_all.csv"
+    df_comp = pd.DataFrame(dtype=object)
+
+    cols_comp = ['variable', 'unit']
+
+    baseline = str(csv_locs[-1])+f"/amwg_table_{case_names[-1]}.csv"
+    df_base = pd.read_csv(baseline)
+
+    for i,val in enumerate(csv_locs[:-1]): 
+        case = str(val)+f"/amwg_table_{case_names[i]}.csv"
+        df_case = pd.read_csv(case)
+        
+        if test_nicknames[i] == case_names[i]:
+            df_comp[['variable','unit',f"case {i+1}"]] = df_case[['variable','unit','mean']]
+            cols_comp.append(f"case {i+1}")
+        else:
+            df_comp[['variable','unit',f"{test_nicknames[i]}"]] = df_case[['variable','unit','mean']]
+            cols_comp.append(test_nicknames[i])
+    
+    if test_nicknames[-1] == case_names[-1]:
+        df_comp["baseline"] = df_base[['mean']]
+        cols_comp.append("baseline")
+    else:
+        df_comp[f"{test_nicknames[-1]} ( baseline )"] = df_base[['mean']]
+        cols_comp.append(f"{test_nicknames[-1]} ( baseline )")
+
+    for col in df_comp.columns:
+        if (col != 'variable') and (col != "unit"):
+            if "baseline" not in col:
+                for idx,row in enumerate(df_comp[col]):
+                    if np.abs(df_comp[col][idx]) < 1:
+                        formatter = ".3g"
+                    else:
+                        formatter = ".3f"
+
+                    df_comp.at[idx,col]= f'{df_comp[col][idx]:{formatter}}   ({(df_comp[col][idx]-df_base["mean"][idx]):{formatter}})'
+        
+    print(cols_comp)
+    df_comp.to_csv(output_csv_file_comp, header=cols_comp, index=False)
+
+    #Add comparison table dataframe to website (if enabled):
+    adf.add_website_data(df_comp, "all_case_comparison", case_names[0], plot_type="Tables")
+
+#####
 
 ##############
 #END OF SCRIPT


### PR DESCRIPTION
Add multi-case diagnostics and webpages:

- Add multi-case plot section and case nicknames to config yaml
- Update all website templates (add new for multi-case)
- Update web generation
- Add multi-case subplots and all case comp tables
- Designate hub for all test cases individual vs baseline ADF analysis
