### PR TITLE
Provide consolidated averaging methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ If you are using conda on a non-CISL machine, then you can create and activate t
 
 ```
 conda env create -f env/conda_environment.yaml
-conda activate adf_v0.07
+conda activate adf_v0.11
 ```
 
 Also, along with these python requirements, the `ncrcat` NetCDF Operator (NCO) is also needed.  On the CISL machines this can be loaded by simply running:

--- a/config_amwg_default_plots.yaml
+++ b/config_amwg_default_plots.yaml
@@ -118,11 +118,6 @@ diag_basic_info:
     #longitude will default to 180 degrees E.
     central_longitude: 180
 
-    #Apply monthly weights to seasonal averages.
-    #If False or missing, then all months are
-    #given the same weight:
-    weight_season: True
-
     #Number of processors on which to run the ADF.
     #If this config variable isn't present then
     #the ADF defaults to one processor.  Also, if

--- a/config_cam_baseline_example.yaml
+++ b/config_cam_baseline_example.yaml
@@ -65,10 +65,10 @@ user: 'USER-NAME-NOT-SET'
 diag_basic_info:
 
     #History file string to match (eg. cam.h0 or ocn.pop.h.ecosys.nday1)
-    # Only affects timeseries as everything else uses timeseries 
+    # Only affects timeseries as everything else uses timeseries
     # Leave off trailing '.'
     #Default: cam.h0
-    hist_str: cam.h0           
+    hist_str: cam.h0
 
     #Is this a model vs observations comparison?
     #If "false" or missing, then a model-model comparison is assumed:
@@ -118,11 +118,6 @@ diag_basic_info:
     #If this config option is missing then the central
     #longitude will default to 180 degrees E.
     central_longitude: 180
-
-    #Apply monthly weights to seasonal averages.
-    #If False or missing, then all months are
-    #given the same weight:
-    weight_season: True
 
     #Number of processors on which to run the ADF.
     #If this config variable isn't present then

--- a/lib/plotting_functions.py
+++ b/lib/plotting_functions.py
@@ -305,7 +305,7 @@ def seasonal_mean(data, season=None, is_climo=None):
 
     try:
         month_length = data.time.dt.days_in_month
-    except AttributeError:
+    except (AttributeError, TypeError):
         # do our best to determine the temporal dimension and assign weights
         if not is_climo:
             raise ValueError("Non-climo file provided, but without a decoded time dimension.")
@@ -329,6 +329,7 @@ def seasonal_mean(data, season=None, is_climo=None):
             timefix = pd.date_range(start='1/1/1999', end='12/1/1999', freq='MS') # generic time coordinate from a non-leap-year
             data = data.assign_coords({"time":timefix})
         month_length = data.time.dt.days_in_month
+    #End try/except
 
     data = data.sel(time=data.time.dt.month.isin(seasons[season])) # directly take the months we want based on season kwarg
     return data.weighted(data.time.dt.daysinmonth).mean(dim='time')
@@ -341,7 +342,7 @@ def seasonal_mean(data, season=None, is_climo=None):
 
 def domain_stats(data, domain):
     x_region = data.sel(lat=slice(domain[2],domain[3]), lon=slice(domain[0],domain[1]))
-    x_region_mean = x_region.weighted(np.cos(x_region['lat'])).mean().item()
+    x_region_mean = x_region.weighted(np.cos(np.deg2rad(x_region['lat']))).mean().item()
     x_region_min = x_region.min().item()
     x_region_max = x_region.max().item()
     return x_region_mean, x_region_max, x_region_min

--- a/lib/plotting_functions.py
+++ b/lib/plotting_functions.py
@@ -213,7 +213,7 @@ def spatial_average(indata, weights=None, spatial_dims=None):
         if 'ncol' in indata.dims:
             spatial_dims = ['ncol']
         else:
-            spatial_dims = [dimname for dimname in indata.dims if (('lat' in dimname.lower()) or ('lon' in dimname.lower))]
+            spatial_dims = [dimname for dimname in indata.dims if (('lat' in dimname.lower()) or ('lon' in dimname.lower()))]
 
     if not spatial_dims:
         warnings.warn("No spatial dimensions were identified, so can not perform average.")

--- a/scripts/analysis/amwg_table.py
+++ b/scripts/analysis/amwg_table.py
@@ -268,7 +268,7 @@ def amwg_table(adf):
                 # flags that we have spatial dimensions
                 # Note: that could be 'lev' which should trigger different behavior
                 # Note: we should be able to handle (lat, lon) or (ncol,) cases, at least
