### PR TITLE
TEM diagnostics

### DIFF
--- a/config_amwg_default_plots.yaml
+++ b/config_amwg_default_plots.yaml
@@ -369,11 +369,11 @@ diag_var_list:
     #If missing or blank, ADF will default to h4
 #    hist_num: h4
     
-    #Overwrite TEMs files, if found?
+    #Overwrite TEM files, if found?
     #If set to false, then TEM creation will be skipped if files are found:
 #    overwrite_tem_case: false
 
-    #For multi-case?
+    #For multi-case:
     #overwrite_tem_case
     #    - false
     #    - true

--- a/config_amwg_default_plots.yaml
+++ b/config_amwg_default_plots.yaml
@@ -269,6 +269,7 @@ diag_cvdp_info:
 #These scripts must be located in "scripts/averaging":
 time_averaging_scripts:
     - create_climo_files
+    #- create_TEM_files #To generate TEM files, please un-comment
 
 #Name of regridding scripts being used.
 #These scripts must be located in "scripts/regridding":
@@ -288,6 +289,9 @@ plotting_scripts:
     - zonal_mean
     - polar_map
     - cam_taylor_diagram
+    #- tem #To plot TEM, please un-comment
+    #- regional_map_multicase #To use this please un-comment and fill-out
+                              #the "region_multicase" section below
 
 #List of CAM variables that will be processesd:
 #If CVDP is to be run PSL, TREFHT, TS and PRECT (or PRECC and PRECL) should be listed
@@ -334,5 +338,27 @@ diag_var_list:
    - LANDFRAC
 
 #<Add more variables here.>
+
+# Options for multi-case regional contour plots (./plotting/regional_map_multicase.py)
+# region_multicase:
+#     region_spec: [slat, nlat, wlon, elon]
+#     region_time_option: <calendar | zeroanchor>  # If calendar, will look for specified years. If zeroanchor will use a nyears starting from year_offset from the beginning of timeseries
+#     region_start_year:
+#     region_end_year:
+#     region_nyear:
+#     region_year_offset:
+#     region_month: <NULL means look for season>
+#     region_season: <NULL means use annual mean>
+#     region_variables: <list of variables to try to use; allows for a subset of the total diag variables>
+
+# Options for TEM diagnostics (./averaging/create_TEM_files.py and ./plotting/temp.py)
+#tem_info:
+    #Location where TEM files are stored:
+    #If path not specified or commented out, skip TEM calculation
+    #If no path, diagnostics wont run even if declared in averaging/plotting scripts below
+    #tem_loc: /glade/scratch/richling/adf-output/tem/fixes/cam_vs_cam/TEM/
+
+    #TEM history file number
+    #hist_num: h4
 
 #END OF FILE

--- a/config_amwg_default_plots.yaml
+++ b/config_amwg_default_plots.yaml
@@ -362,8 +362,7 @@ diag_var_list:
 # Options for TEM diagnostics (./averaging/create_TEM_files.py and ./plotting/temp.py)
 #tem_info:
     #Location where TEM files are stored:
-    #If path not specified or commented out, TEM calculation will be skipped
-    #If no path, TEM diagnostics wont run even if declared in averaging/plotting scripts
+    #If path not specified or commented out, TEM calculation/plots will be skipped
 #    tem_loc: /glade/scratch/richling/adf-output/ADF-data/TEM/
 
     #TEM history file number

--- a/config_amwg_default_plots.yaml
+++ b/config_amwg_default_plots.yaml
@@ -63,6 +63,12 @@ user: 'USER-NAME-NOT-SET'
 #This first set of variables specify basic info used by all diagnostic runs:
 diag_basic_info:
 
+    #History file string to match (eg. cam.h0 or ocn.pop.h.ecosys.nday1)
+    # Only affects timeseries as everything else uses timeseries
+    # Leave off trailing '.'
+    #Default: cam.h0
+    hist_str: cam.h0
+
     #Is this a model vs observations comparison?
     #If "false" or missing, then a model-model comparison is assumed:
     compare_obs: false
@@ -90,20 +96,10 @@ diag_basic_info:
     #Location where diagnostic plots are stored:
     cam_diag_plot_loc: /glade/scratch/${user}/ADF/plots
 
-    #CAM history file number to use (h0,h1,h2, etc)
-    #Currently only affects timeseries generation,
-    #as everything else uses the timeseries files themselves.
-    #If this variable is not present then it will default ot "h0".
-    hist_num: h0
-
-    #Use default variable plot settings?
-    #If "true", then variable-specific plotting attributes as defined in
-    #ADF/lib/adf_variable_defaults.yaml will be used:
-    use_defaults: true
-
-    #Location of ADF variable plotting defaults YAML file
-    #if not using the one in ADF/lib:
-    #defaults_file: /some/path/to/defaults/file
+    #Location of ADF variable plotting defaults YAML file:
+    #If left blank or missing, ADF/lib/adf_variable_defaults.yaml will be used
+    #Uncomment and change path for custom variable defaults file 
+    #defaults_file: /some/path/to/defaults/file.yaml
 
     #Vertical pressure levels (in hPa) on which to plot 3-D variables
     #when using horizontal (e.g. lat/lon) map projections.
@@ -111,7 +107,7 @@ diag_basic_info:
     #horizontal maps.  Please note too that pressure levels must currently match
     #what is available in the observations file in order to be plotted in a
     #model vs obs run:
-    plot_press_levels: [ ]
+    plot_press_levels: [200,850]
 
     #Longitude line on which to center all lat/lon maps.
     #If this config option is missing then the central
@@ -354,11 +350,23 @@ diag_var_list:
 # Options for TEM diagnostics (./averaging/create_TEM_files.py and ./plotting/temp.py)
 #tem_info:
     #Location where TEM files are stored:
-    #If path not specified or commented out, skip TEM calculation
-    #If no path, diagnostics wont run even if declared in averaging/plotting scripts below
-    #tem_loc: /glade/scratch/richling/adf-output/tem/fixes/cam_vs_cam/TEM/
+    #If path not specified or commented out, TEM calculation will be skipped
+    #If no path, TEM diagnostics wont run even if declared in averaging/plotting scripts
+#    tem_loc: /glade/scratch/richling/adf-output/ADF-data/TEM/
 
     #TEM history file number
-    #hist_num: h4
+    #If missing or blank, ADF will default to h4
+#    hist_num: h4
+    
+    #Overwrite TEMs files, if found?
+    #If set to false, then TEM creation will be skipped if files are found:
+#    overwrite_tem_case: false
+
+    #For multi-case?
+    #overwrite_tem_case
+    #    - false
+    #    - true
+
+#    overwrite_tem_base: false
 
 #END OF FILE

--- a/config_amwg_default_plots.yaml
+++ b/config_amwg_default_plots.yaml
@@ -64,7 +64,7 @@ user: 'USER-NAME-NOT-SET'
 diag_basic_info:
 
     #History file string to match (eg. cam.h0 or ocn.pop.h.ecosys.nday1)
-    # Only affects timeseries as everything else uses timeseries 
+    # Only affects timeseries as everything else uses timeseries
     # Leave off trailing '.'
     #Default: cam.h0
     hist_str: cam.h0
@@ -98,7 +98,7 @@ diag_basic_info:
 
     #Location of ADF variable plotting defaults YAML file:
     #If left blank or missing, ADF/lib/adf_variable_defaults.yaml will be used
-    #Uncomment and change path for custom variable defaults file 
+    #Uncomment and change path for custom variable defaults file
     #defaults_file: /some/path/to/defaults/file.yaml
 
     #Vertical pressure levels (in hPa) on which to plot 3-D variables
@@ -368,13 +368,13 @@ diag_var_list:
     #TEM history file number
     #If missing or blank, ADF will default to h4
 #    hist_num: h4
-    
+
     #Overwrite TEM files, if found?
     #If set to false, then TEM creation will be skipped if files are found:
 #    overwrite_tem_case: false
 
-    #For multi-case:
-    #overwrite_tem_case
+    #For multi-case
+    #overwrite_tem_case:
     #    - false
     #    - true
 

--- a/config_cam_baseline_example.yaml
+++ b/config_cam_baseline_example.yaml
@@ -131,12 +131,6 @@ diag_basic_info:
     #If set to false, then if a plot is found it will be skipped:
     redo_plot: false
 
-    #Location where TEM files are stored:
-    #If path not specified or commented out, skip TEM calculation
-    #If no path, diagnostics wont run even if declared in averaging/plotting scripts below
-    tem_loc: /glade/scratch/${user}/ADF/tem
-
-
 #This second set of variables provides info for the CAM simulation(s) being diagnosed:
 diag_cam_climo:
 
@@ -214,8 +208,8 @@ diag_cam_climo:
     #    - /glade/p/cesm/ADF/b1850.f19_g17.validation_mct.004
 
     #cam_climo_loc:
-    #    -/some/where/you/want/to/have/climo_files/ #MUST EDIT!
-    #    -/the/same/or/some/other/climo/files/location
+    #    - /some/where/you/want/to/have/climo_files/ #MUST EDIT!
+    #    - /the/same/or/some/other/climo/files/location
 
     #start_year:
     #    - 1990
@@ -238,7 +232,7 @@ diag_cam_climo:
     #    - false
 
     #cam_ts_loc:
-    #    - /some/where/you/want/to/have/time_series_files/
+    #    - /some/where/you/want/to/have/time_series_files
     #    - /same/or/different/place/you/want/files
 
     #----------------------
@@ -331,7 +325,7 @@ diag_cvdp_info:
 #These scripts must be located in "scripts/averaging":
 time_averaging_scripts:
     - create_climo_files
-    #- create_TEM_files
+    #- create_TEM_files #To generate TEM files, please un-comment
 
 #Name of regridding scripts being used.
 #These scripts must be located in "scripts/regridding":
@@ -353,7 +347,7 @@ plotting_scripts:
     - polar_map
     - cam_taylor_diagram
     - qbo
-    #- tem
+    #- tem #To plot TEM, please un-comment
     #- regional_map_multicase #To use this please un-comment and fill-out
                               #the "region_multicase" section below
 
@@ -391,5 +385,14 @@ diag_var_list:
 #     region_season: <NULL means use annual mean>
 #     region_variables: <list of variables to try to use; allows for a subset of the total diag variables>
 
+# Options for TEM diagnostics (./averaging/create_TEM_files.py and ./plotting/temp.py)
+#tem_info:
+    #Location where TEM files are stored:
+    #If path not specified or commented out, skip TEM calculation
+    #If no path, diagnostics wont run even if declared in averaging/plotting scripts below
+    #tem_loc: /glade/scratch/richling/adf-output/tem/fixes/cam_vs_cam/TEM/
+
+    #TEM history file number
+    #hist_num: h4
 
 #END OF FILE

