### PR TITLE
Calipso diags

### DIFF
--- a/lib/adf_variable_defaults.yaml
+++ b/lib/adf_variable_defaults.yaml
@@ -2322,6 +2322,71 @@ TOT_ICLD_VISTAU:
   pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
   pct_diff_colormap: "PuOr_r"
 
+CLDTOT_CAL:
+  colormap: "cividis"
+  contour_levels_range: [0, 105, 5]
+  diff_colormap: "RdBu_r"
+  diff_contour_range: [-40, 40, 5]
+  scale_factor: 1.
+  add_offset: 0
+  new_unit: "Percent"
+  obs_file: "CALIPSO_GOCCP_3.1.2_climo_200606-202012.nc"
+  obs_name: "CALIPSO"
+  obs_var_name: "CLDTOT_CAL"
+  category: "COSP"
+
+CLDHGH_CAL:
+  colormap: "cividis"
+  contour_levels_range: [0, 105, 5]
+  diff_colormap: "RdBu_r"
+  diff_contour_range: [-40, 40, 5]
+  scale_factor: 1.
+  add_offset: 0
+  new_unit: "Percent"
+  obs_file: "CALIPSO_GOCCP_3.1.2_climo_200606-202012.nc"
+  obs_name: "CALIPSO"
+  obs_var_name: "CLDHGH_CAL"
+  category: "COSP"
+
+CLDMED_CAL:
+  colormap: "cividis"
+  contour_levels_range: [0, 105, 5]
+  diff_colormap: "RdBu_r"
+  diff_contour_range: [-40, 40, 5]
+  scale_factor: 1.
+  add_offset: 0
+  new_unit: "Percent"
+  obs_file: "CALIPSO_GOCCP_3.1.2_climo_200606-202012.nc"
+  obs_name: "CALIPSO"
+  obs_var_name: "CLDMED_CAL"
+  category: "COSP"
+
+CLDLOW_CAL:
+  colormap: "cividis"
+  contour_levels_range: [0, 105, 5]
+  diff_colormap: "RdBu_r"
+  diff_contour_range: [-40, 40, 5]
+  scale_factor: 1.
+  add_offset: 0
+  new_unit: "Percent"
+  obs_file: "CALIPSO_GOCCP_3.1.2_climo_200606-202012.nc"
+  obs_name: "CALIPSO"
+  obs_var_name: "CLDLOW_CAL"
+  category: "COSP"
+
+CLD_CAL:
+  colormap: "cividis"
+  contour_levels_range: [0, 105, 5]
+  diff_colormap: "RdBu_r"
+  diff_contour_range: [-40, 40, 5]
+  scale_factor: 1.
+  add_offset: 0
+  new_unit: "Percent"
+  obs_file: "CALIPSO_GOCCP_3.1.2_climo_200606-202012.nc"
+  obs_name: "CALIPSO"
+  obs_var_name: "CLD_CAL"
+  category: "COSP"
+
 
 #+++++++++++++++++
 # Category: Other


### PR DESCRIPTION
Trying to incorporate CALIPSO observations into ADF.

The CALIPSO climo file is currently here:
`/glade/work/brianpm/obs_data_for_adf/CALIPSO_GOCCP_3.1.2_climo_200606-202012.nc`

This PR modifies the `adf_variable_defaults.yaml` file to include the CALIPSO variables.

In doing this, I realized that `CLD_CAL` has a different vertical coordinate (`cosp_ht` in CAM). This causes trouble when we hard-code to `lev`. I have started to make modifications to check for any vertical coordinate by having a list of known vertical coordinates in `plotting_functions.py`. 

I think I've got the code working for zonal and meridional plots.

**BUT** something strange is going on in my testing. ADF seems to be using the same data for both the model and the observations. Also, the zonal and meridional plots of `CLD_CAL` are upside down because it's height and not pressure. I will look into these, but if anyone has time to take a look at what I'm doing here, I'd very much appreciate input. (I also need to fix my change to the amwg_table.py to be consistent with the other changes.)