-                data = _spatial_average(data)  # changes data "in place"
+                data = pf.spatial_average(data)  # changes data "in place"
 
             #Add necessary data for RESTOM calcs below
             if var == "FLNT":
@@ -370,11 +370,6 @@ def _load_data(dataloc, varname):
     import xarray as xr
     ds = xr.open_dataset(dataloc)
     return ds[varname]
-
-#####
-
-def _spatial_average(indata):
-    return pf.spatial_average(indata)
 
 #####
 

--- a/scripts/plotting/global_latlon_map.py
+++ b/scripts/plotting/global_latlon_map.py
@@ -268,59 +268,6 @@ def global_latlon_map(adfobj):
 
                         #Loop over season dictionary:
                         for s in seasons:
-
-                            if weight_season:
-                                #Add date-stamp to time dimension:
-                                #Note: For now using made-up dates, but in the future
-                                #it might be good to extract this info from the files
-                                #themselves.
-                                timefix = pd.date_range(start='1/1/1980', end='12/1/1980', freq='MS')
-                                mdata['time']=timefix
-                                odata['time']=timefix
-
-                                #Create array to avoid weighting missing values:
-                                md_ones = xr.where(mdata.isnull(), 0.0, 1.0)
-                                od_ones = xr.where(odata.isnull(), 0.0, 1.0)
-
-                                #Calculate monthly weights based on number of days:
-                                month_length = mdata.time.dt.days_in_month
-                                weights = (month_length.groupby("time.season") / month_length.groupby("time.season").sum())
-
-                                #Calculate monthly-weighted seasonal averages:
-                                if s == 'ANN':
-
-                                    #Calculate annual weights (i.e. don't group by season):
-                                    weights_ann = month_length / month_length.sum()
-
-                                    mseasons[s] = (mdata * weights_ann).sum(dim='time')
-                                    mseasons[s] = mseasons[s] / (md_ones*weights_ann).sum(dim='time')
-
-                                    oseasons[s] = (odata * weights_ann).sum(dim='time')
-                                    oseasons[s] = oseasons[s] / (od_ones*weights_ann).sum(dim='time')
-                                    # difference: each entry should be (lat, lon)
-                                    dseasons[s] = mseasons[s] - oseasons[s]
-                                else:
-                                    #this is inefficient because we do same calc over and over
-                                    mseasons[s] = (mdata * weights).groupby("time.season").sum(dim="time").sel(season=s)
-                                    wgt_denom = (md_ones*weights).groupby("time.season").sum(dim="time").sel(season=s)
-                                    mseasons[s] = mseasons[s] / wgt_denom
-
-                                    oseasons[s] = (odata * weights).groupby("time.season").sum(dim="time").sel(season=s)
-                                    wgt_denom = (od_ones*weights).groupby("time.season").sum(dim="time").sel(season=s)
-                                    oseasons[s] = oseasons[s] / wgt_denom
-
-                                    # difference: each entry should be (lat, lon)
-                                    dseasons[s] = mseasons[s] - oseasons[s]
-                                #End if
-
-                            else:
-                                #Just average months as-is:
-                                mseasons[s] = mdata.sel(time=seasons[s]).mean(dim='time')
-                                oseasons[s] = odata.sel(time=seasons[s]).mean(dim='time')
-                                # difference: each entry should be (lat, lon)
-                                dseasons[s] = mseasons[s] - oseasons[s]
-                            #End if
-
                             # time to make plot; here we'd probably loop over whatever plots we want for this variable
                             # I'll just call this one "LatLon_Mean"  ... would this work as a pattern [operation]_[AxesDescription] ?
                             plot_name = plot_loc / f"{var}_{s}_LatLon_Mean.{plot_type}"
@@ -335,6 +282,20 @@ def global_latlon_map(adfobj):
                                 continue
                             elif (redo_plot) and plot_name.is_file():
                                 plot_name.unlink()
+
+
+                            if weight_season:
+                                mseasons[s] = pf.seasonal_mean(mdata, season=s, is_climo=True)
+                                oseasons[s] = pf.seasonal_mean(mdata, season=s, is_climo=True)
+                            else:
+                                #Just average months as-is:
+                                mseasons[s] = mdata.sel(time=seasons[s]).mean(dim='time')
+                                oseasons[s] = odata.sel(time=seasons[s]).mean(dim='time')
+                            #End if
+
+                            # difference: each entry should be (lat, lon)
+                            dseasons[s] = mseasons[s] - oseasons[s]
+
 
                             #Create new plot:
                             # NOTE: send vres as kwarg dictionary.  --> ONLY vres, not the full res
