### PR TITLE
update defaults to use ERA5 climos

### DIFF
--- a/lib/adf_variable_defaults.yaml
+++ b/lib/adf_variable_defaults.yaml
@@ -474,9 +474,6 @@ PS:
   mpl:
     colorbar:
       label : "hPa"
-  # obs_file: "ERAI_all_climo.nc"
-  # obs_name: "ERAI"
-  obs_var_name: "PS"
   category: "Surface variables"
   obs_file: "PS_ERA5_monthly_climo_197901-202112.nc"
   obs_name: "ERA5"
@@ -595,9 +592,6 @@ U:
   mpl:
     colorbar:
       label : "ms$^{-1}$"
-  # obs_file: "ERAI_all_climo.nc"
-  # obs_name: "ERAI"
-  # obs_var_name: "U"
   obs_file: "U_ERA5_monthly_climo_197901-202112.nc"
   obs_name: "ERA5"
   obs_var_name: "U"
@@ -616,9 +610,6 @@ V:
   mpl:
     colorbar:
       label : "ms$^{-1}$"
-  # obs_file: "ERAI_all_climo.nc"
-  # obs_name: "ERAI"
-  # obs_var_name: "V"
   obs_file: "V_ERA5_monthly_climo_197901-202112.nc"
   obs_name: "ERA5"
   obs_var_name: "V"

--- a/lib/adf_variable_defaults.yaml
+++ b/lib/adf_variable_defaults.yaml
@@ -203,6 +203,9 @@ ZMDT:
 
 CAPE:
   category: "Deep Convection"
+  obs_file: "CAPE_ERA5_monthly_climo_197901-202112.nc"
+  obs_name: "ERA5"
+  obs_var_name: "CAPE"
 
 CMFMC_DP:
   category: "Deep Convection"
@@ -259,9 +262,15 @@ N2O:
 
 CLDICE:
   category: "Clouds"
+  obs_file: "CLDICE_ERA5_monthly_climo_197901-202112.nc"
+  obs_name: "ERA5"
+  obs_var_name: "CLDICE"
 
 CLDLIQ:
   category: "Clouds"
+  obs_file: "CLDLIQ_ERA5_monthly_climo_197901-202112.nc"
+  obs_name: "ERA5"
+  obs_var_name: "CLDLIQ"
 
 CLDTOT:
   colormap: "Oranges"
@@ -343,6 +352,9 @@ TGCLDLWP:
     colorbar:
       label : "g m$^{-2}$"
   category: "Clouds"
+  obs_file: "TGCLDLWP_ERA5_monthly_climo_197901-202112.nc"
+  obs_name: "ERA5"
+  obs_var_name: "TGCLDLWP"
 
 TGCLDIWP:
   colormap: "Blues"
@@ -356,6 +368,9 @@ TGCLDIWP:
     colorbar:
       label : "g m$^{-2}$"
   category: "Clouds"
+  obs_file: "TGCLDIWP_ERA5_monthly_climo_197901-202112.nc"
+  obs_name: "ERA5"
+  obs_var_name: "TGCLDIWP"
 
 CCN3:
   category: "Clouds"
@@ -428,6 +443,9 @@ QFLX:
 
 PBLH:
   category: "Surface variables"
+  obs_file: "PBLH_ERA5_monthly_climo_197901-202112.nc"
+  obs_name: "ERA5"
+  obs_var_name: "PBLH"
 
 PSL:
   colormap: "Oranges"
@@ -441,6 +459,9 @@ PSL:
     colorbar:
       label : "hPa"
   category: "Surface variables"
+  obs_file: "PSL_ERA5_monthly_climo_197901-202112.nc"
+  obs_name: "ERA5"
+  obs_var_name: "PSL"
 
 PS:
   colormap: "Oranges"
@@ -453,13 +474,19 @@ PS:
   mpl:
     colorbar:
       label : "hPa"
-  obs_file: "ERAI_all_climo.nc"
-  obs_name: "ERAI"
+  # obs_file: "ERAI_all_climo.nc"
+  # obs_name: "ERAI"
   obs_var_name: "PS"
   category: "Surface variables"