--- a/config_cam_baseline_example.yaml
+++ b/config_cam_baseline_example.yaml
@@ -404,8 +404,7 @@ diag_var_list:
 # Options for TEM diagnostics (./averaging/create_TEM_files.py and ./plotting/temp.py)
 #tem_info:
     #Location where TEM files are stored:
-    #If path not specified or commented out, TEM calculation will be skipped
-    #If no path, TEM diagnostics wont run even if declared in averaging/plotting scripts
+    #If path not specified or commented out, TEM calculation/plots will be skipped
 #    tem_loc: /glade/scratch/richling/adf-output/ADF-data/TEM/
 
     #TEM history file number

--- a/config_cam_baseline_example.yaml
+++ b/config_cam_baseline_example.yaml
@@ -411,11 +411,11 @@ diag_var_list:
     #If missing or blank, ADF will default to h4
 #    hist_num: h4
     
-    #Overwrite TEMs files, if found?
+    #Overwrite TEM files, if found?
     #If set to false, then TEM creation will be skipped if files are found:
 #    overwrite_tem_case: false
 
-    #For multi-case?
+    #For multi-case:
     #overwrite_tem_case
     #    - false
     #    - true

--- a/config_cam_baseline_example.yaml
+++ b/config_cam_baseline_example.yaml
@@ -99,7 +99,7 @@ diag_basic_info:
 
     #Location of ADF variable plotting defaults YAML file:
     #If left blank or missing, ADF/lib/adf_variable_defaults.yaml will be used
-    #Uncomment and change path for custom variable defaults file 
+    #Uncomment and change path for custom variable defaults file
     #defaults_file: /some/path/to/defaults/file.yaml
 
     #Vertical pressure levels (in hPa) on which to plot 3-D variables
@@ -410,13 +410,13 @@ diag_var_list:
     #TEM history file number
     #If missing or blank, ADF will default to h4
 #    hist_num: h4
-    
+
     #Overwrite TEM files, if found?
     #If set to false, then TEM creation will be skipped if files are found:
 #    overwrite_tem_case: false
 
-    #For multi-case:
-    #overwrite_tem_case
+    #For multi-case
+    #overwrite_tem_case:
     #    - false
     #    - true
 

--- a/config_cam_baseline_example.yaml
+++ b/config_cam_baseline_example.yaml
@@ -97,14 +97,10 @@ diag_basic_info:
     #Location where diagnostic plots are stored:
     cam_diag_plot_loc: /glade/scratch/${user}/ADF/plots
 
-    #Use default variable plot settings?
-    #If "true", then variable-specific plotting attributes as defined in
-    #ADF/lib/adf_variable_defaults.yaml will be used:
-    use_defaults: true
-
-    #Location of ADF variable plotting defaults YAML file
-    #if not using the one in ADF/lib:
-  #  defaults_file: /some/path/to/defaults/file
+    #Location of ADF variable plotting defaults YAML file:
+    #If left blank or missing, ADF/lib/adf_variable_defaults.yaml will be used
+    #Uncomment and change path for custom variable defaults file 
+    #defaults_file: /some/path/to/defaults/file.yaml
 
     #Vertical pressure levels (in hPa) on which to plot 3-D variables
     #when using horizontal (e.g. lat/lon) map projections.
@@ -388,11 +384,23 @@ diag_var_list:
 # Options for TEM diagnostics (./averaging/create_TEM_files.py and ./plotting/temp.py)
 #tem_info:
     #Location where TEM files are stored:
-    #If path not specified or commented out, skip TEM calculation
-    #If no path, diagnostics wont run even if declared in averaging/plotting scripts below
-    #tem_loc: /glade/scratch/richling/adf-output/tem/fixes/cam_vs_cam/TEM/
+    #If path not specified or commented out, TEM calculation will be skipped
+    #If no path, TEM diagnostics wont run even if declared in averaging/plotting scripts
+#    tem_loc: /glade/scratch/richling/adf-output/ADF-data/TEM/
 
     #TEM history file number
-    #hist_num: h4
+    #If missing or blank, ADF will default to h4
+#    hist_num: h4
+    
+    #Overwrite TEMs files, if found?
+    #If set to false, then TEM creation will be skipped if files are found:
+#    overwrite_tem_case: false
+
+    #For multi-case?
+    #overwrite_tem_case
+    #    - false
+    #    - true
+
+#    overwrite_tem_base: false
 
 #END OF FILE

--- a/config_cam_baseline_example.yaml
+++ b/config_cam_baseline_example.yaml
@@ -131,6 +131,11 @@ diag_basic_info:
     #If set to false, then if a plot is found it will be skipped:
     redo_plot: false
 
+    #Location where TEM files are stored:
+    #If path not specified or commented out, skip TEM calculation
+    #If no path, diagnostics wont run even if declared in averaging/plotting scripts below
+    tem_loc: /glade/scratch/${user}/ADF/tem
+
 
 #This second set of variables provides info for the CAM simulation(s) being diagnosed:
 diag_cam_climo:
@@ -326,6 +331,7 @@ diag_cvdp_info:
 #These scripts must be located in "scripts/averaging":
 time_averaging_scripts:
     - create_climo_files
+    #- create_TEM_files
 
 #Name of regridding scripts being used.
 #These scripts must be located in "scripts/regridding":
@@ -347,6 +353,7 @@ plotting_scripts:
     - polar_map
     - cam_taylor_diagram
     - qbo
+    #- tem
     #- regional_map_multicase #To use this please un-comment and fill-out
                               #the "region_multicase" section below
 

--- a/lib/adf_diag.py
+++ b/lib/adf_diag.py
@@ -396,9 +396,6 @@ class AdfDiag(AdfWeb):
             start_year = start_years[case_idx]
             end_year   = end_years[case_idx]
 
-            print(type(start_year))
-            print(type(end_year))
-
             #Create path object for the CAM history file(s) location:
             starting_location = Path(cam_hist_locs[case_idx])
 

--- a/lib/adf_diag.py
+++ b/lib/adf_diag.py
@@ -17,6 +17,7 @@ import os.path
 import glob
 import subprocess
 import multiprocessing as mp
+import copy
 
 import importlib
 
@@ -180,6 +181,14 @@ class AdfDiag(AdfWeb):
 
         #Add plotting script names:
         self.__plotting_scripts = self.read_config_var('plotting_scripts')
+
+    # Create property needed to return "plotting_scripts" variable to user:
+    @property
+    def plotting_scripts(self):
+        """Return a copy of the '__plotting_scripts' string list to user if requested."""
+        #Note that a copy is needed in order to avoid having a script mistakenly
+        #modify this variable:
+        return copy.copy(self.__plotting_scripts)
 
     #########
     #Variable extraction functions

--- a/lib/adf_info.py
+++ b/lib/adf_info.py
@@ -117,8 +117,6 @@ class AdfInfo(AdfConfig):
         #Case names:
         case_names = self.get_cam_info('cam_case_name', required=True)
 
-        print(case_names)
-
         #Grab test case nickname(s)
         test_nicknames = self.get_cam_info('case_nickname')
         if test_nicknames is None:
@@ -130,15 +128,6 @@ class AdfInfo(AdfConfig):
 
         #Initialize "compare_obs" variable:
         self.__compare_obs = self.get_basic_info('compare_obs')
-
-        #Case names:
-        case_names = self.get_cam_info('cam_case_name', required=True)
-
-        #Grab test case nickname(s)
-        test_nicknames = self.get_cam_info('case_nickname', required=True)
-        if test_nicknames is None:
-            for idx,case_name in enumerate(case_names):
-                test_nicknames[idx] = case_name
 
         #Check if a CAM vs AMWG obs comparison is being performed:
         if self.__compare_obs:

--- a/lib/adf_info.py
+++ b/lib/adf_info.py
@@ -117,6 +117,15 @@ class AdfInfo(AdfConfig):
         #Initialize "compare_obs" variable:
         self.__compare_obs = self.get_basic_info('compare_obs')
 
+        #Case names:
+        case_names = self.get_cam_info('cam_case_name', required=True)
+
+        #Grab test case nickname(s)
+        test_nicknames = self.get_cam_info('case_nickname', required=True)
+        if test_nicknames is None:
+            for idx,case_name in enumerate(case_names):
+                test_nicknames[idx] = case_name
+
         #Check if a CAM vs AMWG obs comparison is being performed:
         if self.__compare_obs:
 
@@ -126,6 +135,7 @@ class AdfInfo(AdfConfig):
 
             #Also set data name for use below:
             data_name = "Obs"
+            base_nickname = "Obs"
 
             #Set the baseline years to empty strings:
             syear_baseline = ""
@@ -183,9 +193,18 @@ class AdfInfo(AdfConfig):
                 #End if
             #End if
 
+            #Grab baseline nickname
+            base_nickname = self.get_baseline_info('case_nickname')
+            if base_nickname == None:
+                base_nickname = data_name
+
             #Update baseline case name:
             data_name += f"_{syear_baseline}_{eyear_baseline}"
         #End if (compare_obs)
+
+        #Initialize case nicknames:
+        self.__test_nicknames = test_nicknames
+        self.__base_nickname = base_nickname
 
         #Save starting and ending years as object variables:
         self.__syear_baseline = syear_baseline
@@ -271,6 +290,7 @@ class AdfInfo(AdfConfig):
 
         #End for
 
+        #Save starting and ending years as object variables:
         self.__syears = syears
         self.__eyears = eyears
 
@@ -409,6 +429,18 @@ class AdfInfo(AdfConfig):
         eyears = copy.copy(self.__eyears)
         return {"syears":syears,"eyears":eyears,
                 "syear_baseline":self.__syear_baseline, "eyear_baseline":self.__eyear_baseline}
+
+    # Create property needed to return the case nicknames to user:
+    @property
+    def case_nicknames(self):
+        """Return the test case and baseline nicknames to the user if requested."""
+
+        #Note that copies are needed in order to avoid having a script mistakenly
+        #modify these variables, as they are mutable and thus passed by reference:
+        test_nicknames = copy.copy(self.__test_nicknames)
+        base_nickname = copy.copy(self.__base_nickname)
+
+        return {"test_nicknames":test_nicknames,"base_nickname":base_nickname}
 
     #########
 

--- a/lib/adf_obs.py
+++ b/lib/adf_obs.py
@@ -93,11 +93,11 @@ class AdfObs(AdfInfo):
             for var in self.diag_var_list:
                 #Check if any variable wants a land or ocean mask:
                 if var in self.__variable_defaults:
-                   if 'mask' in self.__variable_defaults[var]:
-                       #Variable needs a mask, so add "OCNFRAC" to
-                       #the variable list:
-                       self.add_diag_var('OCNFRAC')
-                       break
+                    if 'mask' in self.__variable_defaults[var]:
+                        #Variable needs a mask, so add "OCNFRAC" to
+                        #the variable list:
+                        self.add_diag_var('OCNFRAC')
+                        break
                    #End if
                 #End if
             #End for

--- a/lib/adf_obs.py
+++ b/lib/adf_obs.py
@@ -66,24 +66,21 @@ class AdfObs(AdfInfo):
         #Determine local directory:
         _adf_lib_dir = Path(__file__).parent
 
-        #Determine if variable defaults will be used:
-        self.__use_defaults = self.get_basic_info('use_defaults')
-
         # Check whether user wants to use defaults:
         #-----------------------------------------
-        if self.__use_defaults:
-            #Determine whether to use adf defaults or custom:
-            _defaults_file = self.get_basic_info('defaults_file')
-            if _defaults_file is None:
-                _defaults_file = _adf_lib_dir/'adf_variable_defaults.yaml'
-
-            #Open YAML file:
-            with open(_defaults_file, encoding='UTF-8') as dfil:
-                self.__variable_defaults = yaml.load(dfil, Loader=yaml.SafeLoader)
+        #Determine whether to use adf defaults or custom:
+        _defaults_file = self.get_basic_info('defaults_file')
+        if _defaults_file is None:
+            _defaults_file = _adf_lib_dir/'adf_variable_defaults.yaml'
         else:
-            #Set variable_defaults to empty dictionary:
-            self.__variable_defaults = {}
+            print(f"\n\t Not using ADF default variables yaml file, instead using {_defaults_file}\n")
         #End if
+
+        #Open YAML file:
+        with open(_defaults_file, encoding='UTF-8') as dfil:
+            self.__variable_defaults = yaml.load(dfil, Loader=yaml.SafeLoader)
+
+        _variable_defaults = self.__variable_defaults
         #-----------------------------------------
 
         #Check if land or ocean mask is requested, and if so then add OCNFRAC
@@ -117,21 +114,6 @@ class AdfObs(AdfInfo):
 
         #Extract the "obs_data_loc" default observational data location:
         obs_data_loc = self.get_basic_info("obs_data_loc")
-
-        #Check that a variable defaults file exists (as it is currently needed to extract obs data):
-        if not self.__variable_defaults:
-            #Determine whether to use adf defaults or custom:
-            _defaults_file = self.get_basic_info('defaults_file')
-            if _defaults_file is None:
-                _defaults_file = _adf_lib_dir/'adf_variable_defaults.yaml'
-
-            #Open YAML file (but don't assign to object):
-            with open(_defaults_file, encoding='UTF-8') as nfil:
-                _variable_defaults = yaml.load(nfil, Loader=yaml.SafeLoader)
-        else:
-            #Set local variable to stored variable defaults dictionary:
-            _variable_defaults = self.__variable_defaults
-        #End if
 
         #Loop over variable list:
         for var in self.diag_var_list:
@@ -228,12 +210,6 @@ class AdfObs(AdfInfo):
         #Note that a copy is needed in order to avoid having a script mistakenly
         #modify this variable, as it is mutable and thus passed by reference:
         return copy.copy(self.__variable_defaults)
-
-    # Create property needed to return "use_defaults" variable to user:
-    @property
-    def use_defaults(self):
-        """Return the '__use_defaults' logical to the user if requested."""
-        return self.__use_defaults
 
     # Create property needed to return "var_obs_dict" dictionary to user:
     @property

--- a/lib/adf_variable_defaults.yaml
+++ b/lib/adf_variable_defaults.yaml
@@ -986,7 +986,7 @@ psitem:
   long_name: Transformed Eulerian mean mass stream function
   obs_file: "TEM_ERA5.nc"
   obs_name: "ERA5"
-  obs_var_name: ""
+  obs_var_name: "psitem"
 
 utendepfd:
   ylim: [1e2,1]
@@ -994,7 +994,7 @@ utendepfd:
   long_name: tendency of eastward wind due to Eliassen-Palm flux divergence
   obs_file: "TEM_ERA5.nc"
   obs_name: "ERA5"
-  obs_var_name: "psitem"
+  obs_var_name: "utendepfd"
 
 utendvtem:
   ylim: [1e2,1]

--- a/lib/adf_variable_defaults.yaml
+++ b/lib/adf_variable_defaults.yaml
@@ -933,7 +933,6 @@ OMEGAT:
 # Category: TEM
 #++++++++++++++
 uzm:
-  axs: [0,0]
   ylim: [1e3,1]
   units: m s-1
   long_name: Zonal-Mean zonal wind
@@ -942,7 +941,6 @@ uzm:
   obs_var_name: "uzm"
 
 vzm:
-  axs: [0,1]
   ylim: [1e3,1]
   units: m s-1
   long_name: Zonal-Mean meridional wind
@@ -951,8 +949,6 @@ vzm:
   obs_var_name: "vzm"
 
 epfy:
-  axs: [1,0]
-  vmax: 1e6
   ylim: [1e2,1]
   units: m3 s−2
   long_name: northward component of the Eliassen–Palm flux
@@ -961,8 +957,6 @@ epfy:
   obs_var_name: "epfy"
 
 epfz:
-  axs: [1,1]
-  vmax: 1e6
   ylim: [1e2,1]
   units: m3 s−2
   long_name: upward component of the Eliassen–Palm flux
@@ -971,11 +965,7 @@ epfz:
   obs_var_name: "epfz"
 
 vtem:
-  axs: [2,0]
-  vmax: 1e6
   ylim: [1e2,1]
-  vmax: 3
-  vmin: -3
   units: m/s
   long_name: Transformed Eulerian mean northward wind
   obs_file: "/glade/work/richling/ERA5.nc"
@@ -983,11 +973,7 @@ vtem:
   obs_var_name: "vtem"
 
 wtem:
-  axs: [2,1]
-  vmax: 1e6
   ylim: [1e2,1]
-  vmax: 0.005
-  vmin: -0.005
   units: m/s
   long_name: Transformed Eulerian mean upward wind
   obs_file: "/glade/work/richling/ERA5.nc"
@@ -995,8 +981,6 @@ wtem:
   obs_var_name: "wtem"
 
 psitem:
-  axs: [3,0]
-  vmax: 1e6
   ylim: [1e2,1]
   units: m3 s−2
   long_name: Transformed Eulerian mean mass stream function
@@ -1005,8 +989,6 @@ psitem:
   obs_var_name: ""
 
 utendepfd:
-  axs: [3,1]
-  vmax: 1e6
   ylim: [1e2,1]
   units: m3 s−2
   long_name: tendency of eastward wind due to Eliassen-Palm flux divergence
@@ -1015,8 +997,6 @@ utendepfd:
   obs_var_name: "psitem"
 
 utendvtem:
-  axs: [1,1]
-  vmax: 1e6
   ylim: [1e2,1]
   units: m3 s−2
   long_name: tendency of eastward wind due to TEM northward wind advection and the coriolis term
@@ -1025,8 +1005,6 @@ utendvtem:
   obs_var_name: "utendvtem"
 
 utendwtem:
-  axs: [1,1]
-  vmax: 1e6
   ylim: [1e2,1]
   units: m3 s−2
   long_name: tendency of eastward wind due to TEM upward wind advection

--- a/lib/adf_variable_defaults.yaml
+++ b/lib/adf_variable_defaults.yaml
@@ -929,5 +929,110 @@ OMEGAT:
   diff_colormap: "coolwarm"
   plot_log_pressure: True
 
+#++++++++++++++
+# Category: TEM
+#++++++++++++++
+uzm:
+  axs: [0,0]
+  ylim: [1e3,1]
+  units: m s-1
+  long_name: Zonal-Mean zonal wind
+  obs_file: "/glade/work/richling/ERA5.nc"
+  obs_name: "ERA5"
+  obs_var_name: "uzm"
+
+vzm:
+  axs: [0,1]
+  ylim: [1e3,1]
+  units: m s-1
+  long_name: Zonal-Mean meridional wind
+  obs_file: "/glade/work/richling/ERA5.nc"
+  obs_name: "ERA5"
+  obs_var_name: "vzm"
+
+epfy:
+  axs: [1,0]
+  vmax: 1e6
+  ylim: [1e2,1]
+  units: m3 s−2
+  long_name: northward component of the Eliassen–Palm flux
+  obs_file: "/glade/work/richling/ERA5.nc"
+  obs_name: "ERA5"
+  obs_var_name: "epfy"
+
+epfz:
+  axs: [1,1]
+  vmax: 1e6
+  ylim: [1e2,1]
+  units: m3 s−2
+  long_name: upward component of the Eliassen–Palm flux
+  obs_file: "/glade/work/richling/ERA5.nc"
+  obs_name: "ERA5"
+  obs_var_name: "epfz"
+
+vtem:
+  axs: [2,0]
+  vmax: 1e6
+  ylim: [1e2,1]
+  vmax: 3
+  vmin: -3
+  units: m/s
+  long_name: Transformed Eulerian mean northward wind
+  obs_file: "/glade/work/richling/ERA5.nc"
+  obs_name: "ERA5"
+  obs_var_name: "vtem"
+
+wtem:
+  axs: [2,1]
+  vmax: 1e6
+  ylim: [1e2,1]
+  vmax: 0.005
+  vmin: -0.005
+  units: m/s
+  long_name: Transformed Eulerian mean upward wind
+  obs_file: "/glade/work/richling/ERA5.nc"
+  obs_name: "ERA5"
+  obs_var_name: "wtem"
+
+psitem:
+  axs: [3,0]
+  vmax: 1e6
+  ylim: [1e2,1]
+  units: m3 s−2
+  long_name: Transformed Eulerian mean mass stream function
+  obs_file: "/glade/work/richling/ERA5.nc"
+  obs_name: "ERA5"
+  obs_var_name: ""
+
+utendepfd:
+  axs: [3,1]
+  vmax: 1e6
+  ylim: [1e2,1]
+  units: m3 s−2
+  long_name: tendency of eastward wind due to Eliassen-Palm flux divergence
+  obs_file: "/glade/work/richling/ERA5.nc"
+  obs_name: "ERA5"
+  obs_var_name: "psitem"
+
+utendvtem:
+  axs: [1,1]
+  vmax: 1e6
+  ylim: [1e2,1]
+  units: m3 s−2
+  long_name: tendency of eastward wind due to TEM northward wind advection and the coriolis term
+  obs_file: "/glade/work/richling/ERA5.nc"
+  obs_name: "ERA5"
+  obs_var_name: "utendvtem"
+
+utendwtem:
+  axs: [1,1]
+  vmax: 1e6
+  ylim: [1e2,1]
+  units: m3 s−2
+  long_name: tendency of eastward wind due to TEM upward wind advection
+  obs_file: "/glade/work/richling/ERA5.nc"
+  obs_name: "ERA5"
+  obs_var_name: "utendwtem"
+
 #-----------
 #End of File

