### PR TITLE
Update tape recorder for new CAM hist string

### DIFF
--- a/lib/adf_info.py
+++ b/lib/adf_info.py
@@ -417,13 +417,19 @@ class AdfInfo(AdfConfig):
 
             #Set the final directory name and save it to plot_location:
             direc_name = f"{case_name}_vs_{data_name}"
-            self.__plot_location.append(os.path.join(plot_dir, direc_name))
+            plot_loc = os.path.join(plot_dir, direc_name)
+            self.__plot_location.append(plot_loc)
 
             #If first iteration, then save directory name for use by baseline:
             if case_idx == 0:
                 first_case_dir = direc_name
             #End if
 
+            #Go ahead and make the diag plot location if it doesn't exist already
+            diag_location = Path(plot_loc)
+            if not diag_location.is_dir():
+                print(f"\t    {diag_location} not found, making new directory")
+                diag_location.mkdir(parents=True)
         #End for
 
         self.__syears = syears_fixed
@@ -436,11 +442,6 @@ class AdfInfo(AdfConfig):
             self.__plot_location.append(os.path.join(plot_dir, first_case_dir))
         #End if
 
-        #Go ahead and make the diag plot location if it doesn't exist already
-        diag_location = Path(self.__plot_location[0])
-        if not diag_location.is_dir():
-            print(f"\t    {diag_location} not found, making new directory")
-            diag_location.mkdir(parents=True)
         #-------------------------------------------------------------------------
 
         #Initialize "num_procs" variable:

--- a/lib/adf_info.py
+++ b/lib/adf_info.py
@@ -310,10 +310,10 @@ class AdfInfo(AdfConfig):
 
         #Extract cam history files location:
         cam_hist_locs = self.get_cam_info('cam_hist_loc')
-        
+
         #Check if using pre-made ts files
         cam_ts_done   = self.get_cam_info("cam_ts_done")
-        
+
         #Grab case time series file location(s)
         input_ts_locs = self.get_cam_info("cam_ts_loc", required=True)
 
@@ -587,7 +587,6 @@ class AdfInfo(AdfConfig):
     def hist_string(self):
         """ Return the history string name to the user if requested."""
         return self.__hist_str
-        
 
     #########
 
@@ -696,9 +695,10 @@ class AdfInfo(AdfConfig):
         #Average time dimension over time bounds, if bounds exist:
         if 'time_bnds' in cam_ts_data:
             time = cam_ts_data['time']
-            #NOTE: force `load` here b/c if dask & time is cftime, 
+            #NOTE: force `load` here b/c if dask & time is cftime,
             #throws a NotImplementedError:
-            time = xr.DataArray(cam_ts_data['time_bnds'].load().mean(dim='nbnd').values, dims=time.dims, attrs=time.attrs)
+            time = xr.DataArray(cam_ts_data['time_bnds'].load().mean(dim='nbnd').values, 
+                                dims=time.dims, attrs=time.attrs)
             cam_ts_data['time'] = time
             cam_ts_data.assign_coords(time=time)
             cam_ts_data = xr.decode_cf(cam_ts_data)

--- a/lib/adf_info.py
+++ b/lib/adf_info.py
@@ -111,6 +111,7 @@ class AdfInfo(AdfConfig):
         if not hist_str:
             hist_str = 'cam.h0'
         #End if
+        self.__hist_str = hist_str
 
         #Initialize ADF variable list:
         self.__diag_var_list = self.read_config_var('diag_var_list', required=True)
@@ -435,6 +436,11 @@ class AdfInfo(AdfConfig):
             self.__plot_location.append(os.path.join(plot_dir, first_case_dir))
         #End if
 
+        #Go ahead and make the diag plot location if it doesn't exist already
+        diag_location = Path(self.__plot_location[0])
+        if not diag_location.is_dir():
+            print(f"\t    {diag_location} not found, making new directory")
+            diag_location.mkdir(parents=True)
         #-------------------------------------------------------------------------
 
         #Initialize "num_procs" variable:
@@ -576,6 +582,12 @@ class AdfInfo(AdfConfig):
         base_nickname = self.__base_nickname
 
         return {"test_nicknames":test_nicknames,"base_nickname":base_nickname}
+
+    @property
+    def hist_string(self):
+        """ Return the history string name to the user if requested."""
+        return self.__hist_str
+        
 
     #########
 

