### PR TITLE
Add Tape Recorder plots for Q

### DIFF
--- a/config_amwg_default_plots.yaml
+++ b/config_amwg_default_plots.yaml
@@ -297,6 +297,7 @@ plotting_scripts:
     - zonal_mean
     - polar_map
     - cam_taylor_diagram
+    #- tape_recorder
     #- tem #To plot TEM, please un-comment fill-out
                               #the "tem_info" section below
     #- regional_map_multicase #To use this please un-comment and fill-out

--- a/config_cam_baseline_example.yaml
+++ b/config_cam_baseline_example.yaml
@@ -363,6 +363,7 @@ plotting_scripts:
     - polar_map
     - cam_taylor_diagram
     - qbo
+    #- tape_recorder
     #- tem #To plot TEM, please un-comment fill-out
                               #the "tem_info" section below
     #- regional_map_multicase #To use this please un-comment and fill-out

--- a/lib/adf_web.py
+++ b/lib/adf_web.py
@@ -422,6 +422,9 @@ class AdfWeb(AdfObs):
         #Set main title for website:
         main_title = "CAM Diagnostics"
 
+        #List of seasons
+        seasons = ["ANN","DJF","MAM","JJA","SON"]
+
         #Determine local directory:
         adf_lib_dir = Path(__file__).parent
 
@@ -589,7 +592,6 @@ class AdfWeb(AdfObs):
                 #Check if the mean plot type page exists for this case (or for multi-case):
                 mean_table_file = table_pages_dir / "mean_tables.html"
                 if not mean_table_file.exists():
-
                     #Construct mean_table.html
                     mean_table_tmpl = jinenv.get_template('template_mean_tables.html')
                     mean_table_rndr = mean_table_tmpl.render(title=main_title,
@@ -613,7 +615,6 @@ class AdfWeb(AdfObs):
                 img_pages_dir = self.__case_web_paths[web_data.case]['img_pages_dir']
                 img_data = [os.path.relpath(web_data.asset_path, start=img_pages_dir),
                             web_data.asset_path.stem]
-
                 #Check if plot image already handles multiple cases:
                 if web_data.multi_case:
                     case1 = "Listed in plots."
@@ -622,7 +623,6 @@ class AdfWeb(AdfObs):
                     case1 = web_data.case
                     plot_types = plot_type_html
                 #End if
-
                 tmpl = jinenv.get_template('template.html')  #Set template
                 rndr = tmpl.render(title=main_title,
                                    var_title=web_data.name,
@@ -634,7 +634,8 @@ class AdfWeb(AdfObs):
                                    case_yrs=case_yrs,
                                    baseline_yrs=baseline_yrs,
                                    mydata=mean_html_info[web_data.plot_type],
-                                   plot_types=plot_types) #The template rendered
+                                   plot_types=plot_types,
+                                   seasons=seasons) #The template rendered
 
                 #Write HTML file:
                 with open(web_data.html_file, 'w', encoding='utf-8') as ofil:
@@ -644,7 +645,6 @@ class AdfWeb(AdfObs):
                 #Check if the mean plot type page exists for this case:
                 mean_ptype_file = img_pages_dir / f"mean_diag_{web_data.plot_type}.html"
                 if not mean_ptype_file.exists():
-
                     #Construct individual plot type mean_diag html files, if they don't
                     #already exist:
                     mean_tmpl = jinenv.get_template('template_mean_diag.html')
@@ -680,7 +680,8 @@ class AdfWeb(AdfObs):
                                                  baseline_yrs=baseline_yrs,
                                                  mydata=mean_html_info[web_data.plot_type],
                                                  curr_type=web_data.plot_type,
-                                                 plot_types=plot_types)
+                                                 plot_types=plot_types,
+                                                 seasons=seasons)
 
                     #Write mean diagnostic plots HTML file:
                     with open(mean_ptype_plot_page,'w', encoding='utf-8') as ofil:

--- a/lib/website_templates/adf_diag.css
+++ b/lib/website_templates/adf_diag.css
@@ -65,6 +65,10 @@ a {
   text-decoration: none;
   color: navy;
 }
+a-blocked {
+  text-decoration: none;
+  color: black;
+}
 a:visited {
   color: rgb(77, 6, 18);
 }
