### PR TITLE
New adf updates

### DIFF
--- a/lib/adf_variable_defaults.yaml
+++ b/lib/adf_variable_defaults.yaml
@@ -63,6 +63,13 @@
 #+++++++++++
 
 #+++++++++++++
+# Available ADF Default Plot Types
+#+++++++++++++
+
+default_ptypes: ["Tables","LatLon","LatLon_Vector","Zonal","Meridonal",
+                  "NHPolar","SHPolar","Special"]
+
+#+++++++++++++
 # Category: Microphysics
 #+++++++++++++
 

--- a/lib/adf_variable_defaults.yaml
+++ b/lib/adf_variable_defaults.yaml
@@ -66,7 +66,7 @@
 # Available ADF Default Plot Types
 #+++++++++++++
 
-default_ptypes: ["Tables","LatLon","LatLon_Vector","Zonal","Meridonal",
+default_ptypes: ["Tables","LatLon","LatLon_Vector","Zonal","Meridional",
                   "NHPolar","SHPolar","Special"]
 
 #+++++++++++++

--- a/lib/adf_web.py
+++ b/lib/adf_web.py
@@ -652,21 +652,20 @@ class AdfWeb(AdfObs):
 
                 #Check if the mean plot type page exists for this case:
                 mean_ptype_file = img_pages_dir / f"mean_diag_{web_data.plot_type}.html"
-                if not mean_ptype_file.exists():
-                    #Construct individual plot type mean_diag html files, if they don't
-                    #already exist:
-                    mean_tmpl = jinenv.get_template('template_mean_diag.html')
 
-                    #Remove keys from main dictionary for this html page
-                    templ_rend_kwarg_dict = {k: rend_kwarg_dict[k] for k in rend_kwarg_dict.keys() - {'imgs', 'var_title', 'season_title'}}
-                    templ_rend_kwarg_dict["list"] = jinja_list
-                    mean_rndr = mean_tmpl.render(templ_rend_kwarg_dict)
+                #Construct individual plot type mean_diag html files, if they don't
+                #already exist:
+                mean_tmpl = jinenv.get_template('template_mean_diag.html')
 
-                    #Write mean diagnostic plots HTML file:
-                    with open(mean_ptype_file,'w', encoding='utf-8') as ofil:
-                        ofil.write(mean_rndr)
-                    #End with
-                #End if (mean_ptype exists)
+                #Remove keys from main dictionary for this html page
+                templ_rend_kwarg_dict = {k: rend_kwarg_dict[k] for k in rend_kwarg_dict.keys() - {'imgs', 'var_title', 'season_title'}}
+                templ_rend_kwarg_dict["list"] = jinja_list
+                mean_rndr = mean_tmpl.render(templ_rend_kwarg_dict)
+
+                #Write mean diagnostic plots HTML file:
+                with open(mean_ptype_file,'w', encoding='utf-8') as ofil:
+                    ofil.write(mean_rndr)
+                #End with
             #End if (data frame)
 
             #Also check if index page exists for this case:
@@ -681,6 +680,16 @@ class AdfWeb(AdfObs):
             plot_types = plot_type_html
             #End if
 
+            #List of ADF default plot types
+            avail_plot_types = ["Tables","LatLon","LatLon_Vector","Zonal","Meridonal",
+                                "NHPolar","SHPolar","Special"]
+            
+            #Check if current plot type is in ADF default.
+            #If not, add it so the index.html file can include it
+            for ptype in plot_types.keys():
+                if ptype not in avail_plot_types:
+                    avail_plot_types.append(plot_types)
+
             #Construct index.html
             index_title = "AMP Diagnostics Prototype"
             index_tmpl = jinenv.get_template('template_index.html')
@@ -689,7 +698,8 @@ class AdfWeb(AdfObs):
                                             base_name=data_name,
                                             case_yrs=case_yrs,
                                             baseline_yrs=baseline_yrs,
-                                            plot_types=plot_types)
+                                            plot_types=plot_types,
+                                            avail_plot_types=avail_plot_types)
 
             #Write Mean diagnostics index HTML file:
             with open(index_html_file, 'w', encoding='utf-8') as ofil:

--- a/lib/adf_web.py
+++ b/lib/adf_web.py
@@ -353,6 +353,9 @@ class AdfWeb(AdfObs):
             main_site_path = "" #Set main_site_path to blank value
         #End if
 
+        #Access variable defaults yaml file
+        res = self.variable_defaults
+
         #Extract needed variables from yaml file:
         case_names = self.get_cam_info('cam_case_name', required=True)
 
@@ -653,8 +656,7 @@ class AdfWeb(AdfObs):
                 #Check if the mean plot type page exists for this case:
                 mean_ptype_file = img_pages_dir / f"mean_diag_{web_data.plot_type}.html"
 
-                #Construct individual plot type mean_diag html files, if they don't
-                #already exist:
+                #Construct individual plot type mean_diag html files
                 mean_tmpl = jinenv.get_template('template_mean_diag.html')
 
                 #Remove keys from main dictionary for this html page
@@ -681,8 +683,7 @@ class AdfWeb(AdfObs):
             #End if
 
             #List of ADF default plot types
-            avail_plot_types = ["Tables","LatLon","LatLon_Vector","Zonal","Meridonal",
-                                "NHPolar","SHPolar","Special"]
+            avail_plot_types = res["default_ptypes"]
             
             #Check if current plot type is in ADF default.
             #If not, add it so the index.html file can include it

--- a/lib/adf_web.py
+++ b/lib/adf_web.py
@@ -653,7 +653,7 @@ class AdfWeb(AdfObs):
                     ofil.write(rndr)
                 #End with
 
-                #Check if the mean plot type page exists for this case:
+                #Mean plot type html file name
                 mean_ptype_file = img_pages_dir / f"mean_diag_{web_data.plot_type}.html"
 
                 #Construct individual plot type mean_diag html files

--- a/lib/plotting_functions.py
+++ b/lib/plotting_functions.py
@@ -3,6 +3,8 @@ Generic computation and plotting helper functions
 
 Functions
 ---------
+load_dataset()
+    generalized load dataset method used for plotting/analysis functions
 use_this_norm()
     switches matplotlib color normalization method
 get_difference_colors(values)
@@ -100,6 +102,14 @@ from matplotlib.lines import Line2D
 from adf_diag import AdfDiag
 from adf_base import AdfError
 
+import warnings  # use to warn user about missing files.
+
+#Format warning messages:
+def my_formatwarning(msg, *args, **kwargs):
+    """Issue `msg` as warning."""
+    return str(msg) + '\n'
+warnings.formatwarning = my_formatwarning
+
 #Set non-X-window backend for matplotlib:
 mpl.use('Agg')
 
