### PR TITLE
Fix missing comparison tables

### DIFF
--- a/scripts/analysis/amwg_table.py
+++ b/scripts/analysis/amwg_table.py
@@ -150,6 +150,8 @@ def amwg_table(adf):
     #-----------------------------------------
 
     #Loop over CAM cases:
+    #Initialize list of case name csv files for case comparison check later
+    csv_list = []
     for case_idx, case_name in enumerate(case_names):
 
         #Convert output location string to a Path object:
@@ -306,6 +308,9 @@ def amwg_table(adf):
             print(f"\n\tAMWG table for '{case_name}' not created.\n")
         #End try/except
 
+        #Keep track of case csv files for comparison table check later
+        csv_list.append(sorted(output_location.glob(f"amwg_table_{case_name}.csv")))
+
     #End of model case loop
     #----------------------
 
@@ -314,7 +319,7 @@ def amwg_table(adf):
     #Check if observations are being compared to, if so skip table comparison...
     if not adf.get_basic_info("compare_obs"):
         #Check if all tables were created to compare against, if not, skip table comparison...
-        if len(sorted(output_location.glob("*.csv"))) != len(case_names):
+        if len(csv_list) != len(case_names):
             print("\tNot enough cases to compare, skipping comparison table...")
         else:
             #Create comparison table for both cases

--- a/scripts/analysis/amwg_table.py
+++ b/scripts/analysis/amwg_table.py
@@ -309,7 +309,7 @@ def amwg_table(adf):
         #End try/except
 
         #Keep track of case csv files for comparison table check later
-        csv_list.append(sorted(output_location.glob(f"amwg_table_{case_name}.csv")))
+        csv_list.extend(sorted(output_location.glob(f"amwg_table_{case_name}.csv")))
 
     #End of model case loop
     #----------------------


### PR DESCRIPTION
If the ADF was re-run then the comparison table gets skipped from website if not cleared out of plot directory. This PR will fix that by only globbing the case tables and ignoring the comparison table.

The reason behind using glob when appending the case table instead of just appending the csv file name to `csv_list` is that in case that particular table is not created, the glob will miss that and it will reflect appropriately when checking the length of the `csv_list` and length of `case_names`