@@ -143,6 +147,14 @@ table.dataframe td {
 
 .grid-item {
   background-color: rgba(255, 255, 255, 0.6);
+  border: 1px solid rgba(0, 0, 0, 0.8);
+  padding: 10px;
+  font-size: 16px;
+  text-align: center;
+}
+
+.grid-item-blocked {
+  background-color: rgba(192, 192, 192, 0.6);
   border: 1px solid rgba(0, 0, 0, 0.8);
   padding: 10px;
   font-size: 16px;

--- a/lib/website_templates/template.html
+++ b/lib/website_templates/template.html
@@ -1,5 +1,3 @@
-
-
 <!DOCTYPE html>
 <html>
   <head>
@@ -55,11 +53,19 @@
         {% for category, var_seas in mydata.items() %}
         {% for var_name, seas_files in var_seas.items() %}
         {% if var_name == var_title %}
-        {% for season_name, file_name in seas_files.items() %}
+        {% for season in seasons %}
+
+        {% if season in seas_files.keys() %}
         <div class="grid-item">
-          <a href="../html_img/{{ file_name }}">{{ season_name }}</a>
+          <a href="../html_img/{{ seas_files[season] }}">{{ season }}</a>
         </div><!--grid-item-->
-        {% endfor %}
+        {% else %}
+        <div class="grid-item-blocked">
+          <a-blocked>{{ season }}</a-blocked>
+        </div><!--grid-item-blocked-->
+        {% endif %}
+
+        {% endfor %}<!--seasons-->
         {% endif %}
         {% endfor %}
         {% endfor %}

--- a/lib/website_templates/template_var.html
+++ b/lib/website_templates/template_var.html
@@ -53,11 +53,19 @@
         {% for category, var_seas in mydata.items() %}
         {% for var_name, seas_files in var_seas.items() %}
         {% if var_name == var_title %}
-        {% for season_name, file_name in seas_files.items() %}
+        {% for season in seasons %}
+
+        {% if season in seas_files.keys() %}
         <div class="grid-item">
-          <a href="../html_img/{{ file_name }}">{{ season_name }}</a>
+          <a href="../html_img/{{ seas_files[season] }}">{{ season }}</a>
         </div><!--grid-item-->
-        {% endfor %}
+        {% else %}
+        <div class="grid-item-blocked ">
+          <a-blocked>{{ season }}</a-blocked>
+        </div><!--grid-item-blocked-->
+        {% endif %}
+
+        {% endfor %}<!--seasons-->
         {% endif %}
         {% endfor %}
         {% endfor %}

--- a/scripts/plotting/cam_taylor_diagram.py
+++ b/scripts/plotting/cam_taylor_diagram.py
@@ -151,6 +151,7 @@ def cam_taylor_diagram(adfobj):
         # Check redo_plot. If set to True: remove old plot, if it already exists:
         if (not redo_plot) and plot_name.is_file():
             #Add already-existing plot to website (if enabled):
+            adfobj.debug_log(f"'{plot_name}' exists and clobber is false.")
             adfobj.add_website_data(plot_name, "TaylorDiag", None, season=s, multi_case=True)
 
             #Continue to next iteration:

--- a/scripts/plotting/global_latlon_map.py
+++ b/scripts/plotting/global_latlon_map.py
@@ -329,6 +329,7 @@ def global_latlon_map(adfobj):
                             # Check redo_plot. If set to True: remove old plot, if it already exists:
                             if (not redo_plot) and plot_name.is_file():
                                 #Add already-existing plot to website (if enabled):
+                                adfobj.debug_log(f"'{plot_name}' exists and clobber is false.")
                                 adfobj.add_website_data(plot_name, var, case_name, category=web_category,
                                                         season=s, plot_type="LatLon")
 
@@ -421,6 +422,7 @@ def global_latlon_map(adfobj):
                                 redo_plot = adfobj.get_basic_info('redo_plot')
                                 if (not redo_plot) and plot_name.is_file():
                                     #Add already-existing plot to website (if enabled):
+                                    adfobj.debug_log(f"'{plot_name}' exists and clobber is false.")
                                     adfobj.add_website_data(plot_name, f"{var}_{pres}hpa", case_name, category=web_category,
                                                             season=s, plot_type="LatLon")
 

--- a/scripts/plotting/global_latlon_vect_map.py
+++ b/scripts/plotting/global_latlon_vect_map.py
@@ -387,6 +387,7 @@ def global_latlon_vect_map(adfobj):
                                 # Check redo_plot. If set to True: remove old plot, if it already exists:
                                 if (not redo_plot) and plot_name.is_file():
                                     #Add already-existing plot to website (if enabled):
+                                    adfobj.debug_log(f"'{plot_name}' exists and clobber is false.")
                                     adfobj.add_website_data(plot_name, f"{var_name}_{lv}hpa", case_name, category=web_category,
                                                             season=s, plot_type="LatLon_Vector")
 
@@ -440,6 +441,7 @@ def global_latlon_vect_map(adfobj):
                             redo_plot = adfobj.get_basic_info('redo_plot')
                             if (not redo_plot) and plot_name.is_file():
                                 #Add already-existing plot to website (if enabled):
+                                adfobj.debug_log(f"'{plot_name}' exists and clobber is false.")
                                 adfobj.add_website_data(plot_name, var_name, case_name, category=web_category,
                                                         season=s, plot_type="LatLon_Vector")
 

--- a/scripts/plotting/meridional_mean.py
+++ b/scripts/plotting/meridional_mean.py
@@ -221,6 +221,7 @@ def meridional_mean(adfobj):
                     # Check redo_plot. If set to True: remove old plot, if it already exists:
                     if (not redo_plot) and plot_name.is_file():
                         #Add already-existing plot to website (if enabled):
+                        adfobj.debug_log(f"'{plot_name}' exists and clobber is false.")
                         adfobj.add_website_data(plot_name, var, case_name, season=s,
                                                 plot_type="Meridional")
                         #Continue to next iteration:

--- a/scripts/plotting/polar_map.py
+++ b/scripts/plotting/polar_map.py
@@ -261,6 +261,7 @@ def polar_map(adfobj):
                                 # If redo_plot set to True: remove old plot, if it already exists:
                                 if (not redo_plot) and plot_name.is_file():
                                     #Add already-existing plot to website (if enabled):
+                                    adfobj.debug_log(f"'{plot_name}' exists and clobber is false.")
                                     adfobj.add_website_data(plot_name, var, case_name, category=web_category,
                                                             season=s, plot_type=hemi_type)
 
@@ -339,6 +340,7 @@ def polar_map(adfobj):
                                     # If redo_plot set to True: remove old plot, if it already exists:
                                     if (not redo_plot) and plot_name.is_file():
                                         #Add already-existing plot to website (if enabled):
+                                        adfobj.debug_log(f"'{plot_name}' exists and clobber is false.")
                                         adfobj.add_website_data(plot_name, f"{var}_{pres}hpa",
                                                                 case_name, category=web_category,
                                                                 season=s, plot_type=hemi_type)

--- a/scripts/plotting/qbo.py
+++ b/scripts/plotting/qbo.py
@@ -67,15 +67,10 @@ def qbo(adfobj):
     print(f"\t QBO plots will be saved here: {plot_locations[0]}")
 
     # Check redo_plot. If set to True: remove old plots, if they already exist:
-    if (not redo_plot) and plot_loc_ts.is_file():
+    if (not redo_plot) and plot_loc_ts.is_file() and plot_loc_amp.is_file():
         #Add already-existing plot to website (if enabled):
-        adfobj.debug_log(f"'{plot_loc_ts}' exists and clobber is false.")
+        adfobj.debug_log(f"'{plot_loc_ts}' and '{plot_loc_amp}' exist and clobber is false.")
         adfobj.add_website_data(plot_loc_ts, "QBO", None, season="QBOts", multi_case=True)
-        #Continue to next iteration:
-        return
-    if (not redo_plot) and plot_loc_amp.is_file():   
-        #Add already-existing plot to website (if enabled):
-        adfobj.debug_log(f"'{plot_loc_amp}' exists and clobber is false.")
         adfobj.add_website_data(plot_loc_amp, "QBO", None, season="QBOamp", multi_case=True)
         #Continue to next iteration:
         return

--- a/scripts/plotting/qbo.py
+++ b/scripts/plotting/qbo.py
@@ -28,7 +28,7 @@ def qbo(adfobj):
     Isla Simpson (islas@ucar.edu) 22nd March 2022
 
     """
- #Notify user that script has started:
+    #Notify user that script has started:
     print("\n  Generating qbo plots...")
 
     #Extract relevant info from the ADF:

--- a/scripts/plotting/qbo.py
+++ b/scripts/plotting/qbo.py
@@ -67,11 +67,16 @@ def qbo(adfobj):
     print(f"\t QBO plots will be saved here: {plot_locations[0]}")
 
     # Check redo_plot. If set to True: remove old plots, if they already exist:
-    if (not redo_plot) and plot_loc_ts.is_file() and plot_loc_amp.is_file():
+    if (not redo_plot) and plot_loc_ts.is_file():
         #Add already-existing plot to website (if enabled):
+        adfobj.debug_log(f"'{plot_loc_ts}' exists and clobber is false.")
         adfobj.add_website_data(plot_loc_ts, "QBO", None, season="QBOts", multi_case=True)
+        #Continue to next iteration:
+        return
+    if (not redo_plot) and plot_loc_amp.is_file():   
+        #Add already-existing plot to website (if enabled):
+        adfobj.debug_log(f"'{plot_loc_amp}' exists and clobber is false.")
         adfobj.add_website_data(plot_loc_amp, "QBO", None, season="QBOamp", multi_case=True)
-
         #Continue to next iteration:
         return
     elif (redo_plot):

--- a/scripts/plotting/tape_recorder.py
+++ b/scripts/plotting/tape_recorder.py
@@ -522,10 +522,10 @@ def plot_pre_mon(fig, data, pre, ci, cmin, cmax, expname, x1=None, x2=None, y1=N
             ax = fig.add_axes([x1, y1, x2-x1, y2-y1])
         else:
             ax = fig.add_axes()
+    ax.xaxis.set_label_position('top')
     if climo_yrs:
-        ax.set_title(f"\n{climo_yrs}", loc='right',
-                       fontsize=8)
-
+        ax.set_xlabel(f"{climo_yrs}", loc='center',
+                           fontsize=8)
     ax.contourf(monticks2, -np.log10(data[paxis]), dataplot, levels=clevs, cmap=mymap, extend='max')
     ax.set_ylim(-np.log10(100),-np.log10(3))
     ax.set_yticks([-np.log10(100),-np.log10(30),-np.log10(10),-np.log10(3)])

--- a/scripts/plotting/tape_recorder.py
+++ b/scripts/plotting/tape_recorder.py
@@ -210,7 +210,7 @@ def tape_recorder(adfobj):
     #Notify user that script has ended:
     print("  ...Tape recorder plots have been generated successfully.")
 
-    #End QBO plotting script:
+    #End tape recorder plotting script:
     return
 
 
@@ -438,7 +438,6 @@ def plotcolorbar(fig, ci, cmin, cmax, titlestr, x1, x2, y1, y2,
     clb.set_label(titlestr, fontsize=fsize+2)
 
     if (contourlines):
-        #clevlines = (clevs-ci/2.)*contourlinescale
         clevlines = clevs*contourlinescale
         clevlines = clevlines[np.abs(clevlines) > ci/2.]
         if (orient=='horizontal'):
@@ -521,6 +520,8 @@ def plot_pre_mon(fig, data, pre, ci, cmin, cmax, expname, x1=None, x2=None, y1=N
             ax = fig.add_axes([x1, y1, x2-x1, y2-y1])
         else:
             ax = fig.add_axes()
+
+    #Set up axis
     ax.xaxis.set_label_position('top')
     if climo_yrs:
         ax.set_xlabel(f"{climo_yrs}", loc='center',

--- a/scripts/plotting/tape_recorder.py
+++ b/scripts/plotting/tape_recorder.py
@@ -110,7 +110,7 @@ def tape_recorder(adfobj):
     mls['time'] = time
     mls = cosweightlat(mls.H2O,-10,10)
     mls = mls.groupby('time.month').mean('time')
-    # Convert values from < > to < >
+    # Convert mixing ratio values from ppmv to kg/kg
     mls = mls*18.015280/(1e6*28.964)
 
     # ERA5 data

--- a/scripts/plotting/tape_recorder.py
+++ b/scripts/plotting/tape_recorder.py
@@ -19,21 +19,29 @@ def tape_recorder(adfobj):
     MLS h2o data is for 09/2004-11/2021
     ERA5 Q data is for 01/1980-12/2020
 
+    Optional built-in colormaps:
+      - blue2red
+      - precip
+      - precip_nowhite -> default cmap
+      - red2blue
+
     NOTE: If the baseline case is observations, it will be ignored
         since a defualt set of obs are already being compared against in the tape recorder.
     """
     #Notify user that script has started:
     print("\n  Generating tape recorder plots...")
 
-    #Special ADF variable which contains the output paths for
-    # ADF variable which contains the output path for plots and tables:
+    #Special ADF variable which contains the output paths for plots:
     plot_location = adfobj.plot_location
     plot_loc = Path(plot_location[0])
 
+    #Grab test case name(s)
     case_names = adfobj.get_cam_info('cam_case_name', required=True)
 
+    #Grab test case time series locs(s)
     case_ts_locs = adfobj.get_cam_info("cam_ts_loc", required=True)
 
+    #Grab test case climo years
     start_years = adfobj.climo_yrs["syears"]
     end_years = adfobj.climo_yrs["eyears"]
 
@@ -47,6 +55,7 @@ def tape_recorder(adfobj):
     # Until those are both treated the same (via intake-esm or similar)
     # we will do a simple check and switch options as needed:
     if not adfobj.get_basic_info("compare_obs"):
+
         #Append all baseline objects to test case lists
         data_name = adfobj.get_baseline_info("cam_case_name", required=True)
         case_names = case_names + [data_name]
@@ -68,12 +77,6 @@ def tape_recorder(adfobj):
     # Default colormap
     cmap='precip_nowhite'
 
-    #Availaible cmaps are:
-    "blue2red"
-    "precip"
-    "precip_nowhite"
-    'red2blue'
-
     #Set plot file type:
     # -- this should be set in basic_info_dict, but is not required
     # -- So check for it, and default to png
@@ -93,12 +96,14 @@ def tape_recorder(adfobj):
     # Check redo_plot. If set to True: remove old plot, if it already exists:
     if (not redo_plot) and plot_name.is_file():
         #Add already-existing plot to website (if enabled):
+        adfobj.debug_log(f"'{plot_name}' exists and clobber is false.")
         adfobj.add_website_data(plot_name, "tape_recorder", None, season="ANN", multi_case=True)
         return
 
     elif (redo_plot) and plot_name.is_file():
         plot_name.unlink()
     
+    #Make dictionary for case names and associated timeseries file locations
     runs_LT2={}
     for i,val in enumerate(test_nicknames):
         runs_LT2[val] = case_ts_locs[i]

--- a/scripts/plotting/tape_recorder.py
+++ b/scripts/plotting/tape_recorder.py
@@ -25,15 +25,15 @@ import dask
 
 def tape_recorder(adfobj):
     """
-    Plot the values of Q against two sets of obseravations, MLS and ERA5, for the tropics
+    Calculate the weighted latitude average for the simulations and 
+    plot the values of Q against two sets of obseravations, MLS and ERA5, for the tropics
     between 10S and 10N.
 
     MLS h2o data is for 04/2009-11/2021
     ERA5 Q data is for 01/1980-12/2020
 
-    This will calculate the weighted latitude average for the simulations/baseline observations in the tropics.
-    NOTE: If the baseline case are observations and ERA5 is set for Q in the obs location, it will be ignored
-        since ERA5 is used as a defualt obs in the tape recorder.
+    NOTE: If the baseline case are observations, it will be ignored
+        since a defualt set of obs are already being compared against in the tape recorder.
     
     
     
@@ -83,8 +83,8 @@ def tape_recorder(adfobj):
     # Until those are both treated the same (via intake-esm or similar)
     # we will do a simple check and switch options as needed:
     if not adfobj.get_basic_info("compare_obs"):
-        data_name = adfobj.get_baseline_info("cam_case_name", required=True) # does not get used, is just here as a placemarker
-        data_list = [data_name] # gets used as just the name to search for climo files HAS TO BE LIST
+        data_name = adfobj.get_baseline_info("cam_case_name", required=True)
+        case_names = case_names + [data_name]
 
         #Grab baseline case nickname
         base_nickname = adfobj.get_baseline_info('case_nickname')
@@ -149,14 +149,13 @@ def tape_recorder(adfobj):
     plot_min = 1.5e-6
     plot_max = 3e-6
 
-    #1e-7,1.5e-6,3e-6
     ax = plot_pre_mon(fig, mls, mls.lev, plot_step,plot_min,plot_max,'MLS',
                       x1[0],x2[0],y1[0],y2[0],cmap=cmap, paxis='lev',
-                      taxis='month')
+                      taxis='month',climo_yrs="2009-2021")
 
     ax = plot_pre_mon(fig, era5.Q, era5.pre, plot_step,plot_min,plot_max,
                       'ERA5',x1[1],x2[1],y1[1],y2[1], cmap=cmap, paxis='pre',
-                      taxis='month')
+                      taxis='month',climo_yrs="1980-2020")
 
     #Start count at 2 to account for MLS and ERA5 plots above
     count=2
@@ -191,7 +190,7 @@ def tape_recorder(adfobj):
                       x1_loc, x2_loc, y1_loc, y2_loc,
                       cmap=cmap)
 
-    plot_name = plot_loc / f"TapeRecorder_ANN_Special_Mean.{plot_type}"
+    plot_name = plot_loc / f"Q_ANN_TapeRecorder_Mean.{plot_type}"
     print(f"\t - Plotting annual tape recorder for Q")
 
     # Check redo_plot. If set to True: remove old plot, if it already exists:
@@ -396,7 +395,7 @@ def plotcolorbar(fig, ci, cmin, cmax, titlestr, x1, x2, y1, y2,
            orient = the orientation (horizontal or vertical)
            posneg = if "both", both positive and negative sides are plotted
                     if "pos", only the positive side is plotted
-                    if "net", only the negative side is plotted
+                    if "neg", only the negative side is plotted
            ticks = user specified ticklabels
            fsize = user specified font size
            contourlines = used to overplot contour lines

--- a/scripts/plotting/tape_recorder.py
+++ b/scripts/plotting/tape_recorder.py
@@ -1,0 +1,543 @@
+import os.path
+import sys
+import glob
+from pathlib import Path
+
+# Import necessary packages for the new script
+import numpy as np
+import matplotlib.pyplot as plt
+from matplotlib.ticker import MultipleLocator
+from matplotlib.lines import Line2D
+
+import xarray as xr
+
+#
+# load libraries: ncar_pylib
+#
+import xarray as xr
+import numpy as np
+import matplotlib.pyplot as plt
+from math import nan
+import pandas as pd
+import sys
+
+import dask
+
+def tape_recorder(adfobj):
+    """
+    Plot the values of Q against two sets of obseravations, MLS and ERA5, for the tropics
+    between 10S and 10N.
+
+    MLS h2o data is for 04/2009-11/2021
+    ERA5 Q data is for 01/1980-12/2020
+
+    This will calculate the weighted latitude average for the simulations/baseline observations in the tropics.
+    NOTE: If the baseline case are observations and ERA5 is set for Q in the obs location, it will be ignored
+        since ERA5 is used as a defualt obs in the tape recorder.
+    
+    
+    
+    """
+    #Notify user that script has started:
+    print("\n  Generating tape recorder plots...")
+
+    #Special ADF variable which contains the output paths for
+    # ADF variable which contains the output path for plots and tables:
+    plot_location = adfobj.plot_location
+    if not plot_location:
+        plot_location = adfobj.get_basic_info("cam_diag_plot_loc")
+    if isinstance(plot_location, list):
+        for pl in plot_location:
+            plpth = Path(pl)
+            #Check if plot output directory exists, and if not, then create it:
+            if not plpth.is_dir():
+                print(f"\t    {pl} not found, making new directory")
+                plpth.mkdir(parents=True)
+        if len(plot_location) == 1:
+            plot_loc = Path(plot_location[0])
+        else:
+            print(f"Ambiguous plotting location since all cases go on same plot. Will put them in first location: {plot_location[0]}")
+            plot_loc = Path(plot_location[0])
+    else:
+        plot_loc = Path(plot_location)
+
+    case_names = adfobj.get_cam_info('cam_case_name', required=True)
+    data_name = adfobj.get_baseline_info('cam_case_name', required=False)
+
+    case_ts_locs = adfobj.get_cam_info("cam_ts_loc", required=True)
+    data_ts_loc = adfobj.get_baseline_info("cam_ts_loc", required=False)
+
+    start_years = adfobj.climo_yrs["syears"]
+    end_years = adfobj.climo_yrs["eyears"]
+
+    data_start_year = adfobj.climo_yrs["syear_baseline"]
+    data_end_year = adfobj.climo_yrs["eyear_baseline"]
+
+    #Grab test case nickname(s)
+    test_nicknames = adfobj.get_cam_info('case_nickname')
+    if test_nicknames == None:
+        test_nicknames = case_names
+
+    # CAUTION:
+    # "data" here refers to either obs or a baseline simulation,
+    # Until those are both treated the same (via intake-esm or similar)
+    # we will do a simple check and switch options as needed:
+    if not adfobj.get_basic_info("compare_obs"):
+        data_name = adfobj.get_baseline_info("cam_case_name", required=True) # does not get used, is just here as a placemarker
+        data_list = [data_name] # gets used as just the name to search for climo files HAS TO BE LIST
+
+        #Grab baseline case nickname
+        base_nickname = adfobj.get_baseline_info('case_nickname')
+        if base_nickname == None:
+            base_nickname = data_name
+        case_ts_locs = case_ts_locs+[data_ts_loc]
+        test_nicknames = test_nicknames+[base_nickname]
+        start_years = start_years+[data_start_year]
+        end_years = end_years+[data_end_year]
+    #End if
+    
+    # Default colormap
+    cmap='precip_nowhite'
+
+    #Set plot file type:
+    # -- this should be set in basic_info_dict, but is not required
+    # -- So check for it, and default to png
+    basic_info_dict = adfobj.read_config_var("diag_basic_info")
+    plot_type = basic_info_dict.get('plot_type', 'png')
+    print(f"\t NOTE: Plot type is set to {plot_type}")
+
+    # check if existing plots need to be redone
+    redo_plot = adfobj.get_basic_info('redo_plot')
+    print(f"\t NOTE: redo_plot is set to {redo_plot}")
+    #-----------------------------------------
+    
+    runs_LT2={}
+    for i,val in enumerate(test_nicknames):
+        runs_LT2[val] = case_ts_locs[i]
+
+    # MLS data
+    mls = xr.open_dataset("/glade/campaign/cgd/cas/islas/CAM7validation/MLS/mls_h2o_latNpressNtime_3d_monthly_v5.nc")
+    mls = mls.rename(x='lat', y='lev', t='time')
+    time = pd.date_range("2004-09","2021-11",freq='M')
+    mls['time'] = time
+    mls = cosweightlat(mls.H2O,-10,10)
+    mls = mls.groupby('time.month').mean('time')
+    mls = mls*18.015280/(1e6*28.964)
+
+    # ERA5 data
+    era5 = xr.open_dataset("/glade/campaign/cgd/cas/islas/CAM7validation/ERA5/ERA5_Q_10Sto10N_1980to2020.nc")
+    era5 = era5.groupby('time.month').mean('time')
+
+    alldat=[]
+    runname_LT=[]
+    for key in runs_LT2:
+        dat = xr.open_dataset(glob.glob(runs_LT2[key]+'/*h0.Q.*.nc')[0])
+        dat = fixcesmtime(dat)
+        datzm = dat.mean('lon')
+        dat_tropics = cosweightlat(datzm.Q, -10, 10)
+        dat_mon = dat_tropics.groupby('time.month').mean('time').load()
+        alldat.append(dat_mon)
+        runname_LT.append(key)
+
+    runname_LT=xr.DataArray(runname_LT, dims='run', coords=[np.arange(0,len(runname_LT),1)], name='run')
+    alldat_concat_LT = xr.concat(alldat, dim=runname_LT)
+
+    fig = plt.figure(figsize=(16,16))
+    x1, x2, y1, y2 = get5by5coords_zmplots()
+
+    plot_step = 0.5e-7
+    plot_min = 1.5e-6
+    plot_max = 3e-6
+
+    #1e-7,1.5e-6,3e-6
+    ax = plot_pre_mon(fig, mls, mls.lev, plot_step,plot_min,plot_max,'MLS',
+                      x1[0],x2[0],y1[0],y2[0],cmap=cmap, paxis='lev',
+                      taxis='month')
+
+    ax = plot_pre_mon(fig, era5.Q, era5.pre, plot_step,plot_min,plot_max,
+                      'ERA5',x1[1],x2[1],y1[1],y2[1], cmap=cmap, paxis='pre',
+                      taxis='month')
+
+    #Start count at 2 to account for MLS and ERA5 plots above
+    count=2
+    for irun in np.arange(0,alldat_concat_LT.run.size,1):
+        title = f"{alldat_concat_LT.run.isel(run=irun).values}"
+        ax = plot_pre_mon(fig, alldat_concat_LT.isel(run=irun), 
+                          alldat_concat_LT.isel(run=irun).lev,
+                          plot_step, plot_min, plot_max, title,
+                          x1[count],x2[count],y1[count],y2[count],cmap=cmap, paxis='lev',
+                          taxis='month',climo_yrs=f"{start_years[irun]}-{end_years[irun]}")
+        count=count+1
+    
+    #Shift colorbar if there are less than 5 subplots
+    # There will always be at least 2 (MLS and ERA5)
+    if len(case_ts_locs) == 0:
+        print("Seems like there are no simulations to plot, exiting script.")
+        return
+    if len(case_ts_locs) == 1:
+        x1_loc = (x1[1]-x1[0])/2
+        x2_loc = ((x2[2]-x2[1])/2)+x2[1]
+    elif len(case_ts_locs) == 2:
+        x1_loc = (x1[1]-x1[0])/2
+        x2_loc = ((x2[3]-x2[2])/2)+x2[2]
+    else:
+        x1_loc = x1[0]
+        x2_loc = x2[3]
+
+    y1_loc = y1[count]-0.03
+    y2_loc = y1[count]-0.02
+
+    ax = plotcolorbar(fig, plot_step, plot_min, plot_max, 'Q (kg/kg)',
+                      x1_loc, x2_loc, y1_loc, y2_loc,
+                      cmap=cmap)
+
+    plot_name = plot_loc / f"TapeRecorder_ANN_Special_Mean.{plot_type}"
+    print(f"\t - Plotting annual tape recorder for Q")
+
+    # Check redo_plot. If set to True: remove old plot, if it already exists:
+    if (not redo_plot) and plot_name.is_file():
+        #Add already-existing plot to website (if enabled):
+        adfobj.add_website_data(plot_name, "tape_recorder", None, season="ANN", multi_case=True)
+
+    elif (redo_plot) and plot_name.is_file():
+        plot_name.unlink()
+
+    #Save image
+    fig.savefig(plot_name, bbox_inches='tight', facecolor='white')
+
+    #Add plot to website (if enabled):
+    adfobj.add_website_data(plot_name, "tape_recorder", None, season="ANN", multi_case=True)
+
+    #Notify user that script has ended:
+    print("  ...Tape recorder plots have been generated successfully.")
+
+    #End QBO plotting script:
+    return
+
+
+# Helper Functions
+import matplotlib.pyplot as plt
+from matplotlib.colors import ListedColormap ## used to create custom colormaps
+import matplotlib.colors as mcolors
+import numpy as np
+
+def blue2red_cmap(n, nowhite = False):
+    """ combine two existing color maps to create a diverging color map with white in the middle
+    n = the number of contour intervals
+    """
+
+    if (int(n/2) == n/2):
+        # even number of contours
+        nwhite=1
+        nneg=n/2
+        npos=n/2
+    else:
+        nwhite=2
+        nneg = (n-1)/2
+        npos = (n-1)/2
+
+    if (nowhite):
+        nwhite=0
+
+    colors1 = plt.cm.Blues_r(np.linspace(0,1, int(nneg)))
+    colors2 = plt.cm.YlOrRd(np.linspace(0,1, int(npos)))
+    colorsw = np.ones((nwhite,4))
+
+    colors = np.vstack((colors1, colorsw, colors2))
+    mymap = mcolors.LinearSegmentedColormap.from_list('my_colormap', colors)
+
+    return mymap 
+
+def red2blue_cmap(n, nowhite = False):
+    """ combine two existing color maps to create a diverging color map with white in the middle
+    n = the number of contour intervals """
+
+    if (int(n/2) == n/2):
+        #even number of contours
+        nwhite=1
+        nneg = n/2
+        npos = n/2
+    else:
+        nwhite=2
+        nneg = (n-1)/2
+        npos = (n-1)/2
+
+    if (nowhite):
+        nwhite=0
+
+    colors1 = plt.cm.YlOrRd_r(np.linspace(0.1,1,int(npos)))
+    colors2 = plt.cm.Blues(np.linspace(0.1,1,int(nneg)))
+    colorsw = np.ones((nwhite,4))
+
+    if (nowhite):
+        colors = np.vstack( (colors1, colors2))
+    else:
+        colors = np.vstack((colors1, colorsw, colors2))
+    mymap = mcolors.LinearSegmentedColormap.from_list('my_colormap', colors)
+  
+    return mymap
+
+
+
+def precip_cmap(n, nowhite=False):
+    """ combine two existing color maps to create a diverging color map with white in the middle.
+    browns for negative, blues for positive
+    n = the number of contour intervals
+    """
+    if (int(n/2) == n/2):
+        # even number of contours
+        nwhite=1
+        nneg=n/2
+        npos=n/2
+    else:
+        nwhite=2
+        nneg = (n-1)/2
+        npos = (n-1)/2
+
+    if (nowhite):
+        nwhite=0
+
+    colors1 = plt.cm.YlOrBr_r(np.linspace(0,1, int(nneg)))
+    colors2 = plt.cm.GnBu(np.linspace(0,1, int(npos)))
+    colorsw = np.ones((nwhite,4))
+
+    colors = np.vstack((colors1, colorsw, colors2))
+    mymap = mcolors.LinearSegmentedColormap.from_list('my_colormap', colors)
+
+    return mymap
+
+def precip_cmap_nowhite(n):
+    """ combine two existing color maps to create a diverging color map with white in the middle.
+    browns for negative, blues for positive
+    n = the number of contour intervals
+    """
+    if (int(n/2) == n/2):
+        # even number of contours
+        nneg=n/2
+        npos=n/2
+    else:
+        nneg = (n-1)/2
+        npos = (n-1)/2
+
+    colors1 = plt.cm.YlOrBr_r(np.linspace(0,0.8, int(nneg)))
+    colors2 = plt.cm.GnBu(np.linspace(0.2,1, int(npos)))
+
+    colors = np.vstack((colors1, colors2))
+    mymap = mcolors.LinearSegmentedColormap.from_list('my_colormap', colors)
+
+    return mymap
+
+
+
+def fixcesmtime(dat,timebndsvar='time_bnds'):
+    """ Fix the CESM timestamp using the average of time_bnds"""
+
+    try:
+        timebndavg = np.array(dat.isel(M=0)[timebndsvar],
+                  dtype='datetime64[s]').view('i8').mean(axis=1).astype('datetime64[s]')
+        dat['time'] = timebndavg
+    except:
+        timebndavg = np.array(dat[timebndsvar],
+                  dtype='datetime64[s]').view('i8').mean(axis=1).astype('datetime64[s]')
+        dat['time'] = timebndavg
+
+    return dat
+
+
+def get5by5coords_zmplots():
+    """ positioning for 5x5 plots """
+    x1 = [0.02,0.225,0.43,0.635,0.84,
+          0.02,0.225,0.43,0.635,0.84,
+          0.02,0.225,0.43,0.635,0.84,
+          0.02,0.225,0.43,0.635,0.84,
+          0.02,0.225,0.43,0.635,0.84] 
+    x2 = [0.18,0.385,0.59,0.795,1,
+          0.18,0.385,0.59,0.795,1,
+          0.18,0.385,0.59,0.795,1,
+          0.18,0.385,0.59,0.795,1,
+          0.18,0.385,0.59,0.795,1]
+    y1 = [0.8,0.8,0.8,0.8,0.8,
+          0.6,0.6,0.6,0.6,0.6,
+          0.4,0.4,0.4,0.4,0.4,
+          0.2,0.2,0.2,0.2,0.2,
+          0.,0.,0.,0.,0.]
+    y2 = [0.95,0.95,0.95,0.95,0.95,
+          0.75,0.75,0.75,0.75,0.75,
+          0.55,0.55,0.55,0.55,0.55,
+          0.35,0.35,0.35,0.35,0.35,
+          0.15,0.15,0.15,0.15,0.15]
+    
+    return x1, x2, y1, y2
+
+
+
+import matplotlib.pyplot as plt
+import matplotlib as mpl
+
+import importlib
+
+import numpy as np
+
+def plotcolorbar(fig, ci, cmin, cmax, titlestr, x1, x2, y1, y2, 
+   cmap='blue2red', orient='horizontal', posneg='both', ticks=None, fsize=14, nowhite=False,
+   contourlines=False, contourlinescale=1):
+    """plot a color bar
+       Input:
+           fig = the figure identified
+           ci = the contour interval for the color map
+           cmin = the minimum extent of the contour range
+           cmax = the maximum extent of the contour range
+           titlestr = the label for the color bar
+           x1 = the location of the left edge of the color bar
+           x2 = the location of the right edge of the color bar
+           y1 = the location of the bottom edge of the color bar
+           y2 = the location of the top edge of the color bar
+           cmap = the color map to be used (only set up for blue2red at the moment)
+           orient = the orientation (horizontal or vertical)
+           posneg = if "both", both positive and negative sides are plotted
+                    if "pos", only the positive side is plotted
+                    if "net", only the negative side is plotted
+           ticks = user specified ticklabels
+           fsize = user specified font size
+           contourlines = used to overplot contour lines
+           contourlinescale = scale factor for contour lines to be overplotted
+    """
+
+    # set up contour levels and color map
+    nlevs = (cmax-cmin)/ci + 1
+    clevs = ci * np.arange(cmin/ci, (cmax+ci)/ci, 1) 
+
+    if (cmap == "blue2red"):
+        mymap = blue2red_cmap(nlevs, nowhite)
+
+    if (cmap == "precip"):
+        mymap = precip_cmap(nlevs, nowhite)
+
+    if (cmap == "precip_nowhite"):
+        mymap = precip_cmap_nowhite(nlevs)
+
+    if (cmap == 'red2blue'):
+        mymap = red2blue_cmap(nlevs, nowhite)
+
+    clevplot=clevs
+    if (posneg == "pos"):
+        clevplot = clevs[clevs >= 0]
+    if (posneg == "neg"):
+        clevplot = clevs[clevs <= 0]
+
+    ax = fig.add_axes([x1, y1, x2-x1, y2-y1])
+    norm = mpl.colors.Normalize(vmin=cmin, vmax=cmax)
+    
+    if (ticks):
+        clb = mpl.colorbar.ColorbarBase(ax, cmap=mymap,
+           orientation=orient, norm=norm, values=clevplot, ticks=ticks)
+    else:
+        clb = mpl.colorbar.ColorbarBase(ax, cmap=mymap, 
+           orientation=orient, norm=norm, values=clevplot)
+
+    clb.ax.tick_params(labelsize=fsize)
+    clb.set_label(titlestr, fontsize=fsize+2)
+
+    if (contourlines):
+        #clevlines = (clevs-ci/2.)*contourlinescale
+        clevlines = clevs*contourlinescale
+        clevlines = clevlines[np.abs(clevlines) > ci/2.]
+        if (orient=='horizontal'):
+            ax.vlines(clevlines[clevlines > 0],-5,5, colors='black', linestyle='solid')
+            ax.vlines(clevlines[clevlines < 0],-5,5, colors='black', linestyle='dashed')
+        if (orient=='vertical'):
+            ax.hlines(clevlines[clevlines > 0],-10,15, colors='black', linestyle='solid')
+            ax.hlines(clevlines[clevlines < 0],-10,15, colors='black', linestyle='dashed')
+
+    return ax
+
+
+def cosweightlat(darray, lat1, lat2):
+    """Calculate the weighted average for an [:,lat] array over the region
+    lat1 to lat2
+    """
+
+    # flip latitudes if they are decreasing
+    if (darray.lat[0] > darray.lat[darray.lat.size -1]):
+        print("flipping latitudes")
+        darray = darray.sortby('lat')
+
+    region = darray.sel(lat=slice(lat1, lat2))
+    weights=np.cos(np.deg2rad(region.lat))
+    regionw = region.weighted(weights)
+    regionm = regionw.mean("lat")
+
+    return regionm
+
+
+import matplotlib.pyplot as plt
+import numpy as np
+import sys
+
+def plot_pre_mon(fig, data, pre, ci, cmin, cmax, expname, x1=None, x2=None, y1=None, y2=None, 
+                 oplot=False, ax=None, cmap='precip', taxis='time', paxis='lev', climo_yrs=None):
+    """
+    Plot seasonal cycle, pressure versus time.
+    """
+
+    # move the time axis to the first
+    if (data.dims[1] != taxis):
+        data = data.transpose(..., taxis)
+
+    nlevs = (cmax - cmin)/ci + 1
+    clevs = np.arange(cmin, cmax+ci, ci)
+
+    if (cmap == "blue2red"):
+        mymap = blue2red_cmap(nlevs)
+
+    if (cmap == "precip"):
+        mymap = precip_cmap(nlevs)
+
+    if (cmap == "precip_nowhite"):
+        mymap = precip_cmap_nowhite(nlevs)
+
+    # if overplotting, check for axis input
+    if (oplot and (not ax)):
+        print("This isn't going to work.  If overplotting, specify axis")
+        sys.exit()
+
+    plt.rcParams['font.size'] = '14'
+
+    monticks_temp = np.arange(0,12,1)
+    monticks2_temp = np.arange(0,12,1)+0.5
+
+    monticks = monticks_temp
+    monticks2 = np.zeros([len(monticks2_temp)+2])
+    monticks2[0] = -0.5 ; monticks2[len(monticks2)-1] = 12.5
+    monticks2[1:len(monticks2)-1] = monticks2_temp
+
+    dataplot = np.zeros([data[paxis].size,len(monticks2)])
+    dataplot[:,0] = data[:,11]
+    dataplot[:,len(monticks2)-1] = data[:,0]
+    dataplot[:,1:len(monticks2)-1] = data[:,:]
+
+    #Check for over plotting
+    if not oplot:
+        if (x1):
+            ax = fig.add_axes([x1, y1, x2-x1, y2-y1])
+        else:
+            ax = fig.add_axes()
+    if climo_yrs:
+        ax.set_title(f"\n{climo_yrs}", loc='right',
+                       fontsize=8)
+
+    ax.contourf(monticks2, -np.log10(data[paxis]), dataplot, levels=clevs, cmap=mymap, extend='max')
+    ax.set_ylim(-np.log10(100),-np.log10(3))
+    ax.set_yticks([-np.log10(100),-np.log10(30),-np.log10(10),-np.log10(3)])
+    ax.set_yticklabels(['100','30','10','3'])
+    ax.set_xlim([0,12])
+    ax.tick_params(which='minor', length=0)
+    ax.set_xticks(monticks)
+    ax.set_xticklabels([])
+    ax.set_xticks(monticks2[1:13], minor=True)
+    ax.set_xticklabels(['J','F','M','A','M','J','J','A','S','O','N','D'], minor=True, fontsize=14)
+    ax.set_title(expname, fontsize=16)
+
+    return ax
+
+

--- a/scripts/plotting/tape_recorder.py
+++ b/scripts/plotting/tape_recorder.py
@@ -181,7 +181,7 @@ def tape_recorder(adfobj):
         x1_loc = (x1[1]-x1[0])/2
         x2_loc = ((x2[3]-x2[2])/2)+x2[2]
     else:
-        x1_loc = x1[0]
+        x1_loc = x1[1]
         x2_loc = x2[3]
 
     y1_loc = y1[count]-0.03

--- a/scripts/plotting/tem.py
+++ b/scripts/plotting/tem.py
@@ -188,6 +188,8 @@ def tem(adf):
         #Add plot to website (if enabled):
         adf.add_website_data(plot_name, "TEM", case_name, season=s)
 
+    print("  ...TEM plots have been generated successfully.")
+
 # Helper functions
 ##################
 

--- a/scripts/plotting/tem.py
+++ b/scripts/plotting/tem.py
@@ -150,6 +150,7 @@ def tem(adf):
             # Check redo_plot. If set to True: remove old plot, if it already exists:
             if (not redo_plot) and plot_name.is_file():
                 #Add already-existing plot to website (if enabled):
+                adf.debug_log(f"'{plot_name}' exists and clobber is false.")
                 adf.add_website_data(plot_name, "TEM", case_name, season=s)
 
                 #Continue to next iteration:

--- a/scripts/plotting/zonal_mean.py
+++ b/scripts/plotting/zonal_mean.py
@@ -165,6 +165,7 @@ def zonal_mean(adfobj):
                 if (not redo_plot) and plot_name.is_file():
                     zonal_skip.append(plot_name)
                     #Add already-existing plot to website (if enabled):
+                    adfobj.debug_log(f"'{plot_name}' exists and clobber is false.")
                     adfobj.add_website_data(plot_name, var, case_name, season=s,
                                                         plot_type="Zonal")
 


### PR DESCRIPTION
This will add the diagnostic "tape recorder" plot of Q to the Special plots section of the ADF.

The tape recorder plot will highlight moisture in the vertical vs monthly averaged mean on the x-axis for the tropical band between 10S and 10N. The default plot will be case/baseline vs MLS and ERA5 data:

![Q_tape_recorder_FCLTHIST_vs_FLTHIST_2000_2011](https://github.com/NCAR/ADF/assets/56696811/0d21a1e4-3877-4bef-9cee-cc78b16e3cf1)


If the ADF is comparing against Obs, the tape recorder will only plot the test case vs the default MLS and ERA5 data.

![TapeRecorder_ANN_Special_Mean_OBS](https://github.com/NCAR/ADF/assets/56696811/36fc7262-ae81-4c09-a605-ac1b2e10f1ad)


 This PR will also add some CSS code to block and grey out any seasonal tab not available for plots on the website.
<img width="1724" alt="Screen Shot 2023-11-14 at 11 47 26 AM" src="https://github.com/NCAR/ADF/assets/56696811/61a0c601-8fab-4b93-9527-f5d7c52bfad8">

Closes #266