--- a/lib/adf_variable_defaults.yaml
+++ b/lib/adf_variable_defaults.yaml
@@ -936,7 +936,7 @@ uzm:
   ylim: [1e3,1]
   units: m s-1
   long_name: Zonal-Mean zonal wind
-  obs_file: "/glade/work/richling/ERA5.nc"
+  obs_file: "TEM_ERA5.nc"
   obs_name: "ERA5"
   obs_var_name: "uzm"
 
@@ -944,7 +944,7 @@ vzm:
   ylim: [1e3,1]
   units: m s-1
   long_name: Zonal-Mean meridional wind
-  obs_file: "/glade/work/richling/ERA5.nc"
+  obs_file: "TEM_ERA5.nc"
   obs_name: "ERA5"
   obs_var_name: "vzm"
 
@@ -952,7 +952,7 @@ epfy:
   ylim: [1e2,1]
   units: m3 s−2
   long_name: northward component of the Eliassen–Palm flux
-  obs_file: "/glade/work/richling/ERA5.nc"
+  obs_file: "TEM_ERA5.nc"
   obs_name: "ERA5"
   obs_var_name: "epfy"
 
@@ -960,7 +960,7 @@ epfz:
   ylim: [1e2,1]
   units: m3 s−2
   long_name: upward component of the Eliassen–Palm flux
-  obs_file: "/glade/work/richling/ERA5.nc"
+  obs_file: "TEM_ERA5.nc"
   obs_name: "ERA5"
   obs_var_name: "epfz"
 
@@ -968,7 +968,7 @@ vtem:
   ylim: [1e2,1]
   units: m/s
   long_name: Transformed Eulerian mean northward wind
-  obs_file: "/glade/work/richling/ERA5.nc"
+  obs_file: "TEM_ERA5.nc"
   obs_name: "ERA5"
   obs_var_name: "vtem"
 
@@ -976,7 +976,7 @@ wtem:
   ylim: [1e2,1]
   units: m/s
   long_name: Transformed Eulerian mean upward wind
-  obs_file: "/glade/work/richling/ERA5.nc"
+  obs_file: "TEM_ERA5.nc"
   obs_name: "ERA5"
   obs_var_name: "wtem"
 
@@ -984,7 +984,7 @@ psitem:
   ylim: [1e2,1]
   units: m3 s−2
   long_name: Transformed Eulerian mean mass stream function
-  obs_file: "/glade/work/richling/ERA5.nc"
+  obs_file: "TEM_ERA5.nc"
   obs_name: "ERA5"
   obs_var_name: ""
 
@@ -992,7 +992,7 @@ utendepfd:
   ylim: [1e2,1]
   units: m3 s−2
   long_name: tendency of eastward wind due to Eliassen-Palm flux divergence
-  obs_file: "/glade/work/richling/ERA5.nc"
+  obs_file: "TEM_ERA5.nc"
   obs_name: "ERA5"
   obs_var_name: "psitem"
 
@@ -1000,7 +1000,7 @@ utendvtem:
   ylim: [1e2,1]
   units: m3 s−2
   long_name: tendency of eastward wind due to TEM northward wind advection and the coriolis term
-  obs_file: "/glade/work/richling/ERA5.nc"
+  obs_file: "TEM_ERA5.nc"
   obs_name: "ERA5"
   obs_var_name: "utendvtem"
 
@@ -1008,7 +1008,7 @@ utendwtem:
   ylim: [1e2,1]
   units: m3 s−2
   long_name: tendency of eastward wind due to TEM upward wind advection
-  obs_file: "/glade/work/richling/ERA5.nc"
+  obs_file: "TEM_ERA5.nc"
   obs_name: "ERA5"
   obs_var_name: "utendwtem"
 

--- a/scripts/averaging/create_TEM_files.py
+++ b/scripts/averaging/create_TEM_files.py
@@ -25,6 +25,13 @@ def create_TEM_files(adf):
     start_years   = adf.climo_yrs["syears"]
     end_years     = adf.climo_yrs["eyears"]
 
+    #Grab TEM diagnostics options
+    tem_opts = adf.read_config_var("tem_info")
+
+    #Get test case(s) tem over-write boolean and force to list if not by default
+    overwrite_tem_cases = tem_opts["overwrite_tem_case"]
+    if not isinstance(overwrite_tem_cases, list): overwrite_tem_cases = [overwrite_tem_cases]
+
     #Check if comparing to observations
     if adf.get_basic_info("compare_obs"):
         var_obs_dict = adf.var_obs_dict
@@ -45,14 +52,8 @@ def create_TEM_files(adf):
         case_names.append(base_name)
         start_years.append(syear_baseline)
         end_years.append(eyear_baseline)
+        overwrite_tem_cases.append(tem_opts["overwrite_tem_base"])
     #End if
-
-    #Grab TEM diagnostics options
-    tem_opts = adf.read_config_var("tem_info")
-
-    #Get test case(s) tem over-write boolean and force to list if not by default
-    overwrite_tem_cases = tem_opts["overwrite_tem_case"]
-    if not isinstance(overwrite_tem_cases, list): overwrite_tem_cases = [overwrite_tem_cases]
     
     #Set default to h4
     #TODO: Read this history file number from the yaml file?

--- a/scripts/averaging/create_TEM_files.py
+++ b/scripts/averaging/create_TEM_files.py
@@ -28,8 +28,13 @@ def create_TEM_files(adf):
     #Grab TEM diagnostics options
     tem_opts = adf.read_config_var("tem_info")
 
+    if not tem_opts:
+        print("\n  No TEM options provided, skipping TEM file creation." \
+        "\nSee documentation or config_cam_baseline_example.yaml for options to add to configuration file.")
+        return
+
     #Get test case(s) tem over-write boolean and force to list if not by default
-    overwrite_tem_cases = tem_opts["overwrite_tem_case"]
+    overwrite_tem_cases = tem_opts.get("overwrite_tem_case")
     if not isinstance(overwrite_tem_cases, list): overwrite_tem_cases = [overwrite_tem_cases]
 
     #Check if comparing to observations
@@ -52,12 +57,11 @@ def create_TEM_files(adf):
         case_names.append(base_name)
         start_years.append(syear_baseline)
         end_years.append(eyear_baseline)
-        overwrite_tem_cases.append(tem_opts["overwrite_tem_base"])
+        overwrite_tem_cases.append(tem_opts.get("overwrite_tem_base", False))
     #End if
     
     #Set default to h4
-    #TODO: Read this history file number from the yaml file?
-    hist_num = tem_opts["hist_num"]
+    hist_num = tem_opts.get("hist_num")
     if hist_num is None:
         hist_num = "h4"
 
@@ -182,7 +186,7 @@ def create_TEM_files(adf):
         if not list(starting_location.glob(hist_str+'.*.nc')):
             emsg = f"No CAM history {hist_str} files found in '{starting_location}'."
             emsg += " Script is ending here."
-            return
+            adf.end_diag_fail(emsg)
         #End if
 
         #Get full path and file for file name
@@ -194,7 +198,7 @@ def create_TEM_files(adf):
             output_loc_idx.mkdir(parents=True)
         #End if
 
-        #Set baseline file name
+        #Set case file name
         tem_fil = output_loc_idx / f'{case_name}.TEMdiag_{start_year}-{end_year}.nc'
 
         #Get current case tem over-write boolean

--- a/scripts/averaging/create_TEM_files.py
+++ b/scripts/averaging/create_TEM_files.py
@@ -330,7 +330,7 @@ def calc_tem(ds):
     uwzm = -1.*uwzm*pre/H
 
     # compute the latitudinal gradient of U