@@ -122,6 +132,34 @@ seasons = {"ANN": np.arange(1,13,1),
 #################
 #HELPER FUNCTIONS
 #################
+
+def load_dataset(fils):
+    """
+    This method exists to get an xarray Dataset from input file information that can be passed into the plotting methods.
+
+    Parameters
+    ----------
+    fils : list
+        strings or paths to input file(s)
+
+    Returns
+    -------
+    xr.Dataset
+
+    Notes
+    -----
+    When just one entry is provided, use `open_dataset`, otherwise `open_mfdatset`
+    """
+    if len(fils) == 0:
+        warnings.warn(f"Input file list is empty.")
+        return None
+    elif len(fils) > 1:
+        return xr.open_mfdataset(fils, combine='by_coords')
+    else:
+        sfil = str(fils[0])
+        return xr.open_dataset(sfil)
+    #End if
+#End def
 
 def use_this_norm():
     """Just use the right normalization; avoids a deprecation warning."""

--- a/lib/plotting_functions.py
+++ b/lib/plotting_functions.py
@@ -156,8 +156,7 @@ def load_dataset(fils):
     elif len(fils) > 1:
         return xr.open_mfdataset(fils, combine='by_coords')
     else:
-        sfil = str(fils[0])
-        return xr.open_dataset(sfil)
+        return xr.open_dataset(fils[0])
     #End if
 #End def
 

--- a/lib/website_templates/adf_diag.css
+++ b/lib/website_templates/adf_diag.css
@@ -232,8 +232,11 @@ table.dataframe thead th{
 
 .grid-item-blocked {
   background-color: rgba(192, 192, 192, 0.6);
-  border: 1px solid rgba(0, 0, 0, 0.8);
-  padding: 10px;
+  font-family: Tahoma, Geneva, Verdana, sans-serif;
+  border-collapse: collapse;
+  /*border: 1px solid rgba(0, 0, 0, 0.8);*/
+  border-radius: 15px;  padding: 10px;
+  /*padding: 10px;*/
   font-size: 16px;
   text-align: center;
 }
@@ -260,7 +263,7 @@ table.dataframe thead th{
   display: grid;
   column-gap: 50px;
   row-gap: 50px;
-  grid-template-columns: repeat(3, auto);
+  grid-template-columns: repeat(4, auto);
   background-color: #e4eef0;
   padding: 85px;
 }

--- a/lib/website_templates/adf_diag.css
+++ b/lib/website_templates/adf_diag.css
@@ -234,9 +234,7 @@ table.dataframe thead th{
   background-color: rgba(192, 192, 192, 0.6);
   font-family: Tahoma, Geneva, Verdana, sans-serif;
   border-collapse: collapse;
-  /*border: 1px solid rgba(0, 0, 0, 0.8);*/
   border-radius: 15px;  padding: 10px;
-  /*padding: 10px;*/
   font-size: 16px;
   text-align: center;
 }

--- a/lib/website_templates/template_index.html
+++ b/lib/website_templates/template_index.html
@@ -35,10 +35,16 @@
     </div>
 
     <div class="grid-container">
-      {% for type, html_file in plot_types.items() %}
-      <div class="grid-item">
-        <a href={{ html_file }} style="font-size: 30px;"> &nbsp; {{ type }} </a>
-      </div><!--grid-item-->
+      {% for avail_type in avail_plot_types %}
+        {% if avail_type in plot_types.keys() %}
+          <div class="grid-item">
+            <a href={{ plot_types[avail_type] }} style="font-size: 30px;"> &nbsp; {{ avail_type }} </a>
+          </div><!--grid-item-->
+        {% else %}
+          <div class="grid-item-blocked">
+            <a-blocked style="font-size: 30px;">{{ avail_type }}</a-blocked>
+          </div><!--grid-item-blocked-->
+        {% endif %}
       {% endfor %}
     </div><!--grid-container-ptype-->
 

--- a/scripts/analysis/amwg_table.py
+++ b/scripts/analysis/amwg_table.py
@@ -334,13 +334,6 @@ def amwg_table(adf):
 # Helper functions
 ##################
 
-def _load_data(dataloc, varname):
-    import xarray as xr
-    ds = xr.open_dataset(dataloc)
-    return ds[varname]
-
-#####
-
 def _get_row_vals(data):
     # Now that data is (time,), we can do our simple stats:
 

--- a/scripts/analysis/amwg_table.py
+++ b/scripts/analysis/amwg_table.py
@@ -206,8 +206,9 @@ def amwg_table(adf):
                 continue
             #End if
 
-            #Load model data from file:
-            data = _load_data(ts_files[0], var)
+            #Load model variable data from file:
+            ds = pf.load_dataset(ts_files)
+            data = ds[var]
 
             #Extract units string, if available:
             if hasattr(data, 'units'):

--- a/scripts/plotting/global_latlon_map.py
+++ b/scripts/plotting/global_latlon_map.py
@@ -8,9 +8,6 @@ global_latlon_map(adfobj)
 my_formatwarning(msg, *args, **kwargs)
     format warning messages
     (private method)
-_load_dataset(fils)
-    load files into dataset
-    (private methd) 
 """
 #Import standard modules:
 from pathlib import Path
@@ -242,7 +239,7 @@ def global_latlon_map(adfobj):
             else:
                 oclim_fils = sorted(dclimo_loc.glob(f"{data_src}_{var}_baseline.nc"))
 
-            oclim_ds = _load_dataset(oclim_fils)
+            oclim_ds = pf.load_dataset(oclim_fils)
             if oclim_ds is None:
                 print("WARNING: Did not find any oclim_fils. Will try to skip.")
                 print(f"INFO: Data Location, dclimo_loc is {dclimo_loc}")
@@ -266,7 +263,7 @@ def global_latlon_map(adfobj):
 
                 #Load re-gridded model files:
                 mclim_fils = sorted(mclimo_rg_loc.glob(f"{data_src}_{case_name}_{var}_*.nc"))
-                mclim_ds = _load_dataset(mclim_fils)
+                mclim_ds = pf.load_dataset(mclim_fils)
 
                 #Skip this variable/case if the regridded climo file doesn't exist:
                 if mclim_ds is None:
@@ -484,33 +481,6 @@ def global_latlon_map(adfobj):
 # Helpers
 #########
 
-def _load_dataset(fils):
-    """
-    loads datasets from input file information
-
-    Parameters
-    ----------
-    fils : list
-        strings or paths to input file(s)
-
-    Returns
-    -------
-    xr.Dataset
-
-    Notes
-    -----
-    When just one entry is provided, use `open_dataset`, otherwise `open_mfdatset`
-    """
-    if len(fils) == 0:
-        warnings.warn(f"Input file list is empty.")
-        return None
-    elif len(fils) > 1:
-        return xr.open_mfdataset(fils, combine='by_coords')
-    else:
-        sfil = str(fils[0])
-        return xr.open_dataset(sfil)
-    #End if
-#End def
 
 ##############
 #END OF SCRIPT

--- a/scripts/plotting/meridional_mean.py
+++ b/scripts/plotting/meridional_mean.py
@@ -147,7 +147,7 @@ def meridional_mean(adfobj):
             else:
                 oclim_fils = sorted(dclimo_loc.glob(f"{data_src}_{var}_baseline.nc"))
             #End if
-            oclim_ds = _load_dataset(oclim_fils)
+            oclim_ds = pf.load_dataset(oclim_fils)
 
             #Loop over model cases:
             for case_idx, case_name in enumerate(case_names):
@@ -165,7 +165,7 @@ def meridional_mean(adfobj):
 
                 # load re-gridded model files:
                 mclim_fils = sorted(mclimo_rg_loc.glob(f"{data_src}_{case_name}_{var}_*.nc"))
-                mclim_ds = _load_dataset(mclim_fils)
+                mclim_ds = pf.load_dataset(mclim_fils)
 
                 # stop if data is invalid:
                 if (oclim_ds is None) or (mclim_ds is None):
@@ -256,17 +256,6 @@ def meridional_mean(adfobj):
 # Helpers
 #########
 
-def _load_dataset(fils):
-    if len(fils) == 0:
-        warnings.warn(f"Input file list is empty.")
-        return None
-    elif len(fils) > 1:
-        return xr.open_mfdataset(fils, combine='by_coords')
-    else:
-        sfil = str(fils[0])
-        return xr.open_dataset(sfil)
-    #End if
-#End def
 
 ##############
 #END OF SCRIPT

--- a/scripts/plotting/polar_map.py
+++ b/scripts/plotting/polar_map.py
@@ -161,13 +161,9 @@ def polar_map(adfobj):
                 data_name = data_src
             else:
                 oclim_fils = sorted(dclimo_loc.glob(f"{data_src}_{var}_baseline.nc"))
-
-            if len(oclim_fils) > 1:
-                oclim_ds = xr.open_mfdataset(oclim_fils, combine='by_coords')
-            elif len(oclim_fils) == 1:
-                sfil = str(oclim_fils[0])
-                oclim_ds = xr.open_dataset(sfil)
-            else:
+           
+            oclim_ds = pf.load_dataset(oclim_fils)
+            if oclim_ds is None:
                 print("WARNING: Did not find any oclim_fils. Will try to skip.")
                 print(f"INFO: Data Location, dclimo_loc is {dclimo_loc}")
                 print(f"INFO: The glob is: {data_src}_{var}_*.nc")
@@ -190,11 +186,8 @@ def polar_map(adfobj):
                 # load re-gridded model files:
                 mclim_fils = sorted(mclimo_rg_loc.glob(f"{data_src}_{case_name}_{var}_*.nc"))
 
-                if len(mclim_fils) > 1:
-                    mclim_ds = xr.open_mfdataset(mclim_fils, combine='by_coords')
-                elif len(mclim_fils) == 1:
-                    mclim_ds = xr.open_dataset(mclim_fils[0])
-                else:
+                mclim_ds = pf.load_dataset(mclim_fils)
+                if mclim_ds is None:
                     print("WARNING: Did not find any regridded climo files. Will try to skip.")
                     print(f"INFO: Data Location, mclimo_rg_loc, is {mclimo_rg_loc}")
                     print(f"INFO: The glob is: {data_src}_{case_name}_{var}_*.nc")

--- a/scripts/plotting/qbo.py
+++ b/scripts/plotting/qbo.py
@@ -191,35 +191,6 @@ def qbo(adfobj):
     #End QBO plotting script:
     return
 
-#-------------------For Reading Data------------------------
-
-def _load_dataset(data_loc, case_name, variable, other_name=None):
-    """
-    This method exists to get an xarray Dataset that can be passed into the plotting methods.
-
-    This could (should) be changed to use an intake-esm catalog if (when) that is available.
-    * At some point, we hope ADF will provide functions that can be used directly to replace this step,
-      so the user will not need to know how the data gets saved.
-
-    In this example, assume timeseries files are available via the ADF api.
-
-    """
-
-    dloc    = Path(data_loc)
-
-    # a hack here: ADF uses different file names for "reference" case and regridded model data,
-    # - try the longer name first (regridded), then try the shorter name
-
-    fils = sorted(dloc.glob(f"{case_name}.*.{variable}.*.nc"))
-    if (len(fils) == 0):
-        warnings.warn("QBO: Input file list is empty.")
-        return None
-    elif (len(fils) > 1):
-        return xr.open_mfdataset(fils, combine='by_coords')
-    else:
-        sfil = str(fils[0])
-        return xr.open_dataset(sfil)
-
 #-----------------For Calculating-----------------------------
 
 def cosweightlat(darray, lat1, lat2):

--- a/scripts/plotting/qbo.py
+++ b/scripts/plotting/qbo.py
@@ -6,6 +6,7 @@ import matplotlib.pyplot as plt
 from matplotlib.colors import ListedColormap ## used to create custom colormaps
 import matplotlib.colors as mcolors
 import matplotlib as mpl
+import plotting_functions as pf
 
 def my_formatwarning(msg, *args, **kwargs):
     # ignore everything except the message
@@ -98,7 +99,7 @@ def qbo(adfobj):
 
     #----Read in the case data and baseline
     ncases = len(case_loc)
-    casedat = [ _load_dataset(case_loc[i], case_names[i],'U') for i in range(0,ncases,1) ]
+    casedat = [pf.load_dataset(sorted(Path(case_loc[i]).glob(f"{case_names[i]}.*.U.*.nc"))) for i in range(0,ncases,1)]
 
     #Find indices for all case datasets that don't contain a zonal wind field (U):
     bad_idxs = []

--- a/scripts/plotting/tape_recorder.py
+++ b/scripts/plotting/tape_recorder.py
@@ -9,6 +9,7 @@ import pandas as pd
 from dateutil.relativedelta import relativedelta
 import glob
 from pathlib import Path
+import plotting_functions as pf
 
 def tape_recorder(adfobj):
     """
@@ -90,14 +91,14 @@ def tape_recorder(adfobj):
     #-----------------------------------------
 
     #This may have to change if other variables are desired in this plot type?
-    plot_name = plot_loc / f"Q_ANN_TapeRecorder_Mean.{plot_type}"
+    plot_name = plot_loc / f"Q_TapeRecorder_ANN_Special_Mean.{plot_type}"
     print(f"\t - Plotting annual tape recorder for Q")
 
     # Check redo_plot. If set to True: remove old plot, if it already exists:
     if (not redo_plot) and plot_name.is_file():
         #Add already-existing plot to website (if enabled):
         adfobj.debug_log(f"'{plot_name}' exists and clobber is false.")
-        adfobj.add_website_data(plot_name, "tape_recorder", None, season="ANN", multi_case=True)
+        adfobj.add_website_data(plot_name, "Q_TapeRecorder", None, season="ANN", multi_case=True)
         return
 
     elif (redo_plot) and plot_name.is_file():
@@ -125,7 +126,8 @@ def tape_recorder(adfobj):
     alldat=[]
     runname_LT=[]
     for idx,key in enumerate(runs_LT2):
-        dat = xr.open_dataset(glob.glob(runs_LT2[key]+'/*h0.Q.*.nc')[0])
+        fils= sorted(Path(runs_LT2[key]).glob('*h0.Q.*.nc'))
+        dat = pf.load_dataset(fils)
         dat = fixcesmtime(dat,start_years[idx],end_years[idx])
         datzm = dat.mean('lon')
         dat_tropics = cosweightlat(datzm.Q, -10, 10)
@@ -187,7 +189,7 @@ def tape_recorder(adfobj):
     fig.savefig(plot_name, bbox_inches='tight', facecolor='white')
 
     #Add plot to website (if enabled):
-    adfobj.add_website_data(plot_name, "tape_recorder", None, season="ANN", multi_case=True)
+    adfobj.add_website_data(plot_name, "Q_TapeRecorder", None, season="ANN", multi_case=True)
 
     #Notify user that script has ended:
     print("  ...Tape recorder plots have been generated successfully.")

--- a/scripts/plotting/zonal_mean.py
+++ b/scripts/plotting/zonal_mean.py
@@ -230,7 +230,7 @@ def zonal_mean(adfobj):
             else:
                 oclim_fils = sorted(dclimo_loc.glob(f"{data_src}_{var}_baseline.nc"))
             #End if
-            oclim_ds = _load_dataset(oclim_fils)
+            oclim_ds = pf.load_dataset(oclim_fils)
 
             #Loop over model cases:
             for case_idx, case_name in enumerate(case_names):
@@ -243,7 +243,7 @@ def zonal_mean(adfobj):
 
                 # load re-gridded model files:
                 mclim_fils = sorted(mclimo_rg_loc.glob(f"{data_src}_{case_name}_{var}_*.nc"))
-                mclim_ds = _load_dataset(mclim_fils)
+                mclim_ds = pf.load_dataset(mclim_fils)
 
                 # stop if data is invalid:
                 if (oclim_ds is None) or (mclim_ds is None):
@@ -344,18 +344,6 @@ def zonal_mean(adfobj):
 # Helpers
 #########
 
-def _load_dataset(fils):
-    if len(fils) == 0:
-        warnings.warn(f"Input file list is empty.")
-        return None
-    elif len(fils) > 1:
-        return xr.open_mfdataset(fils, combine='by_coords')
-    else:
-        sfil = str(fils[0])
-        return xr.open_dataset(sfil)
-    #End if
-#End def
 
 ##############
 #END OF SCRIPT
-


### PR DESCRIPTION
### Generalize load dataset

Make `load_dataset` function in `plotting_functions.py` that replaces `_load_dataset` function in various plotting scripts.
Now all plotting scripts will call this function from `plotting_functions.py` to get datasets.

### Website

In `adf_web.py`, add a list of defualt plot types and loop over any additional plot types. The point of this is to show all plot types on the landing page (`index.html`) and grey out any unavailable types. This will keep the main page consistent as well as always showing potential ADF plot types.

Also in `adf_web.py`, the check for mean_diag html file existence is removed. The reasoning is if a certain plot type (ie LatLon) is created from separate plotting scripts, it will only produce the plots from the last instance on the webpage.

In `template_index.html` there is code now that will grey out any unavailable plot types.

### Tape Recorder

Currently there is a bug that is not producing the correct html plot page for the tape recorder. The plot name and web object has been updated to reflect the variable Q specifically in the case a different variable is desired for this plot in the future, like temperature, etc.