+  obs_file: "PS_ERA5_monthly_climo_197901-202112.nc"
+  obs_name: "ERA5"
+  obs_var_name: "PS"
 
 TREFHT:
   category: "Surface variables"
+  obs_file: "TREFHT_ERA5_monthly_climo_197901-202112.nc"
+  obs_name: "ERA5"
+  obs_var_name: "TREFHT"
 
 TS:
   colormap: "Blues"
@@ -568,8 +595,11 @@ U:
   mpl:
     colorbar:
       label : "ms$^{-1}$"
-  obs_file: "ERAI_all_climo.nc"
-  obs_name: "ERAI"
+  # obs_file: "ERAI_all_climo.nc"
+  # obs_name: "ERAI"
+  # obs_var_name: "U"
+  obs_file: "U_ERA5_monthly_climo_197901-202112.nc"
+  obs_name: "ERA5"
   obs_var_name: "U"
   vector_pair: "V"
   vector_name: "Wind"
@@ -586,8 +616,11 @@ V:
   mpl:
     colorbar:
       label : "ms$^{-1}$"
-  obs_file: "ERAI_all_climo.nc"
-  obs_name: "ERAI"
+  # obs_file: "ERAI_all_climo.nc"
+  # obs_name: "ERAI"
+  # obs_var_name: "V"
+  obs_file: "V_ERA5_monthly_climo_197901-202112.nc"
+  obs_name: "ERA5"
   obs_var_name: "V"
   vector_pair: "U"
   vector_name: "Wind"
@@ -595,12 +628,21 @@ V:
 
 Q:
   category: "State"
+  obs_file: "Q_ERA5_monthly_climo_197901-202112.nc"
+  obs_name: "ERA5"
+  obs_var_name: "Q"
 
 T:
   category: "State"
+  obs_file: "T_ERA5_monthly_climo_197901-202112.nc"
+  obs_name: "ERA5"
+  obs_var_name: "T"
 
 OMEGA:
   category: "State"
+  obs_file: "OMEGA_ERA5_monthly_climo_197901-202112.nc"
+  obs_name: "ERA5"
+  obs_var_name: "OMEGA"
 
 OMEGA500:
   category: "State"

--- a/scripts/plotting/global_latlon_map.py
+++ b/scripts/plotting/global_latlon_map.py
@@ -203,6 +203,7 @@ def global_latlon_map(adfobj):
                 print(f"INFO: Data Location, dclimo_loc is {dclimo_loc}")
                 print(f"INFO: The glob is: {data_src}_{var}_*.nc")
                 continue
+            #End if
 
             #Loop over model cases:
             for case_idx, case_name in enumerate(case_names):
@@ -218,9 +219,17 @@ def global_latlon_map(adfobj):
                     print("    {} not found, making new directory".format(plot_loc))
                     plot_loc.mkdir(parents=True)
 
-                # load re-gridded model files:
+                #Load re-gridded model files:
                 mclim_fils = sorted(mclimo_rg_loc.glob(f"{data_src}_{case_name}_{var}_*.nc"))
                 mclim_ds = _load_dataset(mclim_fils)
+
+                #Skip this variable/case if the regridded climo file doesn't exist:
+                if mclim_ds is None:
+                    print("WARNING: Did not find any regridded climo files. Will try to skip.")
+                    print(f"INFO: Data Location, mclimo_rg_loc, is {mclimo_rg_loc}")
+                    print(f"INFO: The glob is: {data_src}_{case_name}_{var}_*.nc")
+                    continue
+                #End if
 
                 #Extract variable of interest
                 odata = oclim_ds[data_var].squeeze()  # squeeze in case of degenerate dimensions

--- a/scripts/plotting/global_latlon_vect_map.py
+++ b/scripts/plotting/global_latlon_vect_map.py
@@ -284,8 +284,13 @@ def global_latlon_vect_map(adfobj):
 
                 if len(umclim_fils) > 1:
                     umclim_ds = xr.open_mfdataset(umclim_fils, combine='by_coords')