-    dudphi = (1./a)*np.gradient(uzm*coslat2d, 
+    dudphi = (1./(a*coslat2d))*np.gradient(uzm*coslat2d, 
                                 latrad, 
                                 axis=1)
     

--- a/scripts/averaging/create_TEM_files.py
+++ b/scripts/averaging/create_TEM_files.py
@@ -89,7 +89,7 @@ def create_TEM_files(adf):
 
     #Check if comparing against observations
     if adf.get_basic_info("compare_obs"):
-        print(f"\t Processing TEM diagnostics for observations :")
+        print(f"\t Processing TEM for observations :")
 
         output_loc_idx = output_loc / base_name
         #Check if re-gridded directory exists, and if not, then create it:
@@ -105,11 +105,13 @@ def create_TEM_files(adf):
         overwrite_tem = tem_opts.get("overwrite_tem_base")
 
         #If files exist, then check if over-writing is allowed:
-        if tem_fil and not overwrite_tem:
-            #If not (overwrite_tem is False), then simply skip this file:
-            print(f"'{tem_fil}' already exists and wont be over-written, moving on")
+        if (tem_fil.is_file()) and (not overwrite_tem):
+            print(f"\t    INFO: Found TEM file and clobber is False, so moving to next case.")
             pass
         else:
+            if tem_fil.is_file():
+                print(f"\t    INFO: Found TEM file but clobber is True, so over-writing file.")
+
             #Group all TEM observation files together
             tem_obs_fils = []
             for var in var_list:
@@ -153,13 +155,13 @@ def create_TEM_files(adf):
             # write output to a netcdf file
             ds_base.to_netcdf(tem_fil, unlimited_dims='time', mode='w')
 
-        #End if over-write file
+        #End if (file creation or over-write file)
     #End if baseline case
 
     #Loop over cases:
     for case_idx, case_name in enumerate(case_names):
 
-        print(f"\t Processing TEM diagnostics for case '{case_name}' :")
+        print(f"\t Processing TEM for case '{case_name}' :")
 
         #Extract start and end year values:
         start_year = start_years[case_idx]
@@ -199,11 +201,13 @@ def create_TEM_files(adf):
         overwrite_tem = overwrite_tem_cases[case_idx]
 
         #If files exist, then check if over-writing is allowed:
-        if tem_fil and not overwrite_tem:
-            #If not (overwrite_tem is False), then simply skip this file:
-            print(f"'{tem_fil}' already exists and wont be over-written, moving on")
+        if (tem_fil.is_file()) and (not overwrite_tem):
+            print(f"\t    INFO: Found TEM file and clobber is False, so moving to next case.")
             pass
         else:
+            if tem_fil.is_file():
+                print(f"\t    INFO: Found TEM file but clobber is True, so over-writing file.")
+
             #Glob each set of years
             #NOTE: This will make a nested list
             hist_files = []
@@ -236,9 +240,9 @@ def create_TEM_files(adf):
             # write output to a netcdf file
             dstem0.to_netcdf(tem_fil, unlimited_dims='time', mode='w')
 
-        #End if over-write file
+        #End if (file creation or over-write file)
     #Notify user that script has ended:
-    print("  ...TEM diagnostics have been calculated successfully.")
+    print("  ...TEM variables have been calculated successfully.")
 
 
 

--- a/scripts/averaging/create_TEM_files.py
+++ b/scripts/averaging/create_TEM_files.py
@@ -1,0 +1,392 @@
+import xarray as xr
+import numpy as np
+from scipy import integrate
+from numpy import ma
+from datetime import date
+from pathlib import Path
+from glob import glob
+
+
+def create_TEM_files(adf):
+    """
+    Calculate the the TEM variables and create new netCDF files
+    
+    """
+
+    #Special ADF variables
+    #CAM simulation variables (these quantities are always lists):
+    case_names    = adf.get_cam_info("cam_case_name", required=True)
+
+    #Grab h4 history files locations
+    cam_hist_locs = adf.get_cam_info("cam_hist_loc", required=True)
+
+    #Extract test case years
+    start_years   = adf.climo_yrs["syears"]
+    end_years     = adf.climo_yrs["eyears"]
+
+    #Extract baseline years (which may be empty strings if using Obs):
+    syear_baseline = adf.climo_yrs["syear_baseline"]
+    eyear_baseline = adf.climo_yrs["eyear_baseline"]
+
+    #Check if comparing to observations
+    if adf.get_basic_info("compare_obs"):
+        base_name = "Obs"
+    else:
+        base_name = adf.get_baseline_info("cam_case_name", required=True) # does not get used, is just here as a placemarker
+        cam_hist_locs.append(adf.get_baseline_info("cam_hist_loc", required=True))
+
+        case_names.append(base_name)
+        start_years.append(syear_baseline)
+        end_years.append(eyear_baseline)
+    #End if
+
+    #New TEM netCDF file save location
+    output_loc = adf.get_basic_info("tem_loc")
+    
+    #If path not specified, skip TEM calculation?
+    if output_loc is None:
+        return
+    else:
+        #Notify user that script has started:
+        print("\n  Generating CAM TEM diagnostics files...")
+
+    #Set default to h4
+    #TODO: Read this history file number from the yaml file?
+    hist_num = "h4"
+
+    res = adf.variable_defaults # will be dict of variable-specific plot preferences
+    # or an empty dictionary if use_defaults was not specified in YAML.
+
+    if "qbo" in adf._AdfDiag__plotting_scripts:
+        var_list = ['uzm','epfy','epfz','vtem','wtem',
+                    'psitem','utendepfd','utendvtem','utendwtem']
+    else:
+        var_list = ['uzm','epfy','epfz','vtem','wtem','psitem','utendepfd']
+
+    #Check if comparing against observations
+    if adf.get_basic_info("compare_obs"):
+        print(f"\t Processing TEM diagnostics for observations :")
+
+        obs_loc = adf.get_basic_info("obs_data_loc")
+        
+        #Group all TEM observation files together
+        tem_base = []
+        for var in var_list:
+            if var in res:
+                #Gather from variable defaults file
+                obs_file = res[var]["obs_file"]
+                tem_base.append(Path(obs_loc) / obs_file)
+
+        tem_base = np.array(tem_base)
+        tem_base = np.unique(tem_base)
+
+        ds = xr.open_mfdataset(tem_base)
+        start_year = str(ds.time[0].values)[0:4]
+        end_year = str(ds.time[-1].values)[0:4]
+
+        print("obs start year:",start_year)
+        print("obs end year:",end_year,"\n")
+
+        #Update the attributes
+        ds.attrs['created'] = str(date.today())
+        ds['lev']=ds['level']
+        ds['zalat']=ds['lat']
+
+        output_loc_idx = Path(output_loc) / base_name
+        #Check if TEM directory exists, and if not, then create it:
+        if not output_loc_idx.is_dir():
+            print(f"    {output_loc_idx} not found, making new directory")
+            output_loc_idx.mkdir(parents=True)
+        #End if
+
+        #Make a copy of obs data so we don't do anything bad
+        ds_obs = ds.copy()
+        ds_base = xr.Dataset({'uzm': xr.Variable(('time', 'lev', 'zalat'), ds_obs.uzm.data),
+                              'epfy': xr.Variable(('time', 'lev', 'zalat'), ds_obs.epfy.data),
+                              'epfz': xr.Variable(('time', 'lev', 'zalat'), ds_obs.epfz.data),
+                              'vtem': xr.Variable(('time', 'lev', 'zalat'), ds_obs.vtem.data),
+                              'wtem': xr.Variable(('time', 'lev', 'zalat'), ds_obs.wtem.data),
+                              'psitem': xr.Variable(('time', 'lev', 'zalat'), ds_obs.psitem.data),
+                              'utendepfd': xr.Variable(('time', 'lev', 'zalat'), ds_obs.utendepfd.data),
+                              'utendvtem': xr.Variable(('time', 'lev', 'zalat'), ds_obs.utendvtem.data),
+                              'utendwtem': xr.Variable(('time', 'lev', 'zalat'), ds_obs.utendwtem.data),
+                              'lev': xr.Variable('lev', ds_obs.level.values),
+                              'zalat': xr.Variable('zalat', ds_obs.lat.values),
+                              'time': xr.Variable('time', ds_obs.time.values)
+                })
+
+        # write output to a netcdf file
+        ds_base.to_netcdf(output_loc_idx / f'{base_name}.TEMdiag.nc', 
+                            unlimited_dims='time', 
+                            mode = 'w' )
+
+    #Loop over cases:
+    for case_idx, case_name in enumerate(case_names):
+
+        print(f"\t Processing TEM diagnostics for case '{case_name}' :")
+
+        #Extract start and end year values:
+        start_year = start_years[case_idx]
+        end_year   = end_years[case_idx]
+
+        #Create path object for the CAM history file(s) location:
+        starting_location = Path(cam_hist_locs[case_idx])
+
+        #Check that path actually exists:
+        if not starting_location.is_dir():
+            emsg = f"Provided 'cam_hist_loc' directory '{starting_location}' not found."
+            emsg += " Script is ending here."
+            adf.end_diag_fail(emsg)
+        #End if
+
+        #Check if history files actually exist. If not then kill script:
+        hist_str = '*.cam.'+hist_num
+        if not list(starting_location.glob(hist_str+'.*.nc')):
+            emsg = f"No CAM history {hist_str} files found in '{starting_location}'."
+            emsg += " Script is ending here."
+            adf.end_diag_fail(emsg)
+        #End if
+
+        # open input files
+        shist = glob(f"{starting_location}/*{hist_num}.{start_year}*.nc")
+        ehist = glob(f"{starting_location}/*{hist_num}.{end_year}*.nc")
+        hist_files = sorted(shist + ehist)
+
+        ds = xr.open_mfdataset(hist_files)
+
+        #iterate over the times in a dataset
+        for idx,_ in enumerate(ds.time.values):
+            if idx == 0:
+                dstem0 = calc_tem(ds.squeeze().isel(time=idx))
+            else:
+                dstem = calc_tem(ds.squeeze().isel(time=idx))
+                dstem0 = xr.concat([dstem0, dstem],'time')
+            #End if
+        #End if
+
+        #Update the attributes
+        dstem0.attrs = ds.attrs
+        dstem0.attrs['created'] = str(date.today())
+        dstem0['lev']=ds['lev']
+
+        output_loc_idx = Path(output_loc) / case_name
+        #Check if re-gridded directory exists, and if not, then create it:
+        if not output_loc_idx.is_dir():
+            print(f"    {output_loc_idx} not found, making new directory")
+            output_loc_idx.mkdir(parents=True)
+        #End if
+
+        # write output to a netcdf file
+        dstem0.to_netcdf(output_loc_idx / f'{case_name}.TEMdiag_{start_year}-{end_year}.nc', 
+                            unlimited_dims='time', 
+                            mode = 'w' )
+
+    #Notify user that script has ended:
+    print("  ...TEM diagnostics have been calculated successfully.")
+
+
+
+
+def calc_tem(ds):
+    """
+    # calc_tem() function to calculate TEM diagnostics on CAM/WACCM output
+    # This assumes the data have already been organized into zonal mean fluxes
+    # Uzm, THzm, VTHzm, Vzm, UVzm, UWzm, Wzm
+    # note that caculations are performed on model interface levels, which is ok
+    # in the stratosphere but not in the troposphere.  If interested in tropospheric
+    # TEM diagnostics, make sure input fields have been interpolated to true pressure levels.
+
+    # The code follows the 'TEM recipe' from Appendix A of Gerber, E. P. and Manzini, E.:
+    # The Dynamics and Variability Model Intercomparison Project (DynVarMIP) for CMIP6:
+    # assessing the stratosphere–troposphere system, Geosci. Model Dev., 9, 3413–3425, 
+    # https://doi.org/10.5194/gmd-9-3413-2016, 2016 and the corrigendum.
+
+    # pdf available here: https://gmd.copernicus.org/articles/9/3413/2016/gmd-9-3413-2016.pdf, 
+    # https://gmd.copernicus.org/articles/9/3413/2016/gmd-9-3413-2016-corrigendum.pdf
+
+    # Output from post-processing function
+
+    # Table A1. Momentum budget variable list (2-D monthly / daily zonal means, YZT).
+
+    # Name      Long name [unit]
+
+    # epfy      northward component of the Eliassen–Palm flux [m3 s−2]
+    # epfz      upward component of the Eliassen–Palm flux [m3 s−2]
+    # vtem      Transformed Eulerian mean northward wind [m s−1] 
+    # wtem      Transformed Eulerian mean upward wind [m s−1]
+    # psitem    Transformed Eulerian mean mass stream function [kg s−1]
+    # utendepfd tendency of eastward wind due to Eliassen–Palm flux divergence [m s−2]
+    # utendvtem tendency of eastward wind due to TEM northward wind advection and the Coriolis term [m s−2] 
+    # utendwtem tendency of eastward wind due to TEM upward wind advection [m s−2]
+
+    # this utility based on python code developed by Isla Simpson 25 Feb 2021
+    # initial coding of stand alone function by Dan Marsh 16 Dec 2022
+
+    # NOTE: function expects an xarray dataset with dataarrays of dimension (nlev,nlat)
+    # to process more than one timestep interate over time. See calcTEM.ipynb notebook
+    # for an example of processed a file or files with more than one timestep.
+    """
+
+    # constants for TEM calculations
+    p0 = 101325. 
+    a = 6.371e6 
+    om = 7.29212e-5
+    H = 7000.
+    g0 = 9.80665
+
+    nlat = ds['zalat'].size
+    nlev = ds['lev'].size
+
+    latrad = np.radians(ds.zalat)
+    coslat = np.cos(latrad)
+    coslat2d = np.tile(coslat,(nlev,1))
+    
+    pre = ds['lev']*100. # pressure levels in Pascals
+    f = 2.*om*np.sin(latrad[:])
+    f2d = np.tile(f,(nlev,1))
+    
+    # change missing values to NaNs
+    uzm = ds['Uzm']
+    uzm.values = ma.masked_greater_equal(uzm, 1e33)
+    vzm = ds['Vzm']
+    vzm.values = ma.masked_greater_equal(vzm, 1e33)
+    wzm = ds['Wzm']
+    wzm.values = ma.masked_greater_equal(wzm, 1e33)
+    thzm = ds['THzm']
+    thzm.values = ma.masked_greater_equal(thzm, 1e33)
+
+    uvzm = ds['UVzm']
+    uvzm.values = ma.masked_greater_equal(uvzm, 1e33)
+    uwzm = ds['UWzm']
+    uwzm.values = ma.masked_greater_equal(uwzm, 1e33)
+    vthzm = ds['VTHzm']
+    vthzm.values = ma.masked_greater_equal(vthzm, 1e33)
+    
+    # convert w terms from m/s to Pa/s
+    wzm  = -1.*wzm*pre/H
+    uwzm = -1.*uwzm*pre/H
+
+    # compute the latitudinal gradient of U
+    dudphi = (1./a)*np.gradient(uzm*coslat2d, 
+                                latrad, 
+                                axis=1)
+    
+    # compute the vertical gradient of theta and u
+    dthdp = np.gradient(thzm, 
+                        pre, 
+                        axis=0)
+    
+    dudp = np.gradient(uzm,
+                       pre,
+                       axis=0)
+
+    # compute eddy streamfunction and its vertical gradient
+    psieddy = vthzm/dthdp
+    dpsidp = np.gradient(psieddy,
+                         pre,
+                         axis=0)
+
+    # (1/acos(phii))**d(psi*cosphi/dphi) for getting w*
+    dpsidy = (1./(a*coslat2d)) \
+           * np.gradient(psieddy*coslat2d,
+                         latrad, 
+                         axis=1)
+
+    # TEM vertical velocity (Eq A7 of dynvarmip)
+    wtem = wzm+dpsidy    
+    
+    # utendwtem (Eq A10 of dynvarmip)
+    utendwtem = -1.*wtem*dudp
+
+    # vtem (Eq A6 of dynvarmip)
+    vtem = vzm-dpsidp
+    
+    # utendvtem (Eq A9 of dynvarmip)
+    utendvtem = vtem*(f2d - dudphi) 
+
+    # calculate E-P fluxes
+    epfy = a*coslat2d*(dudp*psieddy - uvzm) # Eq A2
+    epfz = a*coslat2d*((f2d-dudphi)*psieddy - uwzm) # Eq A3
+
+    # calculate E-P flux divergence and zonal wind tendency 
+    # due to resolved waves (Eq A5)
+    depfydphi = (1./(a*coslat2d)) \
+              * np.gradient(epfy*coslat2d,
+                            latrad, 
+                            axis=1)
+        
+    depfzdp = np.gradient(epfz,
+                          pre,
+                          axis=0)
+    
+    utendepfd = (depfydphi + depfzdp)/(a*coslat2d)
+    utendepfd = xr.DataArray(utendepfd, coords = ds.Uzm.coords, name='utendepfd')
+                             
+    # TEM stream function, Eq A8
+    topvzm = np.zeros([1,nlat])
+    vzmwithzero = np.concatenate((topvzm, vzm), axis=0)
+    prewithzero = np.concatenate((np.zeros([1]), pre))
+    intv = integrate.cumtrapz(vzmwithzero,prewithzero,axis=0)
+    psitem = (2*np.pi*a*coslat2d/g0)*(intv - psieddy)
+   
+    # final scaling of E-P fluxes and divergence to transform to log-pressure
+    epfy = epfy*pre/p0      # A13
+    epfz = -1.*(H/p0)*epfz  # A14
+    wtem = -1.*(H/pre)*wtem # A16
+
+    # 
+    # add long name and unit attributes to TEM diagnostics
+    uzm.attrs['long_name'] = 'Zonal-Mean zonal wind'
+    uzm.attrs['units'] = 'm/s'
+
+    vzm.attrs['long_name'] = 'Zonal-Mean meridional wind'
+    vzm.attrs['units'] = 'm/s'
+
+    epfy.attrs['long_name'] = 'northward component of E-P flux'
+    epfy.attrs['units'] = 'm3/s2'
+    
+    epfz.attrs['long_name'] = 'upward component of E-P flux'
+    epfz.attrs['units'] = 'm3/s2'
+
+    vtem.attrs['long_name'] = 'Transformed Eulerian mean northward wind'
+    vtem.attrs['units'] = 'm/s'
+    
+    wtem.attrs['long_name'] = 'Transformed Eulerian mean upward wind'
+    wtem.attrs['units'] = 'm/s'
+    
+    psitem.attrs['long_name'] = 'Transformed Eulerian mean mass stream function'
+    psitem.attrs['units'] = 'kg/s'
+    
+    utendepfd.attrs['long_name'] = 'tendency of eastward wind due to Eliassen-Palm flux divergence'
+    utendepfd.attrs['units'] = 'm/s2'
+    
+    utendvtem.attrs['long_name'] = 'tendency of eastward wind due to TEM northward wind advection and the coriolis term'
+    utendvtem.attrs['units'] = 'm/s2'
+    
+    utendwtem.attrs['long_name'] = 'tendency of eastward wind due to TEM upward wind advection'
+    utendwtem.attrs['units'] = 'm/s2'
+ 
+    epfy.values = np.float32(epfy.values)
+    epfz.values = np.float32(epfz.values)
+    wtem.values = np.float32(wtem.values)
+    psitem.values = np.float32(psitem.values)
+    utendepfd.values = np.float32(utendepfd.values)
+    utendvtem.values = np.float32(utendvtem.values)
+    utendwtem.values = np.float32(utendwtem.values)
+
+    dstem = xr.Dataset(data_vars=dict(date = ds.date,
+                                      datesec = ds.datesec,
+                                      time_bnds = ds.time_bnds,
+                                      uzm = uzm,
+                                      vzm = vzm, 
+                                      epfy = epfy,
+                                      epfz = epfz,
+                                      vtem = vtem,
+                                      wtem = wtem,
+                                      psitem = psitem,
+                                      utendepfd = utendepfd,
+                                      utendvtem = utendvtem,
+                                      utendwtem = utendwtem
+                                      )) 
+    
+    return dstem

--- a/scripts/plotting/tem.py
+++ b/scripts/plotting/tem.py
@@ -75,8 +75,13 @@ def tem(adf):
     #Grab TEM diagnostics options
     tem_opts = adf.read_config_var("tem_info")
 
+    if not tem_opts:
+        print("\n  No TEM options provided, skipping TEM plots." \
+        "\nSee documentation or config_cam_baseline_example.yaml for options to add to configuration file.")
+        return
+
     #Location of saved TEM netCDF files
-    tem_loc = tem_opts["tem_loc"]
+    tem_loc = tem_opts.get("tem_loc")
 
     #If path not specified, skip TEM calculation
     if tem_loc is None:

--- a/scripts/plotting/tem.py
+++ b/scripts/plotting/tem.py
@@ -1,0 +1,439 @@
+#Import standard modules:
+from pathlib import Path
+import numpy as np
+import xarray as xr
+import warnings  # use to warn user about missing files.
+import matplotlib.pyplot as plt
+import pandas as pd
+
+#Format warning messages:
+def my_formatwarning(msg, *args, **kwargs):
+    # ignore everything except the message
+    return str(msg) + '\n'
+warnings.formatwarning = my_formatwarning
+
+def tem(adf):
+    """
+    Plot the contents of the TEM dignostic ouput of 2-D latitude vs vertical pressure maps.
+    
+    Steps:
+     - loop through TEM variables
+     - calculate all-time fields (from individual months)
+     - Take difference, calculate statistics
+     - make plot
+
+    """
+
+    #Special ADF variable which contains the output paths for
+    #all generated plots and tables for each case:
+    plot_location = Path(adf.plot_location[0])
+
+    #Check if plot output directory exists, and if not, then create it:
+    if not plot_location.is_dir():
+        print("    {} not found, making new directory".format(plot_location))
+        plot_location.mkdir(parents=True)
+
+    #CAM simulation variables (this is always assumed to be a list):
+    case_names = adf.get_cam_info("cam_case_name", required=True)
+
+    res = adf.variable_defaults # will be dict of variable-specific plot preferences
+    # or an empty dictionary if use_defaults was not specified in YAML.
+
+    #Check if comparing against observations
+    if adf.get_basic_info("compare_obs"):
+        obs = True
+        base_name = "Obs"
+
+    else:
+        obs = False
+        base_name = adf.get_baseline_info("cam_case_name", required=True) # does not get used, is just here as a placemarker
+    #End if
+
+    #Extract test case years
+    syear_cases = adf.climo_yrs["syears"]
+    eyear_cases = adf.climo_yrs["eyears"]
+
+    #Extract baseline years (which may be empty strings if using Obs):
+    syear_baseline = adf.climo_yrs["syear_baseline"]
+    eyear_baseline = adf.climo_yrs["eyear_baseline"]
+
+    #Grab all case nickname(s)
+    test_nicknames = adf.case_nicknames["test_nicknames"]
+    base_nickname = adf.case_nicknames["base_nickname"]
+    case_nicknames = test_nicknames + [base_nickname]
+ 
+    #Set plot file type:
+    # -- this should be set in basic_info_dict, but is not required
+    # -- So check for it, and default to png
+    basic_info_dict = adf.read_config_var("diag_basic_info")
+    plot_type = basic_info_dict.get('plot_type', 'png')
+    print(f"\t NOTE: Plot type is set to {plot_type}")
+
+    # check if existing plots need to be redone
+    redo_plot = adf.get_basic_info('redo_plot')
+    print(f"\t NOTE: redo_plot is set to {redo_plot}")
+    #-----------------------------------------
+
+    #Location to saved TEM netCDF files
+    tem_loc = adf.get_basic_info("tem_loc")
+
+    #If path not specified, skip TEM calculation
+    if tem_loc is None:
+        return
+    else:
+        #Notify user that script has started:
+        print("\n  Generating TEM plots...")
+    
+    #Set seasonal ranges:
+    seasons = {"ANN": np.arange(1,13,1),
+               "DJF": [12, 1, 2],
+               "JJA": [6, 7, 8],
+               "MAM": [3, 4, 5],
+               "SON": [9, 10, 11]
+               }
+
+    #Suggestion from Rolando, if QBO is being produced, add utendvtem and utendwtem?
+    if "qbo" in adf._AdfDiag__plotting_scripts:
+        var_list = ['uzm','epfy','epfz','vtem','wtem',
+                    'psitem','utendepfd','utendvtem','utendwtem']
+    #Otherwise keep it simple
+    else:
+        var_list = ['uzm','epfy','epfz','vtem','wtem','psitem','utendepfd']
+
+    #Check if comparing against obs
+    #If so, create the obs TEM netCDF file
+    if adf.get_basic_info("compare_obs"):
+
+        #Create TEM file for observations
+        input_loc_idx = Path(tem_loc) / base_name
+        tem_base = input_loc_idx / f'{base_name}.TEMdiag.nc'
+        ds_base = xr.open_dataset(tem_base)
+
+    else:
+        #Open the baseline TEM file, if it exists
+        input_loc_idx = Path(tem_loc) / base_name
+        tem_base = input_loc_idx / f'{base_name}.TEMdiag_{syear_baseline}-{eyear_baseline}.nc'
+        ds_base = xr.open_dataset(tem_base)
+
+    #Setup TEM plots
+    nrows = len(var_list)
+    ncols = len(case_nicknames)+1
+    fig_width = 20
+
+    #try and dynamically create size of fig based off number of cases
+    fig_height = 15+(ncols*nrows)
+
+    #Loop over season dictionary:
+    for s in seasons:
+        #Location to save plots
+        plot_name = plot_location / f"{s}_TEM_Mean.png"
+        
+        fig, axs = plt.subplots(nrows=nrows, ncols=ncols, figsize=(fig_width,fig_height),
+                                facecolor='w', edgecolor='k')
+
+        #Loop over model cases:
+        for idx,case_name in enumerate(case_names):
+
+            #Extract start and end year values:
+            start_year = syear_cases[idx]
+            end_year   = eyear_cases[idx]
+
+            #Open the TEM file
+            output_loc_idx = Path(tem_loc) / case_name
+            tem = output_loc_idx / f'{case_name}.TEMdiag_{start_year}-{end_year}.nc'
+
+            #Grab the data for the TEM netCDF files
+            ds = xr.open_dataset(tem)
+
+            #Setup and plot the sub-plots
+            tem_plot(ds, ds_base, case_nicknames, axs, s, var_list, res, obs)
+
+        #Set figure title
+        yrs = f"{syear_cases[idx]} - {eyear_cases[idx]}"
+
+        plt.suptitle(f'TEM Diagnostics: {s}', fontsize=20, y=.928)
+        plt.text(x=0.5, y=0.915, s= f"yrs: {yrs}", fontsize=16, ha="center", transform=fig.transFigure)
+
+        #Write the figure to provided workspace/file:
+        fig.savefig(plot_name, bbox_inches='tight', dpi=300)
+
+        #Add plot to website (if enabled):
+        adf.add_website_data(plot_name, "TEM", case_name, season=s)
+
+# Helper functions
+##################
+
+def tem_plot(ds, ds_base, case_names, axs, s, var_list, res, obs):
+    """
+    TEM subplots
+    
+    """
+    #Set empty message for comparison of cases with different vertical levels
+    #TODO: Work towards getting the vertical and horizontal interpolations!! - JR
+    empty_message = "These have different vertical levels\nCan't compare cases currently"
+    props = {'boxstyle': 'round', 'facecolor': 'wheat', 'alpha': 0.9}
+    prop_x = 0.18
+    prop_y = 0.42
+
+    for var in var_list:
+        #Grab variable defaults for this variable
+        vres = res[var]
+
+        #Gather data for both cases
+        mdata = ds[var].squeeze()
+        odata = ds_base[var].squeeze()
+
+        #Create array to avoid weighting missing values:
+        md_ones = xr.where(mdata.isnull(), 0.0, 1.0)
+        od_ones = xr.where(odata.isnull(), 0.0, 1.0)
+
+        month_length = mdata.time.dt.days_in_month
+        weights = (month_length.groupby("time.season") / month_length.groupby("time.season").sum())
+
+        #Calculate monthly-weighted seasonal averages:
+        if s == 'ANN':
+
+            #Calculate annual weights (i.e. don't group by season):
+            weights_ann = month_length / month_length.sum()
+
+            mseasons = (mdata * weights_ann).sum(dim='time')
+            mseasons = mseasons / (md_ones*weights_ann).sum(dim='time')
+
+            #Calculate monthly weights based on number of days:
+            if obs:
+                month_length_obs = odata.time.dt.days_in_month
+                weights_ann_obs = month_length_obs / month_length_obs.sum()
+                oseasons = (odata * weights_ann_obs).sum(dim='time')
+                oseasons = oseasons / (od_ones*weights_ann_obs).sum(dim='time')
+            else:
+                oseasons = (odata * weights_ann).sum(dim='time')
+                oseasons = oseasons / (od_ones*weights_ann).sum(dim='time')
+
+        else:
+            #this is inefficient because we do same calc over and over
+            mseasons = (mdata * weights).groupby("time.season").sum(dim="time").sel(season=s)
+            wgt_denom = (md_ones*weights).groupby("time.season").sum(dim="time").sel(season=s)
+            mseasons = mseasons / wgt_denom
+
+            if obs:
+                month_length_obs = odata.time.dt.days_in_month
+                weights_obs = (month_length_obs.groupby("time.season") / month_length_obs.groupby("time.season").sum())
+                oseasons = (odata * weights_obs).groupby("time.season").sum(dim="time").sel(season=s)
+                wgt_denom = (od_ones*weights_obs).groupby("time.season").sum(dim="time").sel(season=s)
+                oseasons = oseasons / wgt_denom
+            else:
+                oseasons = (odata * weights).groupby("time.season").sum(dim="time").sel(season=s)
+                wgt_denom = (od_ones*weights).groupby("time.season").sum(dim="time").sel(season=s)
+                oseasons = oseasons / wgt_denom
+
+        #difference: each entry should be (lat, lon)
+        dseasons = mseasons-oseasons
+
+        #Run through variables and plot each against the baseline on each row
+        #Each column will be a case, ie (test, base, difference)
+
+        # uzm
+        #------------------------------------------------------------------------------------------
+        if var == "uzm":
+            mseasons.plot(ax=axs[0,0], y='lev', yscale='log',ylim=[1e3,1],
+                                    cbar_kwargs={'label': ds[var].units})
+
+            oseasons.plot(ax=axs[0,1], y='lev', yscale='log',ylim=[1e3,1],
+                                    cbar_kwargs={'label': ds[var].units})
+
+            #Check if difference plot has contour levels, if not print notification
+            if len(dseasons.lev) == 0:
+                axs[0,2].text(prop_x, prop_y, empty_message, transform=axs[0,2].transAxes, bbox=props)
+            else:
+                dseasons.plot(ax=axs[0,2], y='lev', yscale='log', ylim=[1e3,1],cmap="BrBG",
+                                    cbar_kwargs={'label': ds[var].units})
+
+        # epfy
+        #------------------------------------------------------------------------------------------
+        if var == "epfy":
+            mseasons.plot(ax=axs[1,0], y='lev', yscale='log',vmax=1e6,ylim=[1e2,1],
+                                    cbar_kwargs={'label': ds[var].units})
+
+            oseasons.plot(ax=axs[1,1], y='lev', yscale='log',vmax=1e6,ylim=[1e2,1],
+                                    cbar_kwargs={'label': ds[var].units})
+
+            #Check if difference plot has contour levels, if not print notification
+            if len(dseasons.lev) == 0:
+                axs[1,2].text(prop_x, prop_y, empty_message, transform=axs[1,2].transAxes, bbox=props)
+            else:
+                dseasons.plot(ax=axs[1,2], y='lev', yscale='log', vmax=1e6,
+                            ylim=[1e2,1],cmap="BrBG",
+                                    cbar_kwargs={'label': ds[var].units})
+        
+        # epfz
+        #------------------------------------------------------------------------------------------
+        if var == "epfz":
+            mseasons.plot(ax=axs[2,0], y='lev', yscale='log',vmax=1e5,ylim=[1e2,1],
+                                    cbar_kwargs={'label': ds[var].units})
+
+            oseasons.plot(ax=axs[2,1], y='lev', yscale='log',vmax=1e5,ylim=[1e2,1],
+                                    cbar_kwargs={'label': ds[var].units})
+
+            #Check if difference plot has contour levels, if not print notification
+            if len(dseasons.lev) == 0:
+                axs[2,2].text(prop_x, prop_y, empty_message, transform=axs[2,2].transAxes, bbox=props)
+            else:
+                dseasons.plot(ax=axs[2,2], y='lev', yscale='log', vmax=1e5,
+                            ylim=[1e2,1],cmap="BrBG",
+                                    cbar_kwargs={'label': ds[var].units})
+
+        # vtem
+        #------------------------------------------------------------------------------------------
+        if var == "vtem":
+            mseasons.plot.contourf(ax=axs[3,0], levels = 21, y='lev', yscale='log',
+                                                vmax=3,vmin=-3,ylim=[1e2,1], cmap='RdBu_r',
+                                                cbar_kwargs={'label': ds[var].units})
+            mseasons.plot.contour(ax=axs[3,0], levels = 11, y='lev', yscale='log',
+                                                vmax=3,vmin=-3,ylim=[1e2,1],
+                                                colors='black', linestyles=None)
+
+            oseasons.plot.contourf(ax=axs[3,1], levels = 21, y='lev', yscale='log',
+                                                vmax=3,vmin=-3,ylim=[1e2,1], cmap='RdBu_r',
+                                                cbar_kwargs={'label': ds[var].units})
+            oseasons.plot.contour(ax=axs[3,1], levels = 11, y='lev', yscale='log',
+                                                vmax=3,vmin=-3,ylim=[1e2,1],
+                                                colors='black', linestyles=None)
+
+            #Check if difference plot has contour levels, if not print notification
+            if len(dseasons.lev) == 0:
+                axs[3,2].text(prop_x, prop_y, empty_message, transform=axs[3,2].transAxes, bbox=props)
+            else:
+                dseasons.plot(ax=axs[3,2], y='lev', yscale='log', vmax=3,vmin=-3,
+                            ylim=[1e2,1],cmap="BrBG",
+                                    cbar_kwargs={'label': ds[var].units})
+
+        # wtem
+        #------------------------------------------------------------------------------------------
+        if var == "wtem":
+            mseasons.plot.contourf(ax=axs[4,0], levels = 21, y='lev', yscale='log',
+                                                vmax=0.005, vmin=-0.005, ylim=[1e2,1], cmap='RdBu_r',
+                                                cbar_kwargs={'label': ds[var].units})
+            mseasons.plot.contour(ax=axs[4,0], levels = 7, y='lev', yscale='log',
+                                            vmax=0.03, vmin=-0.03, ylim=[1e2,1],
+                                            colors='black', linestyles=None)
+
+            oseasons.plot.contourf(ax=axs[4,1], levels = 21, y='lev', yscale='log',
+                                                vmax=0.005, vmin=-0.005, ylim=[1e2,1], cmap='RdBu_r',
+                                                cbar_kwargs={'label': ds[var].units})
+            oseasons.plot.contour(ax=axs[4,1], levels = 7, y='lev', yscale='log',
+                                            vmax=0.03, vmin=-0.03, ylim=[1e2,1],
+                                            colors='black', linestyles=None)
+
+            #Check if difference plot has contour levels, if not print notification
+            if len(dseasons.lev) == 0:
+                axs[4,2].text(prop_x, prop_y, empty_message, transform=axs[4,2].transAxes, bbox=props)
+            else:
+                dseasons.plot(ax=axs[4,2], y='lev', yscale='log',vmax=0.005, vmin=-0.005,
+                            ylim=[1e2,1],cmap="BrBG",
+                                    cbar_kwargs={'label': ds[var].units})
+
+        # psitem
+        #------------------------------------------------------------------------------------------
+        if var == "psitem":
+            mseasons.plot.contourf(ax=axs[5,0], levels = 21, y='lev', yscale='log',
+                                                vmax=5e9, ylim=[1e2,2],
+                                                cbar_kwargs={'label': ds[var].units})
+
+            oseasons.plot.contourf(ax=axs[5,1], levels = 21, y='lev', yscale='log',
+                                                vmax=5e9, ylim=[1e2,2],
+                                                cbar_kwargs={'label': ds[var].units})
+
+            #Check if difference plot has contour levels, if not print notification
+            if len(dseasons.lev) == 0:
+                axs[5,2].text(prop_x, prop_y, empty_message, transform=axs[5,2].transAxes, bbox=props)
+            else:
+                dseasons.plot(ax=axs[5,2], y='lev', yscale='log',vmax=5e9,
+                                    ylim=[1e2,2],cmap="BrBG",
+                                    cbar_kwargs={'label': ds[var].units})
+
+        # utendepfd
+        #------------------------------------------------------------------------------------------
+        if var == "utendepfd":
+            mseasons.plot(ax=axs[6,0], y='lev', yscale='log',
+                                            vmax=0.0001, vmin=-0.0001, ylim=[1e2,2],
+                                            cbar_kwargs={'label': ds[var].units})
+
+            oseasons.plot(ax=axs[6,1], y='lev', yscale='log',
+                                            vmax=0.0001, vmin=-0.0001, ylim=[1e2,2],
+                                            cbar_kwargs={'label': ds[var].units})
+
+            #Check if difference plot has contour levels, if not print notification
+            if len(dseasons.lev) == 0:
+                axs[6,2].text(prop_x, prop_y, empty_message, transform=axs[6,2].transAxes, bbox=props)
+            else:
+                dseasons.plot(ax=axs[6,2], y='lev', yscale='log',vmax=0.0001, vmin=-0.0001,
+                                    ylim=[1e2,2],cmap="BrBG",
+                                    cbar_kwargs={'label': ds[var].units})
+
+        # utendvtem
+        #------------------------------------------------------------------------------------------
+        if var == "utendvtem":
+            mseasons.plot(ax=axs[7,0], y='lev', yscale='log',vmax=0.001, ylim=[1e3,1],
+                                            cbar_kwargs={'label': ds[var].units})
+
+            oseasons.plot(ax=axs[7,1], y='lev', yscale='log',vmax=0.001, ylim=[1e3,1],
+                                            cbar_kwargs={'label': ds[var].units})
+
+            #Check if difference plot has contour levels, if not print notification
+            if len(dseasons.lev) == 0:
+                axs[7,2].text(prop_x, prop_y, empty_message, transform=axs[7,2].transAxes, bbox=props)
+            else:
+                dseasons.plot(ax=axs[7,2], y='lev', yscale='log', vmax=0.001, ylim=[1e3,1],cmap="BrBG",
+                                    cbar_kwargs={'label': ds[var].units})
+
+        # utendwtem
+        #------------------------------------------------------------------------------------------
+        if var == "utendwtem":
+            mseasons.plot(ax=axs[8,0], y='lev', yscale='log',vmax=0.0001, ylim=[1e3,1],
+                                            cbar_kwargs={'label': ds[var].units})
+
+            oseasons.plot(ax=axs[8,1], y='lev', yscale='log',vmax=0.0001, ylim=[1e3,1],
+                                            cbar_kwargs={'label': ds[var].units})
+
+            #Check if difference plot has contour levels, if not print notification
+            if len(dseasons.lev) == 0:
+                axs[8,2].text(prop_x, prop_y, empty_message, transform=axs[8,2].transAxes, bbox=props)
+            else:
+                dseasons.plot(ax=axs[8,2], y='lev', yscale='log', vmax=0.0001, ylim=[1e3,1],cmap="BrBG",
+                                    cbar_kwargs={'label': ds[var].units})
+
+    # Set the ticks and ticklabels for all x-axes
+    #NOTE: This has to come after all subplots have been done,
+    #I am assuming this is because of the way xarray plots info automatically for labels and titles
+    #This is to change the default xarray labels for each instance of the xarray plot method
+    plt.setp(axs, xticks=np.arange(-80,81,20), xlabel='latitude', title="")
+
+    #Set titles of subplots
+    #Set case names in first subplot only
+    uzm = ds["uzm"].long_name.replace(" ", "\ ")
+    axs[0,0].set_title(f"\n\n"+"$\mathbf{Test}$\n"+f"{case_names[0]}\n\n\n",fontsize=14)
+
+    if obs:
+        obs_title = Path(vres["obs_name"]).stem
+        axs[0,1].set_title(f"\n\n"+"$\mathbf{Baseline}$\n"+f"{obs_title}\n\n"+"$\mathbf{"+uzm+"}$"+"\n",fontsize=14)
+
+    else:
+        axs[0,1].set_title(f"\n\n"+"$\mathbf{Baseline}$\n"+f"{case_names[1]}\n\n"+"$\mathbf{"+uzm+"}$"+"\n",fontsize=14)
+    
+    #Set main title for difference plots column
+    axs[0,2].set_title("$\mathbf{Test} - \mathbf{Baseline}$"+"\n\n\n",fontsize=14)
+    
+    #Set variable name on center plot (except first plot, see above)
+    for i in range(1,len(var_list)):
+        var_name = ds[var_list[i]].long_name.replace(" ", "\ ")
+        axs[i,1].set_title("$\mathbf{"+var_name+"}$"+"\n",fontsize=14)
+    
+    #Adjust subplots
+    #May need to adjust hspace and wspace depending on if multi-case diagnostics ever happen for TEM diags
+    hspace = 0.4
+    plt.subplots_adjust(wspace=0.5, hspace=hspace)
+
+    return axs
+
+##############
+#END OF SCRIPT

--- a/scripts/plotting/tem.py
+++ b/scripts/plotting/tem.py
@@ -107,19 +107,26 @@ def tem(adf):
     else:
         var_list = ['uzm','epfy','epfz','vtem','wtem','psitem','utendepfd']
 
-    #Check if comparing against obs
-    #If so, create the obs TEM netCDF file
-    if obs:
-        #Create TEM file for observations
-        input_loc_idx = Path(tem_loc) / base_name
-        tem_base = input_loc_idx / f'{base_name}.TEMdiag.nc'
-        ds_base = xr.open_dataset(tem_base)
+    #Baseline TEM location
+    input_loc_idx = Path(tem_loc) / base_name
 
+    #Check if comparing against obs
+    if obs:
+        #Set TEM file for observations
+        base_file_name = f'{base_name}.TEMdiag.nc'
     else:
-        #Open the baseline TEM file, if it exists
-        input_loc_idx = Path(tem_loc) / base_name
-        tem_base = input_loc_idx / f'{base_name}.TEMdiag_{syear_baseline}-{eyear_baseline}.nc'
+        #Set TEM file for baseline
+        base_file_name = f'{base_name}.TEMdiag_{syear_baseline}-{eyear_baseline}.nc'
+    
+    #Set full path for baseline/obs file
+    tem_base = input_loc_idx / base_file_name
+
+    #Check to see if baseline/obs TEM file exists    
+    if tem_base.is_file():
         ds_base = xr.open_dataset(tem_base)
+    else:
+        print(f"\t'{base_file_name}' does not exist. TEM plots will be skipped.")
+        return
 
     #Setup TEM plots
     nrows = len(var_list)
@@ -156,10 +163,15 @@ def tem(adf):
 
             #Open the TEM file
             output_loc_idx = Path(tem_loc) / case_name
-            tem = output_loc_idx / f'{case_name}.TEMdiag_{start_year}-{end_year}.nc'
+            case_file_name = f'{case_name}.TEMdiag_{start_year}-{end_year}.nc'
+            tem = output_loc_idx / case_file_name
 
             #Grab the data for the TEM netCDF files
-            ds = xr.open_dataset(tem)
+            if tem.is_file():
+                ds = xr.open_dataset(tem)
+            else:
+                print(f"\t'{case_file_name}' does not exist. TEM plots will be skipped.")
+                return
 
             climo_yrs = {"test":[syear_cases[idx], eyear_cases[idx]],
                          "base":[syear_baseline, eyear_baseline]}


### PR DESCRIPTION
This will calculate TEM files and plots for:
* uzm - Zonal-Mean zonal wind
* epfy - northward component of the Eliassen–Palm flux
* epfz - upward component of the Eliassen–Palm flux
* vtem - Transformed Eulerian mean northward wind
* wtem - Transformed Eulerian mean upward wind
* psitem - Transformed Eulerian mean mass stream function
* utendepfd - tendency of eastward wind due to Eliassen-Palm flux divergence
* utendvtem - tendency of eastward wind due to TEM northward wind advection and the coriolis term
* utendwtem - tendency of eastward wind due to TEM upward wind advection

There are two scripts being added, `scripts/averaging/create_TEM_files.py` for reading in h4 history files, calculating TEM variables and creating new netcdf files. And `scripts/plotting/tem.py` for reading in either the newly created netcdf files, or existing TEM netcdf files and plotting.

Update `adf_variable_defaults.yaml` with TEM variables, including Obs files and variable names.

Update `config_cam_baseline_example.yaml` for TEM scripts

NOTE: If QBO is present, all variables will be calculated, if not, only `uzm` `epfy` `epfz` `vtem` `wtem` `psitem` and `utendepfd` will be calculated.

NOTE: If there are different vertical levels between cases, currently the difference plots don't work. I am working towards a vertical and horizontal interpolation for TEM as noted in issue #225 