### PR TITLE
Add scale factor to LWP obs to convert to g m-2.

### DIFF
--- a/lib/adf_variable_defaults.yaml
+++ b/lib/adf_variable_defaults.yaml
@@ -392,6 +392,8 @@ TGCLDIWP:
   obs_file: "TGCLDIWP_ERA5_monthly_climo_197901-202112.nc"
   obs_name: "ERA5"
   obs_var_name: "TGCLDIWP"
+  obs_scale_factor: 1000
+  obs_add_offset: 0
 
 CCN3:
   category: "Clouds"

--- a/lib/adf_variable_defaults.yaml
+++ b/lib/adf_variable_defaults.yaml
@@ -374,6 +374,8 @@ TGCLDLWP:
   obs_file: "TGCLDLWP_ERA5_monthly_climo_197901-202112.nc"
   obs_name: "ERA5"
   obs_var_name: "TGCLDLWP"
+  obs_scale_factor: 1000
+  obs_add_offset: 0
 
 TGCLDIWP:
   colormap: "Blues"


### PR DESCRIPTION
Adds an obs scale factor to the `TGCLDLWP` variable to ensure that both the model and the observations are in units of g m-2.  

Credit goes to @bstephens82 for finding and reporting the bug!