--- a/scripts/analysis/amwg_table.py
+++ b/scripts/analysis/amwg_table.py
@@ -166,10 +166,6 @@ def amwg_table(adf):
             raise AdfError(errmsg)
         #Write to debug log if enabled:
         adf.debug_log(f"DEBUG: location of files is {str(input_location)}")
-        #Check if analysis directory exists, and if not, then create it:
-        if not output_location.is_dir():
-            print(f"\t    {output_locs[case_idx]} not found, making new directory")
-            output_location.mkdir(parents=True)
 
         #Create output file name:
         output_csv_file = output_location / f"amwg_table_{case_name}.csv"

--- a/scripts/plotting/tape_recorder.py
+++ b/scripts/plotting/tape_recorder.py
@@ -36,6 +36,9 @@ def tape_recorder(adfobj):
     plot_location = adfobj.plot_location
     plot_loc = Path(plot_location[0])
 
+    #Grab history string:
+    hist_str = adfobj.hist_string
+
     #Grab test case name(s)
     case_names = adfobj.get_cam_info('cam_case_name', required=True)
 
@@ -47,9 +50,7 @@ def tape_recorder(adfobj):
     end_years = adfobj.climo_yrs["eyears"]
 
     #Grab test case nickname(s)
-    test_nicknames = adfobj.get_cam_info('case_nickname')
-    if test_nicknames == None:
-        test_nicknames = case_names
+    test_nicknames = adfobj.case_nicknames['test_nicknames']
 
     # CAUTION:
     # "data" here refers to either obs or a baseline simulation,
@@ -64,9 +65,7 @@ def tape_recorder(adfobj):
         data_ts_loc = adfobj.get_baseline_info("cam_ts_loc", required=True)
         case_ts_locs = case_ts_locs+[data_ts_loc]
 
-        base_nickname = adfobj.get_baseline_info('case_nickname')
-        if base_nickname == None:
-            base_nickname = data_name
+        base_nickname = adfobj.case_nicknames['base_nickname']
         test_nicknames = test_nicknames+[base_nickname]
 
         data_start_year = adfobj.climo_yrs["syear_baseline"]
@@ -88,17 +87,24 @@ def tape_recorder(adfobj):
     # check if existing plots need to be redone
     redo_plot = adfobj.get_basic_info('redo_plot')
     print(f"\t NOTE: redo_plot is set to {redo_plot}")
+
+    #Set location for observations
+    obs_loc = Path(adfobj.get_basic_info("obs_data_loc"))
     #-----------------------------------------
 
+    #Set var to Q for now
+    #TODO: add option to look for H2O if Q is not available, and vice-versa
+    var = "Q"
+
     #This may have to change if other variables are desired in this plot type?
-    plot_name = plot_loc / f"Q_TapeRecorder_ANN_Special_Mean.{plot_type}"
-    print(f"\t - Plotting annual tape recorder for Q")
+    plot_name = plot_loc / f"{var}_TapeRecorder_ANN_Special_Mean.{plot_type}"
+    print(f"\t - Plotting annual tape recorder for {var}")
 
     # Check redo_plot. If set to True: remove old plot, if it already exists:
     if (not redo_plot) and plot_name.is_file():
         #Add already-existing plot to website (if enabled):
         adfobj.debug_log(f"'{plot_name}' exists and clobber is false.")
-        adfobj.add_website_data(plot_name, "Q_TapeRecorder", None, season="ANN", multi_case=True)
+        adfobj.add_website_data(plot_name, f"{var}_TapeRecorder", None, season="ANN", multi_case=True)
         return
 
     elif (redo_plot) and plot_name.is_file():
@@ -110,7 +116,7 @@ def tape_recorder(adfobj):
         runs_LT2[val] = case_ts_locs[i]
 
     # MLS data
-    mls = xr.open_dataset("/glade/campaign/cgd/cas/islas/CAM7validation/MLS/mls_h2o_latNpressNtime_3d_monthly_v5.nc")
+    mls = xr.open_dataset(obs_loc / "mls_h2o_latNpressNtime_3d_monthly_v5.nc")
     mls = mls.rename(x='lat', y='lev', t='time')
     time = pd.date_range("2004-09","2021-11",freq='M')
     mls['time'] = time
@@ -120,17 +126,19 @@ def tape_recorder(adfobj):
     mls = mls*18.015280/(1e6*28.964)
 
     # ERA5 data