@@ -400,34 +361,6 @@ def global_latlon_map(adfobj):
 
                             #Loop over seasons:
                             for s in seasons:
-
-                                #If requested, then calculate the monthly-weighted seasonal averages:
-                                if weight_season:
-                                    if s == 'ANN':
-                                        #Calculate annual weights (i.e. don't group by season):
-                                        weights_ann = month_length / month_length.sum()
-
-                                        mseasons[s] = (mdata * weights_ann).sum(dim='time').sel(lev=pres)
-                                        oseasons[s] = (odata * weights_ann).sum(dim='time').sel(lev=pres)
-                                        # difference: each entry should be (lat, lon)
-                                        dseasons[s] = mseasons[s] - oseasons[s]
-                                    else:
-                                        #this is inefficient because we do same calc over and over
-                                        mseasons[s] =(mdata * weights).groupby("time.season").sum(dim="time").sel(season=s,lev=pres)
-                                        oseasons[s] =(odata * weights).groupby("time.season").sum(dim="time").sel(season=s,lev=pres)
-                                        # difference: each entry should be (lat, lon)
-                                        dseasons[s] = mseasons[s] - oseasons[s]
-                                    #End if
-                                else:
-                                    #Just average months as-is:
-                                    mseasons[s] = mdata.sel(time=seasons[s], lev=pres).mean(dim='time')
-                                    oseasons[s] = odata.sel(time=seasons[s], lev=pres).mean(dim='time')
-                                    # difference: each entry should be (lat, lon)
-                                    dseasons[s] = mseasons[s] - oseasons[s]
-                                #End if
-
-                                # time to make plot; here we'd probably loop over whatever plots we want for this variable
-                                # I'll just call this one "LatLon_Mean"  ... would this work as a pattern [operation]_[AxesDescription] ?
                                 plot_name = plot_loc / f"{var}_{pres}hpa_{s}_LatLon_Mean.{plot_type}"
 
                                 # Check redo_plot. If set to True: remove old plot, if it already exists:
@@ -441,6 +374,21 @@ def global_latlon_map(adfobj):
                                     continue
                                 elif (redo_plot) and plot_name.is_file():
                                     plot_name.unlink()
+
+                                #If requested, then calculate the monthly-weighted seasonal averages:
+                                if weight_season:
+                                    mseasons[s] = pf.seasonal_mean(mdata, season=s, is_climo=True)
+                                    oseasons[s] = pf.seasonal_mean(mdata, season=s, is_climo=True)
+                                else:
+                                    #Just average months as-is:
+                                    mseasons[s] = mdata.sel(time=seasons[s], lev=pres).mean(dim='time')
+                                    oseasons[s] = odata.sel(time=seasons[s], lev=pres).mean(dim='time')
+                                    # difference: each entry should be (lat, lon)
+                                    dseasons[s] = mseasons[s] - oseasons[s]
+                                #End if
+
+                                # time to make plot; here we'd probably loop over whatever plots we want for this variable
+                                # I'll just call this one "LatLon_Mean"  ... would this work as a pattern [operation]_[AxesDescription] ?
 
                                 #Create new plot:
                                 # NOTE: send vres as kwarg dictionary.  --> ONLY vres, not the full res

--- a/scripts/plotting/global_latlon_map.py
+++ b/scripts/plotting/global_latlon_map.py
@@ -286,7 +286,7 @@ def global_latlon_map(adfobj):
 
                             if weight_season:
                                 mseasons[s] = pf.seasonal_mean(mdata, season=s, is_climo=True)
-                                oseasons[s] = pf.seasonal_mean(mdata, season=s, is_climo=True)
+                                oseasons[s] = pf.seasonal_mean(odata, season=s, is_climo=True)
                             else:
                                 #Just average months as-is:
                                 mseasons[s] = mdata.sel(time=seasons[s]).mean(dim='time')
@@ -377,15 +377,16 @@ def global_latlon_map(adfobj):
 
                                 #If requested, then calculate the monthly-weighted seasonal averages:
                                 if weight_season:
-                                    mseasons[s] = pf.seasonal_mean(mdata, season=s, is_climo=True)
-                                    oseasons[s] = pf.seasonal_mean(mdata, season=s, is_climo=True)
+                                    mseasons[s] = (pf.seasonal_mean(mdata, season=s, is_climo=True)).sel(lev=pres)
+                                    oseasons[s] = (pf.seasonal_mean(odata, season=s, is_climo=True)).sel(lev=pres)
                                 else:
                                     #Just average months as-is:
                                     mseasons[s] = mdata.sel(time=seasons[s], lev=pres).mean(dim='time')
                                     oseasons[s] = odata.sel(time=seasons[s], lev=pres).mean(dim='time')
-                                    # difference: each entry should be (lat, lon)
-                                    dseasons[s] = mseasons[s] - oseasons[s]
                                 #End if
+
+                                # difference: each entry should be (lat, lon)
+                                dseasons[s] = mseasons[s] - oseasons[s]
 
                                 # time to make plot; here we'd probably loop over whatever plots we want for this variable
                                 # I'll just call this one "LatLon_Mean"  ... would this work as a pattern [operation]_[AxesDescription] ?

--- a/scripts/plotting/global_latlon_map.py
+++ b/scripts/plotting/global_latlon_map.py
@@ -130,9 +130,8 @@ def global_latlon_map(adfobj):
     #pressure levels:
     pres_levs = adfobj.get_basic_info("plot_press_levels")
 