-                else:
+                elif len(umclim_fils) == 1:
                     umclim_ds = xr.open_dataset(umclim_fils[0])
+                else:
+                    print("WARNING: Did not find any regridded climo files. Will try to skip.")
+                    print(f"INFO: Data Location, mclimo_rg_loc, is {mclimo_rg_loc}")
+                    print(f"INFO: The glob is: {data_src}_{case_name}_{var}_*.nc")
+                    continue
                 #End if
 
                 if len(vmclim_fils) > 1:

--- a/scripts/plotting/polar_map.py
+++ b/scripts/plotting/polar_map.py
@@ -196,8 +196,14 @@ def polar_map(adfobj):
 
                 if len(mclim_fils) > 1:
                     mclim_ds = xr.open_mfdataset(mclim_fils, combine='by_coords')
-                else:
+                elif len(mclim_fils) == 1:
                     mclim_ds = xr.open_dataset(mclim_fils[0])
+                else:
+                    print("WARNING: Did not find any regridded climo files. Will try to skip.")
+                    print(f"INFO: Data Location, mclimo_rg_loc, is {mclimo_rg_loc}")
+                    print(f"INFO: The glob is: {data_src}_{case_name}_{var}_*.nc")
+                    continue
+                #End if
 
                 #Extract variable of interest
                 odata = oclim_ds[data_var].squeeze()  # squeeze in case of degenerate dimensions

--- a/scripts/regridding/regrid_and_vert_interp.py
+++ b/scripts/regridding/regrid_and_vert_interp.py
@@ -207,15 +207,17 @@ def regrid_and_vert_interp(adf):
                         tclim_ds = xr.open_dataset(tclim_fils[0])
                     #End if
 
-                    #if regrid_ofrac and 'OCNFRAC' in tclim_ds:
-                    #    regrid_ofrac = False
-
                     #Generate CAM climatology (climo) file list:
                     mclim_fils = sorted(mclimo_loc.glob(f"{case_name}_{var}_*.nc"))
 
                     if len(mclim_fils) > 1:
                         #Combine all cam files together into a single data set:
                         mclim_ds = xr.open_mfdataset(mclim_fils, combine='by_coords')
+                    elif len(mclim_fils) == 0:
+                        wmsg = f"\t - Unable to find climo file for '{var}'."
+                        wmsg += " Continuing to next variable."
+                        print(wmsg)
+                        continue
                     else:
                         #Open single file as new xarray dataset:
                         mclim_ds = xr.open_dataset(mclim_fils[0])


### PR DESCRIPTION
Adds some ERA5 information in the variable defaults yaml file. 

The files that these point to are currently in this directory: `/glade/work/brianpm/obs_data_for_adf/` and will need to be migrated to wherever we're keeping ADF climo files. 

**NOTE:** These are on pressure levels where applicable, and are on the 0.25° grid. This causes a big performance hit because the default regridding puts the model data on the observation grid (I think).

All climos are monthly, based on 1979-2021. File names: 
-     CAPE_ERA5_monthly_climo_197901-202112.nc   
-     Q_ERA5_monthly_climo_197901-202112.nc
-     CLDICE_ERA5_monthly_climo_197901-202112.nc
-     T_ERA5_monthly_climo_197901-202112.nc
-     CLDLIQ_ERA5_monthly_climo_197901-202112.nc
-     TGCLDIWP_ERA5_monthly_climo_197901-202112.nc
-     OMEGA_ERA5_monthly_climo_197901-202112.nc
-     TGCLDLWP_ERA5_monthly_climo_197901-202112.nc
-     PBLH_ERA5_monthly_climo_197901-202112.nc
-     TREFHT_ERA5_monthly_climo_197901-202112.nc
-     PS_ERA5_monthly_climo_197901-202112.nc     
-     U_ERA5_monthly_climo_197901-202112.nc
-     PSL_ERA5_monthly_climo_197901-202112.nc   
-     V_ERA5_monthly_climo_197901-202112.nc

I have done some preliminary testing. It all seems to work. 