### PR TITLE
Pre-made timeseries bug fix

### DIFF
--- a/lib/adf_diag.py
+++ b/lib/adf_diag.py
@@ -365,7 +365,7 @@ class AdfDiag(AdfWeb):
             # to lists:
             case_names = [self.get_baseline_info("cam_case_name", required=True)]
             cam_ts_done = [self.get_baseline_info("cam_ts_done")]
-            cam_hist_locs = [self.get_baseline_info("cam_hist_loc", required=True)]
+            cam_hist_locs = [self.get_baseline_info("cam_hist_loc")]
             ts_dir = [self.get_baseline_info("cam_ts_loc", required=True)]
             overwrite_ts = [self.get_baseline_info("cam_overwrite_ts")]
             start_years = [self.climo_yrs["syear_baseline"]]
@@ -374,7 +374,7 @@ class AdfDiag(AdfWeb):
             # Use test case settings, which are already lists:
             case_names = self.get_cam_info("cam_case_name", required=True)
             cam_ts_done = self.get_cam_info("cam_ts_done")
-            cam_hist_locs = self.get_cam_info("cam_hist_loc", required=True)
+            cam_hist_locs = self.get_cam_info("cam_hist_loc")
             ts_dir = self.get_cam_info("cam_ts_loc", required=True)
             overwrite_ts = self.get_cam_info("cam_overwrite_ts")
             start_years = self.climo_yrs["syears"]

--- a/lib/adf_info.py
+++ b/lib/adf_info.py
@@ -32,6 +32,7 @@ from pathlib import Path
 import copy
 import os
 import numpy as np
+import xarray as xr
 
 #+++++++++++++++++++++++++++++++++++++++++++++++++
 #import non-standard python modules, including ADF
@@ -167,14 +168,15 @@ class AdfInfo(AdfConfig):
             #Attempt to grab baseline start_years (not currently required):
             syear_baseline = self.get_baseline_info('start_year')
             eyear_baseline = self.get_baseline_info('end_year')
-            
+
             #Get climo years for verification or assignment if missing
             baseline_hist_locs = self.get_baseline_info('cam_hist_loc')
 
             #Check if any time series files are pre-made
             baseline_ts_done   = self.get_baseline_info("cam_ts_done")
 
-            #Check if time series files already exist, if so don't rely on climo years from history location
+            #Check if time series files already exist,
+            #if so don't rely on climo years from history location
             if baseline_ts_done:
                 baseline_hist_locs = None
 
@@ -204,7 +206,7 @@ class AdfInfo(AdfConfig):
                 file_list = sorted(starting_location.glob('*'+hist_str+'.*.nc'))
                 #Partition string to find exactly where h-number is
                 #This cuts the string before and after the `{hist_str}.` sub-string
-                # so there will always be three parts: 
+                # so there will always be three parts:
                 # before sub-string, sub-string, and after sub-string
                 #Since the last part always includes the time range, grab that with last index (2)
                 #NOTE: this is based off the current CAM file name structure in the form:
@@ -334,7 +336,7 @@ class AdfInfo(AdfConfig):
                 file_list = sorted(starting_location.glob('*'+hist_str+'.*.nc'))
                 #Partition string to find exactly where h-number is
                 #This cuts the string before and after the `{hist_str}.` sub-string
-                # so there will always be three parts: 
+                # so there will always be three parts:
                 # before sub-string, sub-string, and after sub-string
                 #Since the last part always includes the time range, grab that with last index (2)
                 #NOTE: this is based off the current CAM file name structure in the form:
@@ -613,7 +615,7 @@ class AdfInfo(AdfConfig):
         if var_str not in self.__diag_var_list:
             self.__diag_var_list.append(var_str)
         #End if
-    
+
     #########
 
     #Utility function to grab climo years from pre-made time series files:
@@ -627,7 +629,6 @@ class AdfInfo(AdfConfig):
           - start year
           - end year
         """
-        import xarray as xr
 
         #Grab variable list
         var_list = self.__diag_var_list.copy()
@@ -653,7 +654,8 @@ class AdfInfo(AdfConfig):
         #Average time dimension over time bounds, if bounds exist:
         if 'time_bnds' in cam_ts_data:
             time = cam_ts_data['time']
-            # NOTE: force `load` here b/c if dask & time is cftime, throws a NotImplementedError:
+            #NOTE: force `load` here b/c if dask & time is cftime, 
+            #throws a NotImplementedError:
             time = xr.DataArray(cam_ts_data['time_bnds'].load().mean(dim='nbnd').values, dims=time.dims, attrs=time.attrs)
             cam_ts_data['time'] = time
             cam_ts_data.assign_coords(time=time)

--- a/lib/adf_info.py
+++ b/lib/adf_info.py
@@ -341,12 +341,12 @@ class AdfInfo(AdfConfig):
                     msg = f"No given start year for {case_name}, "
                     msg += f"using first found year: {found_syear}"
                     print(msg)
-                    syear_baseline = found_syear
+                    syear = found_syear
                 if syear not in found_yr_range:
                     msg = f"Given start year '{syear}' is not in current dataset "
                     msg += f"{case_name}, using first found year: {found_syear}\n"
                     print(msg)
-                    syear_baseline = found_syear
+                    syear = found_syear
                 #End if
                 if eyear is None:
                     msg = f"No given end year for {case_name}, "
@@ -355,7 +355,7 @@ class AdfInfo(AdfConfig):
                     eyear = found_eyear
                 if eyear not in found_yr_range:
                     msg = f"Given end year '{eyear}' is not in current dataset "
-                    msg += f"{case_name}, using first found year: {found_eyear}\n"
+                    msg += f"{case_name}, using last found year: {found_eyear}\n"
                     print(msg)
                     eyear = found_eyear
                 #End if
@@ -391,7 +391,6 @@ class AdfInfo(AdfConfig):
                     msg += f"{case_name}, using first found year: {case_climo_yrs[0]}\n"
                     print(msg)
                     syear = case_found_syr
-
                 #End if
                 if eyear is None:
                     msg = f"No given end year for {case_name}, "
@@ -403,8 +402,6 @@ class AdfInfo(AdfConfig):
                     msg += f"{case_name}, using last found year: {case_climo_yrs[-1]}\n"
                     print(msg)
                     eyear = case_found_eyr
-                #else:
-                #    eyear = int(eyear)
                 #End if
             #End if
 

--- a/lib/plotting_functions.py
+++ b/lib/plotting_functions.py
@@ -1152,7 +1152,6 @@ def plot_map_and_save(wks, case_nickname, base_nickname,
 
     # LAYOUT WITH GRIDSPEC
     gs = mpl.gridspec.GridSpec(3, 6, wspace=0.5,hspace=0.0) # 2 rows, 4 columns, but each map will take up 2 columns
-    #gs.tight_layout(fig)
     proj = ccrs.PlateCarree(central_longitude=central_longitude)
     ax1 = plt.subplot(gs[0:2, :3], projection=proj, **cp_info['subplots_opt'])
     ax2 = plt.subplot(gs[0:2, 3:], projection=proj, **cp_info['subplots_opt'])

--- a/scripts/analysis/amwg_table.py
+++ b/scripts/analysis/amwg_table.py
@@ -138,13 +138,8 @@ def amwg_table(adf):
         baseline_name     = adf.get_baseline_info("cam_case_name", required=True)
         input_ts_baseline = adf.get_baseline_info("cam_ts_loc", required=True)
 
-        if "CMIP" in baseline_name:
-            print("CMIP files detected, skipping AMWG table (for now)...")
-
-        else:
-            #Append to case list:
-            case_names.append(baseline_name)
-            input_ts_locs.append(input_ts_baseline)
+        case_names.append(baseline_name)
+        input_ts_locs.append(input_ts_baseline)
 
         #Save the baseline to the first case's plots directory:
         output_locs.append(output_locs[0])
@@ -204,7 +199,8 @@ def amwg_table(adf):
             if len(ts_files) != 1:
                 errmsg =  "Currently the AMWG table script can only handle one time series file per variable."
                 errmsg += f" Multiple files were found for the variable '{var}'"
-                raise AdfError(errmsg)
+                print(errmsg)
+                return
             #End if
 
             #Load model data from file:

--- a/scripts/analysis/amwg_table.py
+++ b/scripts/analysis/amwg_table.py
@@ -300,7 +300,6 @@ def amwg_table(adf):
                 table_df.to_csv(output_csv_file, header=cols, index=False)
 
             # last step is to add table dataframe to website (if enabled):
-            table_df = pd.read_csv(output_csv_file)
             adf.add_website_data(table_df, case_name, case_name, plot_type="Tables")
         except FileNotFoundError:
             print(f"\n\tAMWG table for '{case_name}' not created.\n")

--- a/scripts/analysis/amwg_table.py
+++ b/scripts/analysis/amwg_table.py
@@ -143,6 +143,9 @@ def amwg_table(adf):
 
         #Save the baseline to the first case's plots directory:
         output_locs.append(output_locs[0])
+    else:
+        print("AMWG table doesn't currently work with obs, so obs table won't be created.")
+    #End if
 
     #-----------------------------------------
 
@@ -198,9 +201,9 @@ def amwg_table(adf):
             #TEMPORARY:  For now, make sure only one file exists:
             if len(ts_files) != 1:
                 errmsg =  "Currently the AMWG table script can only handle one time series file per variable."
-                errmsg += f" Multiple files were found for the variable '{var}'"
+                errmsg += f" Multiple files were found for the variable '{var}', so it will be skipped."
                 print(errmsg)
-                return
+                continue
             #End if
 
             #Load model data from file:
@@ -287,29 +290,32 @@ def amwg_table(adf):
         #End of var_list loop
         #--------------------
 
-        # Move RESTOM to top of table
-        #----------------------------
-        if 'RESTOM' in var_list:
+        # Move RESTOM to top of table (if applicable)
+        #--------------------------------------------
+        try:
             table_df = pd.read_csv(output_csv_file)
-            table_df = pd.concat([table_df[table_df['variable'] == 'RESTOM'], table_df]).reset_index(drop = True)
-            table_df = table_df.drop_duplicates()
-            table_df.to_csv(output_csv_file, header=cols, index=False)
-        #End if
+            if 'RESTOM' in table_df['variable'].values:
+                table_df = pd.concat([table_df[table_df['variable'] == 'RESTOM'], table_df]).reset_index(drop = True)
+                table_df = table_df.drop_duplicates()
+                table_df.to_csv(output_csv_file, header=cols, index=False)
 
-        # last step is to add table dataframe to website (if enabled):
-        table_df = pd.read_csv(output_csv_file)
-        adf.add_website_data(table_df, case_name, case_name, plot_type="Tables")
+            # last step is to add table dataframe to website (if enabled):
+            table_df = pd.read_csv(output_csv_file)
+            adf.add_website_data(table_df, case_name, case_name, plot_type="Tables")
+        except FileNotFoundError:
+            print(f"\n\tAMWG table for '{case_name}' not created.\n")
+        #End try/except
 
     #End of model case loop
     #----------------------
 
-    #Notify user that script has ended:
-    print("  ...AMWG variable table has been generated successfully.")
-
-    #Check if observations are being comapred to, if so skip table comparison...
+    #Start case comparison tables
+    #----------------------------
+    #Check if observations are being compared to, if so skip table comparison...
     if not adf.get_basic_info("compare_obs"):
-        if "CMIP" in baseline_name:
-            print("CMIP case detected, skipping comparison table...")
+        #Check if all tables were created to compare against, if not, skip table comparison...
+        if len(sorted(output_location.glob("*.csv"))) != len(case_names):
+            print("\tNot enough cases to compare, skipping comparison table...")
         else:
             #Create comparison table for both cases
             print("\n  Making comparison table...")
@@ -317,8 +323,11 @@ def amwg_table(adf):
             print("  ... Comparison table has been generated successfully")
         #End if
     else:
-        print(" Comparison table currently doesn't work with obs, so skipping...")
+        print(" No comparison table will be generated due to running against obs.")
     #End if
+
+    #Notify user that script has ended:
+    print("  ...AMWG variable table(s) have been generated successfully.")
 
 
 ##################


### PR DESCRIPTION
Currently if the user wants to use pre-made time series files, the ADF is trying to grab climo years from the given history files even if `cam_ts_done` variable is true because `cam_hist_loc` is always required. This will cause the ADF to fail as it tries to read from files that don't exist or have a different filename format that doesn't match CAM hist files.

This fix removes the requirement of `cam_hist_loc` so the user can now use pre-made time series files and not have to specify the `cam_hist_loc`. 

This also introduces a check in `adf_diag.py` if `cam_ts_done` is true then it will make `cam_hist_loc` none if it was provided, so that the climo years are not trying to be read in from the `cam_hist_loc`.

This will also change the ADF behavior that requires the user to specify climo years for pre-made ts files. Now if the years are not specified, they are read in via xarrray in `adf_info.py` via new function `get_climo_yrs_from_ts`. This will print a warning message if the year range is larger than 100 because the ADF has a hard time creating climo files on the order of hundreds of years.

Additionally, this addresses the scenario if any of the test cases in a multi-case run have pre-made time series files. The user still must have the same number of entries for `cam_hist_loc` as the rest of variables, but they can be left blank (but not commented out) for cases that are using pre-made ts files:

<h3>Works</h3>

```
cam_hist_loc:
        - /glade/derecho/scratch/tilmes/archive/b.e21.B1850WmaCARMA.f19_g17.carmats16_cesm2.2.001/atm/hist/
        - 
   .
   .
   .

cam_ts_done:
        - false
        - true
```

<h3>Does NOT Work</h3>

```
cam_hist_loc:
        - /glade/derecho/scratch/tilmes/archive/b.e21.B1850WmaCARMA.f19_g17.carmats16_cesm2.2.001/atm/hist/
        #- 
   .
   .
   .

cam_ts_done:
        - false
        - true
```

Finally, instead of killing the ADF if the tables script encounters CMIP-like files or multiple time series files in the same directory, it just quits the tables script and continues the ADF flow. 