-    #Determine if user wants monthly weights to be applied
-    #to the seasonal averages:
-    weight_season = adfobj.get_basic_info("weight_season")
+    #For now, let's always do seasonal weighting:
+    weight_season = True
 
     #Set seasonal ranges:
     seasons = {"ANN": np.arange(1,13,1),

--- a/scripts/plotting/global_latlon_vect_map.py
+++ b/scripts/plotting/global_latlon_vect_map.py
@@ -375,10 +375,10 @@ def global_latlon_vect_map(adfobj):
 
                             #Loop over season dictionary:
                             for s in seasons:
-                                umseasons[s] = (pf.seasonal_mean(umdata, seasons=s, is_climo=True)).sel(lev=lv)
-                                vmseasons[s] = (pf.seasonal_mean(vmdata, seasons=s, is_climo=True)).sel(lev=lv)
-                                uoseasons[s] = (pf.seasonal_mean(uodata, seasons=s, is_climo=True)).sel(lev=lv)
-                                voseasons[s] = (pf.seasonal_mean(vodata, seasons=s, is_climo=True)).sel(lev=lv)
+                                umseasons[s] = (pf.seasonal_mean(umdata, season=s, is_climo=True)).sel(lev=lv)
+                                vmseasons[s] = (pf.seasonal_mean(vmdata, season=s, is_climo=True)).sel(lev=lv)
+                                uoseasons[s] = (pf.seasonal_mean(uodata, season=s, is_climo=True)).sel(lev=lv)
+                                voseasons[s] = (pf.seasonal_mean(vodata, season=s, is_climo=True)).sel(lev=lv)
                                 # difference: each entry should be (lat, lon)
                                 udseasons[s] = umseasons[s] - uoseasons[s]
                                 vdseasons[s] = vmseasons[s] - voseasons[s]
@@ -428,10 +428,10 @@ def global_latlon_vect_map(adfobj):
 
                         #Loop over season dictionary:
                         for s in seasons:
-                            umseasons[s] = pf.seasonal_mean(umdata, seasons=s, is_climo=True)
-                            vmseasons[s] = pf.seasonal_mean(vmdata, seasons=s, is_climo=True)
-                            uoseasons[s] = pf.seasonal_mean(uodata, seasons=s, is_climo=True)
-                            voseasons[s] = pf.seasonal_mean(vodata, seasons=s, is_climo=True)
+                            umseasons[s] = pf.seasonal_mean(umdata, season=s, is_climo=True)
+                            vmseasons[s] = pf.seasonal_mean(vmdata, season=s, is_climo=True)
+                            uoseasons[s] = pf.seasonal_mean(uodata, season=s, is_climo=True)
+                            voseasons[s] = pf.seasonal_mean(vodata, season=s, is_climo=True)
                             # difference: each entry should be (lat, lon)
                             udseasons[s] = umseasons[s] - uoseasons[s]
                             vdseasons[s] = vmseasons[s] - voseasons[s]

--- a/scripts/plotting/global_latlon_vect_map.py
+++ b/scripts/plotting/global_latlon_vect_map.py
@@ -370,10 +370,10 @@ def global_latlon_vect_map(adfobj):
 
                             #Loop over season dictionary:
                             for s in seasons:
-                                umseasons[s] = umdata.sel(time=seasons[s],lev=lv).mean(dim='time')
-                                vmseasons[s] = vmdata.sel(time=seasons[s],lev=lv).mean(dim='time')
-                                uoseasons[s] = uodata.sel(time=seasons[s],lev=lv).mean(dim='time')
-                                voseasons[s] = vodata.sel(time=seasons[s],lev=lv).mean(dim='time')
+                                umseasons[s] = (pf.seasonal_mean(umdata, seasons=s, is_climo=True)).sel(lev=lv)
+                                vmseasons[s] = (pf.seasonal_mean(vmdata, seasons=s, is_climo=True)).sel(lev=lv)
+                                uoseasons[s] = (pf.seasonal_mean(uodata, seasons=s, is_climo=True)).sel(lev=lv)
+                                voseasons[s] = (pf.seasonal_mean(vodata, seasons=s, is_climo=True)).sel(lev=lv)
                                 # difference: each entry should be (lat, lon)
                                 udseasons[s] = umseasons[s] - uoseasons[s]
                                 vdseasons[s] = vmseasons[s] - voseasons[s]
@@ -423,10 +423,10 @@ def global_latlon_vect_map(adfobj):
 
                         #Loop over season dictionary:
                         for s in seasons:
-                            umseasons[s] = umdata.sel(time=seasons[s]).mean(dim='time')
-                            vmseasons[s] = vmdata.sel(time=seasons[s]).mean(dim='time')
-                            uoseasons[s] = uodata.sel(time=seasons[s]).mean(dim='time')
-                            voseasons[s] = vodata.sel(time=seasons[s]).mean(dim='time')
+                            umseasons[s] = pf.seasonal_mean(umdata, seasons=s, is_climo=True)
+                            vmseasons[s] = pf.seasonal_mean(vmdata, seasons=s, is_climo=True)
+                            uoseasons[s] = pf.seasonal_mean(uodata, seasons=s, is_climo=True)
+                            voseasons[s] = pf.seasonal_mean(vodata, seasons=s, is_climo=True)
                             # difference: each entry should be (lat, lon)
                             udseasons[s] = umseasons[s] - uoseasons[s]
                             vdseasons[s] = vmseasons[s] - voseasons[s]

--- a/scripts/plotting/meridional_mean.py
+++ b/scripts/plotting/meridional_mean.py
@@ -220,19 +220,6 @@ def meridional_mean(adfobj):
 
                 #Loop over season dictionary:
                 for s in seasons:
-                    mseasons[s] = mdata.sel(time=seasons[s]).mean(dim='time')
-                    oseasons[s] = odata.sel(time=seasons[s]).mean(dim='time')
-
-                    # difference: each entry should be (lat, lon) or (plev, lat, lon)
-                    # dseasons[s] = mseasons[s] - oseasons[s]
-                    # difference will be calculated in plot_meridional_mean_and_save.
-
-                    # time to make plot; here we'd probably loop over whatever plots we want for this variable
-                    # I'll just call this one "Meridional_Mean"  ... would this work as a pattern [operation]_[AxesDescription] ?
-                    # NOTE: Up to this point, nothing really differs from global_latlon_map,
-                    #       so we could have made one script instead of two.
-                    #       Merging would make overall timing better because looping twice will double I/O steps.
-                    #
                     plot_name = plot_loc / f"{var}_{s}_Meridional_Mean.{plot_type}"
 
                     # Check redo_plot. If set to True: remove old plot, if it already exists:
@@ -240,11 +227,14 @@ def meridional_mean(adfobj):
                         #Add already-existing plot to website (if enabled):
                         adfobj.add_website_data(plot_name, var, case_name, season=s,
                                                 plot_type="Meridional")
-
                         #Continue to next iteration:
                         continue
                     elif (redo_plot) and plot_name.is_file():
                         plot_name.unlink()
+
+                    mseasons[s] = pf.seasonal_mean(mdata, season=s, is_climo=True)
+                    oseasons[s] = pf.seasonal_mean(mdata, season=s, is_climo=True)
+
 
                     #Create new plot:
                     pf.plot_meridional_mean_and_save(plot_name, case_nickname, base_nickname,

--- a/scripts/plotting/meridional_mean.py
+++ b/scripts/plotting/meridional_mean.py
@@ -233,7 +233,7 @@ def meridional_mean(adfobj):
                         plot_name.unlink()
 
                     mseasons[s] = pf.seasonal_mean(mdata, season=s, is_climo=True)
-                    oseasons[s] = pf.seasonal_mean(mdata, season=s, is_climo=True)
+                    oseasons[s] = pf.seasonal_mean(odata, season=s, is_climo=True)
 
 
                     #Create new plot:

--- a/scripts/plotting/polar_map.py
+++ b/scripts/plotting/polar_map.py
@@ -251,8 +251,8 @@ def polar_map(adfobj):
 
                         #Loop over season dictionary:
                         for s in seasons:
-                            mseasons[s] = pf.seasonal_mean(mdata, season=s, is_climo=True) 
-                            oseasons[s] = pf.seasonal_mean(odata, season=s, is_climo=True) 
+                            mseasons[s] = pf.seasonal_mean(mdata, season=s, is_climo=True)
+                            oseasons[s] = pf.seasonal_mean(odata, season=s, is_climo=True)
                             # difference: each entry should be (lat, lon)
                             dseasons[s] = mseasons[s] - oseasons[s]
 
@@ -329,8 +329,8 @@ def polar_map(adfobj):
 
                             #Loop over season dictionary:
                             for s in seasons:
-                                mseasons[s] = (pf.seasonal_mean(mdata, seasons=s, is_climo=True)).sel(lev=pres)
-                                oseasons[s] = (pf.seasonal_mean(odata, seasons=s, is_climo=True)).sel(lev=pres)
+                                mseasons[s] = (pf.seasonal_mean(mdata, season=s, is_climo=True)).sel(lev=pres)
+                                oseasons[s] = (pf.seasonal_mean(odata, season=s, is_climo=True)).sel(lev=pres)
                                 # difference: each entry should be (lat, lon)
                                 dseasons[s] = mseasons[s] - oseasons[s]
 

--- a/scripts/plotting/polar_map.py
+++ b/scripts/plotting/polar_map.py
@@ -245,8 +245,8 @@ def polar_map(adfobj):
 
                         #Loop over season dictionary:
                         for s in seasons:
-                            mseasons[s] = mdata.sel(time=seasons[s]).mean(dim='time')
-                            oseasons[s] = odata.sel(time=seasons[s]).mean(dim='time')
+                            mseasons[s] = pf.seasonal_mean(mdata, season=s, is_climo=True) 
+                            oseasons[s] = pf.seasonal_mean(odata, season=s, is_climo=True) 
                             # difference: each entry should be (lat, lon)
                             dseasons[s] = mseasons[s] - oseasons[s]
 
@@ -323,8 +323,8 @@ def polar_map(adfobj):
 
                             #Loop over season dictionary:
                             for s in seasons:
-                                mseasons[s] = mdata.sel(time=seasons[s], lev=pres).mean(dim='time')
-                                oseasons[s] = odata.sel(time=seasons[s], lev=pres).mean(dim='time')
+                                mseasons[s] = (pf.seasonal_mean(mdata, seasons=s, is_climo=True)).sel(lev=pres)
+                                oseasons[s] = (pf.seasonal_mean(odata, seasons=s, is_climo=True)).sel(lev=pres)
                                 # difference: each entry should be (lat, lon)
                                 dseasons[s] = mseasons[s] - oseasons[s]
 

--- a/scripts/plotting/zonal_mean.py
+++ b/scripts/plotting/zonal_mean.py
@@ -253,8 +253,8 @@ def zonal_mean(adfobj):
                     #End if
 
                     #Seasonal Averages
-                    mseasons[s] = pf.seasonal_mean(mdata, season=s, is_climo=True) #mdata.sel(time=seasons[s]).mean(dim='time')
-                    oseasons[s] = pf.seasonal_mean(odata, season=s, is_climo=True) #odata.sel(time=seasons[s]).mean(dim='time')
+                    mseasons[s] = pf.seasonal_mean(mdata, season=s, is_climo=True)
+                    oseasons[s] = pf.seasonal_mean(odata, season=s, is_climo=True)
 
                     # difference: each entry should be (lat, lon) or (plev, lat, lon)
                     # dseasons[s] = mseasons[s] - oseasons[s]

--- a/scripts/plotting/zonal_mean.py
+++ b/scripts/plotting/zonal_mean.py
@@ -254,7 +254,7 @@ def zonal_mean(adfobj):
 
                     #Seasonal Averages
                     mseasons[s] = pf.seasonal_mean(mdata, season=s, is_climo=True) #mdata.sel(time=seasons[s]).mean(dim='time')
-                    oseasons[s] = pf.seasonal_mean(mdata, season=s, is_climo=True) #odata.sel(time=seasons[s]).mean(dim='time')
+                    oseasons[s] = pf.seasonal_mean(odata, season=s, is_climo=True) #odata.sel(time=seasons[s]).mean(dim='time')
 
                     # difference: each entry should be (lat, lon) or (plev, lat, lon)
                     # dseasons[s] = mseasons[s] - oseasons[s]

--- a/scripts/plotting/zonal_mean.py
+++ b/scripts/plotting/zonal_mean.py
@@ -230,8 +230,6 @@ def zonal_mean(adfobj):
 
                 #
                 # Seasonal Averages
-                # Note: xarray can do seasonal averaging, but depends on having time accessor,
-                # which these prototype climo files don't.
                 #
 
                 #Create new dictionaries:
@@ -240,21 +238,6 @@ def zonal_mean(adfobj):
 
                 #Loop over season dictionary:
                 for s in seasons:
-                    mseasons[s] = mdata.sel(time=seasons[s]).mean(dim='time')
-                    oseasons[s] = odata.sel(time=seasons[s]).mean(dim='time')
-
-                    # difference: each entry should be (lat, lon) or (plev, lat, lon)
-                    # dseasons[s] = mseasons[s] - oseasons[s]
-                    # difference will be calculated in plot_zonal_mean_and_save;
-                    # because we can let any pressure-level interpolation happen there
-                    # This could be re-visited for efficiency or improved code structure.
-
-                    # time to make plot; here we'd probably loop over whatever plots we want for this variable
-                    # I'll just call this one "Zonal_Mean"  ... would this work as a pattern [operation]_[AxesDescription] ?
-                    # NOTE: Up to this point, nothing really differs from global_latlon_map,
-                    #       so we could have made one script instead of two.
-                    #       Merging would make overall timing better because looping twice will double I/O steps.
-                    #
                     plot_name = plot_loc / f"{var}_{s}_Zonal_Mean.{plot_type}"
 
                     # Check redo_plot. If set to True: remove old plot, if it already exists:
@@ -268,6 +251,16 @@ def zonal_mean(adfobj):
                     elif (redo_plot) and plot_name.is_file():
                         plot_name.unlink()
                     #End if
+
+                    #Seasonal Averages
+                    mseasons[s] = pf.seasonal_mean(mdata, season=s, is_climo=True) #mdata.sel(time=seasons[s]).mean(dim='time')
+                    oseasons[s] = pf.seasonal_mean(mdata, season=s, is_climo=True) #odata.sel(time=seasons[s]).mean(dim='time')
+
+                    # difference: each entry should be (lat, lon) or (plev, lat, lon)
+                    # dseasons[s] = mseasons[s] - oseasons[s]
+                    # difference will be calculated in plot_zonal_mean_and_save;
+                    # because we can let any pressure-level interpolation happen there
+                    # This could be re-visited for efficiency or improved code structure.
 
                     #Create new plot:
                     pf.plot_zonal_mean_and_save(plot_name, case_nickname, base_nickname,


### PR DESCRIPTION
I added these functions to `plotting_functions.py`:
- spatial_average : transplanted this from somewhere `amwg_table.py` to start consolidating all the averaging into one place
- annual_mean : provides a reliable way to produce time-weighted annual means
- seasonal_mean : provides a method to make seasonal means that are time-weighted

I then modified:
- `global_latlon_map.py`
- `zonal_mean.py`
- `meridional_mean.py`

To all use the same averaging (i.e., `seasonal_mean()`). 

I did **limited** testing to see if this works. My hope is that this helps to reduce any inconsistencies in the final output. For example, this should provide time-weighted means in both the table and the maps.

I moved the checks for the output files to *before* the averaging. That should allow a speed up when re-running the ADF because the calculations can be skipped once existing plots are detected. 


### an aside
I'm not sure whether we want to reconsider the option `weight_season`? I think whenever we have monthly data, we should use a weighted average (even for weird calendars that don't have different lengths of months, I guess). The weighting could be dropped for high-frequency output, but maybe that shouldn't a user-facing option?