-    era5 = xr.open_dataset("/glade/campaign/cgd/cas/islas/CAM7validation/ERA5/ERA5_Q_10Sto10N_1980to2020.nc")
+    era5 = xr.open_dataset(obs_loc / "ERA5_Q_10Sto10N_1980to2020.nc")
     era5 = era5.groupby('time.month').mean('time')
+    era5_data = era5.Q
 
     alldat=[]
     runname_LT=[]
     for idx,key in enumerate(runs_LT2):
-        fils= sorted(Path(runs_LT2[key]).glob('*h0.Q.*.nc'))
+        fils= sorted(Path(runs_LT2[key]).glob(f'*{hist_str}.{var}.*.nc'))
         dat = pf.load_dataset(fils)
         dat = fixcesmtime(dat,start_years[idx],end_years[idx])
         datzm = dat.mean('lon')
-        dat_tropics = cosweightlat(datzm.Q, -10, 10)
+        datzm = datzm[var]
+        dat_tropics = cosweightlat(datzm, -10, 10)
         dat_mon = dat_tropics.groupby('time.month').mean('time').load()
         alldat.append(dat_mon)
         runname_LT.append(key)
@@ -149,9 +157,11 @@ def tape_recorder(adfobj):
                       x1[0],x2[0],y1[0],y2[0],cmap=cmap, paxis='lev',
                       taxis='month',climo_yrs="2004-2021")
 
-    ax = plot_pre_mon(fig, era5.Q, plot_step,plot_min,plot_max,
+    ax = plot_pre_mon(fig, era5_data, plot_step,plot_min,plot_max,
                       'ERA5',x1[1],x2[1],y1[1],y2[1], cmap=cmap, paxis='pre',
                       taxis='month',climo_yrs="1980-2020")
+
+
 
     #Start count at 2 to account for MLS and ERA5 plots above
     count=2
@@ -181,7 +191,7 @@ def tape_recorder(adfobj):
     y1_loc = y1[count]-0.03
     y2_loc = y1[count]-0.02
 
-    ax = plotcolorbar(fig, plot_step, plot_min, plot_max, 'Q (kg/kg)',
+    ax = plotcolorbar(fig, plot_step, plot_min, plot_max, f'{var} (kg/kg)',
                       x1_loc, x2_loc, y1_loc, y2_loc,
                       cmap=cmap)
 
@@ -189,7 +199,7 @@ def tape_recorder(adfobj):
     fig.savefig(plot_name, bbox_inches='tight', facecolor='white')
 
     #Add plot to website (if enabled):
-    adfobj.add_website_data(plot_name, "Q_TapeRecorder", None, season="ANN", multi_case=True)
+    adfobj.add_website_data(plot_name, f"{var}_TapeRecorder", None, season="ANN", multi_case=True)
 
     #Notify user that script has ended:
     print("  ...Tape recorder plots have been generated successfully.")

--- a/scripts/plotting/tape_recorder.py
+++ b/scripts/plotting/tape_recorder.py
@@ -141,8 +141,7 @@ def tape_recorder(adfobj):
             continue
         dat = fixcesmtime(dat,start_years[idx],end_years[idx])
         datzm = dat.mean('lon')
-        datzm = datzm[var]
-        dat_tropics = cosweightlat(datzm, -10, 10)
+        dat_tropics = cosweightlat(datzm[var], -10, 10)
         dat_mon = dat_tropics.groupby('time.month').mean('time').load()
         alldat.append(dat_mon)
         runname_LT.append(key)

--- a/scripts/plotting/tape_recorder.py
+++ b/scripts/plotting/tape_recorder.py
@@ -135,6 +135,10 @@ def tape_recorder(adfobj):
     for idx,key in enumerate(runs_LT2):
         fils= sorted(Path(runs_LT2[key]).glob(f'*{hist_str}.{var}.*.nc'))
         dat = pf.load_dataset(fils)
+        if not dat:
+            dmsg = f"No data for `{var}` found in {fils}, case will be skipped in tape recorder plot."
+            print(dmsg)
+            continue
         dat = fixcesmtime(dat,start_years[idx],end_years[idx])
         datzm = dat.mean('lon')
         datzm = datzm[var]


### PR DESCRIPTION
This will remove the hard coded paths to obs files, add check if case exists or if Q is in history file, and remove hard coded history string in file search.

Also add ADF object for `hist_str` in `adf_info.py` to be called in all scripts.

Add diagnostic plot location creation in `adf_info.py` instead of in `amwg_table.py` in the scenarios where the tables aren't requested/don't run but still have the diagnostics plot location needing to be created for other diagnostic plots.