### PR TITLE
Call MDTF from ADF Revised 20240612

### DIFF
--- a/config_amwg_default_plots.yaml
+++ b/config_amwg_default_plots.yaml
@@ -63,12 +63,6 @@ user: 'USER-NAME-NOT-SET'
 #This first set of variables specify basic info used by all diagnostic runs:
 diag_basic_info:
 
-    #History file string to match (eg. cam.h0 or ocn.pop.h.ecosys.nday1)
-    # Only affects timeseries as everything else uses timeseries
-    # Leave off trailing '.'
-    #Default: cam.h0
-    hist_str: cam.h0
-
     #Is this a model vs observations comparison?
     #If "false" or missing, then a model-model comparison is assumed:
     compare_obs: false
@@ -129,6 +123,12 @@ diag_basic_info:
 
 #This second set of variables provides info for the CAM simulation(s) being diagnosed:
 diag_cam_climo:
+
+    # History file list of strings to match
+    # eg. cam.h0 or ocn.pop.h.ecosys.nday1 or hist_str: [cam.h2,cam.h0]  
+    # Only affects timeseries as everything else uses the created timeseries 
+    # Default: 
+    hist_str: cam.h0
 
     #Calculate climatologies?
     #If false, the climatology files will not be created:
@@ -202,7 +202,13 @@ diag_cam_climo:
 #This only matters if "compare_obs" is false:
 diag_cam_baseline_climo:
 
-    #Calculate cam baseline climatologies?
+    # History file list of strings to match
+    # eg. cam.h0 or ocn.pop.h.ecosys.nday1 or hist_str: [cam.h2,cam.h0]  
+    # Only affects timeseries as everything else uses the created timeseries 
+    # Default: 
+    hist_str: cam.h0
+    
+#Calculate cam baseline climatologies?
     #If false, the climatology files will not be created:
     calc_cam_climo: true
 
@@ -290,6 +296,71 @@ diag_cvdp_info:
     # tar up CVDP results?
     cvdp_tar: false
 
+# This set of variables provides settings for calling NOAA's
+# Model Diagnostic Task Force (MDTF) diagnostic package.
+# https://github.com/NOAA-GFDL/MDTF-diagnostics
+#
+# If mdtf_run: true, the MDTF will be set up and 
+# run in background mode, likely completing after the ADF has completed.
+#
+# The variables required depend on the diagnostics (PODs) selected. 
+# AMWG-developed PODS and their required variables:
+#   (Note that PRECT can be computed from PRECC & PRECL)
+#  - MJO_suite: daily PRECT, FLUT, U850, U200, V200  (all required)
+#  - Wheeler-Kiladis Wavenumber Frequency Spectra: daily PRECT, FLUT, U200, U850, OMEGA500
+#              (will use what is available)
+#  - Blocking (Rich Neale):  daily OMEGA500
+#  - Precip Diurnal Cycle (Rich Neale): 3-hrly PRECT
+#
+# Many other diagnostics are available; see 
+# https://mdtf-diagnostics.readthedocs.io/en/main/sphinx/start_overview.html
+
+#
+diag_mdtf_info:
+    # Run the MDTF on the model cases
+    mdtf_run: false
+
+    # The file that will be written by ADF to input to MDTF. Call this whatever you want.
+    mdtf_input_settings_filename : mdtf_input.json   
+
+    ## MDTF code path, sets the location of the MDTF codebase and pre-compiled conda envs
+    #  CHANGE if you have any: your own MDTF code, installed conda envs and/or obs_data
+
+    mdtf_codebase_path : /glade/campaign/cgd/amp/amwg/mdtf                                                                                                                                 
+    mdtf_codebase_loc  : ${mdtf_codebase_path}/MDTF-diagnostics.v3.1.20230817.ADF
+    conda_root         : ${mdtf_codebase_path}/miniconda2
+    conda_env_root     : ${mdtf_codebase_path}/miniconda2/envs.MDTFv3.1.20230412/
+    OBS_DATA_ROOT      : ${mdtf_codebase_path}/obs_data
+
+
+
+    # Set to default for same as the ADF plot_location. Anything else here overrides that
+    OUTPUT_DIR         : default
+    WORKING_DIR        : default
+
+    # SET this to a writable dir. The ADF will place ts files here for the MDTF to read (adds the casename)
+    MODEL_DATA_ROOT     : ${diag_cam_climo.cam_ts_loc}/mdtf/inputdata/model     
+
+    # Choose diagnostics (PODs). Full list of available PODs: https://github.com/NOAA-GFDL/MDTF-diagnostics
+    pod_list      :  [ "MJO_suite" ]
+
+    # Intermediate/output file settings
+    make_variab_tar: false     # tar up MDTF results
+    save_ps : false     # save postscript figures in addition to bitmaps
+    save_nc : true      # save netCDF files of processed data (recommend true when starting with new model data)
+    overwrite: true     # overwrite results in OUTPUT_DIR; otherwise results saved under a unique name
+
+    # Settings used in debugging:
+    verbose  : 3       # Log verbosity level.
+    test_mode: false   # Set to true for framework test. Data is fetched but PODs are not run.
+    dry_run  : false   # Framework test. No external commands are run and no remote data is copied. Implies test_mode.
+
+    # Settings that shouldn't change in ADF implementation for now
+    data_type           : single_run # single_run or multi_run (only works with single right now)
+    data_manager        : Local_File # Fetch data or it is local?
+    environment_manager : Conda      # Manage dependencies
+
+
 
 #+++++++++++++++++++++++++++++++++++++++++++++++++++
 #These variables below only matter if you are using
@@ -375,7 +446,16 @@ diag_var_list:
    - LANDFRAC
 
 #<Add more variables here.>
-
+# MDTF recommended variables
+#    - OMEGA
+#    - PRECT
+#    - PS
+#    - PSL
+#    - U200
+#    - U850
+#    - V200
+#    - V850
+    
 # Options for multi-case regional contour plots (./plotting/regional_map_multicase.py)
 # region_multicase:
 #     region_spec: [slat, nlat, wlon, elon]

--- a/config_amwg_default_plots.yaml
+++ b/config_amwg_default_plots.yaml
@@ -328,7 +328,7 @@ diag_mdtf_info:
 
     mdtf_codebase_path : /glade/campaign/cgd/amp/amwg/mdtf                                                                                                                                 
     mdtf_codebase_loc  : ${mdtf_codebase_path}/MDTF-diagnostics.v3.1.20230817.ADF
-    conda_root         : ${mdtf_codebase_path}/miniconda2
+    conda_root         : /glade/u/apps/opt/conda
     conda_env_root     : ${mdtf_codebase_path}/miniconda2/envs.MDTFv3.1.20230412/
     OBS_DATA_ROOT      : ${mdtf_codebase_path}/obs_data
 

--- a/config_cam_baseline_example.yaml
+++ b/config_cam_baseline_example.yaml
@@ -64,12 +64,6 @@ user: 'USER-NAME-NOT-SET'
 #This first set of variables specify basic info used by all diagnostic runs:
 diag_basic_info:
 
-    #History file string to match (eg. cam.h0 or ocn.pop.h.ecosys.nday1)
-    # Only affects timeseries as everything else uses timeseries
-    # Leave off trailing '.'
-    #Default: cam.h0
-    hist_str: cam.h0
-
     #Is this a model vs observations comparison?
     #If "false" or missing, then a model-model comparison is assumed:
     compare_obs: false
@@ -129,6 +123,12 @@ diag_basic_info:
 
 #This second set of variables provides info for the CAM simulation(s) being diagnosed:
 diag_cam_climo:
+
+    # History file list of strings to match
+    # eg. cam.h0 or ocn.pop.h.ecosys.nday1 or hist_str: [cam.h2,cam.h0]  
+    # Only affects timeseries as everything else uses the created timeseries 
+    # Default: 
+    hist_str: cam.h0
 
     #Calculate climatologies?
     #If false, the climatology files will not be created:
@@ -286,7 +286,13 @@ diag_cam_climo:
 #This only matters if "compare_obs" is false:
 diag_cam_baseline_climo:
 
-    #Calculate cam baseline climatologies?
+    # History file list of strings to match
+    # eg. cam.h0 or ocn.pop.h.ecosys.nday1 or hist_str: [cam.h2,cam.h0]  
+    # Only affects timeseries as everything else uses the created timeseries 
+    # Default: 
+    hist_str: cam.h0
+    
+#Calculate cam baseline climatologies?
     #If false, the climatology files will not be created:
     calc_cam_climo: true
 
@@ -375,6 +381,71 @@ diag_cvdp_info:
     # tar up CVDP results?
     cvdp_tar: false
 
+# This set of variables provides settings for calling NOAA's
+# Model Diagnostic Task Force (MDTF) diagnostic package.
+# https://github.com/NOAA-GFDL/MDTF-diagnostics
+#
+# If mdtf_run: true, the MDTF will be set up and 
+# run in background mode, likely completing after the ADF has completed.
+#
+# The variables required depend on the diagnostics (PODs) selected. 
+# AMWG-developed PODS and their required variables:
+#   (Note that PRECT can be computed from PRECC & PRECL)
+#  - MJO_suite: daily PRECT, FLUT, U850, U200, V200  (all required)
+#  - Wheeler-Kiladis Wavenumber Frequency Spectra: daily PRECT, FLUT, U200, U850, OMEGA500
+#              (will use what is available)
+#  - Blocking (Rich Neale):  daily OMEGA500
+#  - Precip Diurnal Cycle (Rich Neale): 3-hrly PRECT
+#
+# Many other diagnostics are available; see 
+# https://mdtf-diagnostics.readthedocs.io/en/main/sphinx/start_overview.html
+
+#
+diag_mdtf_info:
+    # Run the MDTF on the model cases
+    mdtf_run: false
+
+    # The file that will be written by ADF to input to MDTF. Call this whatever you want.
+    mdtf_input_settings_filename : mdtf_input.json   
+
+    ## MDTF code path, sets the location of the MDTF codebase and pre-compiled conda envs
+    #  CHANGE if you have any: your own MDTF code, installed conda envs and/or obs_data
+
+    mdtf_codebase_path : /glade/campaign/cgd/amp/amwg/mdtf                                                                                                                                 
+    mdtf_codebase_loc  : ${mdtf_codebase_path}/MDTF-diagnostics.v3.1.20230817.ADF
+    conda_root         : ${mdtf_codebase_path}/miniconda2
+    conda_env_root     : ${mdtf_codebase_path}/miniconda2/envs.MDTFv3.1.20230412/
+    OBS_DATA_ROOT      : ${mdtf_codebase_path}/obs_data
+
+
+
+    # Set to default for same as the ADF plot_location. Anything else here overrides that
+    OUTPUT_DIR         : default
+    WORKING_DIR        : default
+
+    # SET this to a writable dir. The ADF will place ts files here for the MDTF to read (adds the casename)
+    MODEL_DATA_ROOT     : ${diag_cam_climo.cam_ts_loc}/mdtf/inputdata/model     
+
+    # Choose diagnostics (PODs). Full list of available PODs: https://github.com/NOAA-GFDL/MDTF-diagnostics
+    pod_list      :  [ "MJO_suite" ]
+
+    # Intermediate/output file settings
+    make_variab_tar: false     # tar up MDTF results
+    save_ps : false     # save postscript figures in addition to bitmaps
+    save_nc : true      # save netCDF files of processed data (recommend true when starting with new model data)
+    overwrite: true     # overwrite results in OUTPUT_DIR; otherwise results saved under a unique name
+
+    # Settings used in debugging:
+    verbose  : 3       # Log verbosity level.
+    test_mode: false   # Set to true for framework test. Data is fetched but PODs are not run.
+    dry_run  : false   # Framework test. No external commands are run and no remote data is copied. Implies test_mode.
+
+    # Settings that shouldn't change in ADF implementation for now
+    data_type           : single_run # single_run or multi_run (only works with single right now)
+    data_manager        : Local_File # Fetch data or it is local?
+    environment_manager : Conda      # Manage dependencies
+
+
 
 #+++++++++++++++++++++++++++++++++++++++++++++++++++
 #These variables below only matter if you are using
@@ -438,7 +509,16 @@ diag_var_list:
     - LANDFRAC
 
 #<Add more variables here.>
-
+# MDTF recommended variables
+#    - OMEGA
+#    - PRECT
+#    - PS
+#    - PSL
+#    - U200
+#    - U850
+#    - V200
+#    - V850
+    
 # Options for multi-case regional contour plots (./plotting/regional_map_multicase.py)
 # region_multicase:
 #     region_spec: [slat, nlat, wlon, elon]

--- a/config_cam_baseline_example.yaml
+++ b/config_cam_baseline_example.yaml
@@ -413,7 +413,7 @@ diag_mdtf_info:
 
     mdtf_codebase_path : /glade/campaign/cgd/amp/amwg/mdtf                                                                                                                                 
     mdtf_codebase_loc  : ${mdtf_codebase_path}/MDTF-diagnostics.v3.1.20230817.ADF
-    conda_root         : ${mdtf_codebase_path}/miniconda2
+    conda_root         : /glade/u/apps/opt/conda
     conda_env_root     : ${mdtf_codebase_path}/miniconda2/envs.MDTFv3.1.20230412/
     OBS_DATA_ROOT      : ${mdtf_codebase_path}/obs_data
 

--- a/lib/adf_config.py
+++ b/lib/adf_config.py
@@ -275,8 +275,9 @@ class AdfConfig(AdfBase):
         #End if
 
         if varname == "ALL":
-            return var_dict
-        
+            return copy.deepcopy(var_dict)
+        #End if
+
         #Check that variable name exists in dictionary:
         if varname not in var_dict.keys():
             #If variable is required, then throw an error:

--- a/lib/adf_config.py
+++ b/lib/adf_config.py
@@ -240,7 +240,7 @@ class AdfConfig(AdfBase):
         #Loop through dictionary:
         for key, value in config_dict_copy.items():
 
-            #Skipe non-strings (as they won't contain a keyword):
+            #Skip non-strings (as they won't contain a keyword):
             if not isinstance(value, str):
                 continue
 
@@ -274,6 +274,9 @@ class AdfConfig(AdfBase):
             raise TypeError(emsg)
         #End if
 
+        if varname == "ALL":
+            return var_dict
+        
         #Check that variable name exists in dictionary:
         if varname not in var_dict.keys():
             #If variable is required, then throw an error:

--- a/lib/adf_diag.py
+++ b/lib/adf_diag.py
@@ -582,8 +582,8 @@ class AdfDiag(AdfWeb):
                         #If not CAM-CHEM, check regular CAM runs
                         if try_cam_constits:
                             if "derivable_from" in vres:
-                            derive = True
-                            constit_list = vres["derivable_from"]
+                                derive = True
+                                constit_list = vres["derivable_from"]
                         else:
                             # Missing variable or missing derivable_from argument
                             der_from_msg = f"create time series for {case_name}:"

--- a/lib/adf_diag.py
+++ b/lib/adf_diag.py
@@ -183,7 +183,6 @@ class AdfDiag(AdfWeb):
         # Note that a copy is needed in order to avoid having a script mistakenly
         # modify this variable:
         return copy.copy(self.__plotting_scripts)
-        )
 
     #########
     # Script-running functions

--- a/lib/adf_diag.py
+++ b/lib/adf_diag.py
@@ -183,10 +183,6 @@ class AdfDiag(AdfWeb):
         # Note that a copy is needed in order to avoid having a script mistakenly
         # modify this variable:
         return copy.copy(self.__plotting_scripts)
-
-
-        return self.read_config_var(
-            var_str, conf_dict=self.__cvdp_info, required=required
         )
 
     #########

--- a/lib/adf_diag.py
+++ b/lib/adf_diag.py
@@ -20,6 +20,8 @@ import multiprocessing as mp
 import copy
 
 import importlib
+import shutil
+import json
 
 from pathlib import Path
 from typing import Optional
@@ -162,14 +164,6 @@ class AdfDiag(AdfWeb):
         # Initialize Config/Base attributes:
         super().__init__(config_file, debug=debug)
 
-        # Add CVDP info to object:
-        self.__cvdp_info = self.read_config_var("diag_cvdp_info")
-
-        # Expand CVDP climo info variable strings:
-        if self.__cvdp_info is not None:
-            self.expand_references(self.__cvdp_info)
-        # End if
-
         # Add averaging script names:
         self.__time_averaging_scripts = self.read_config_var("time_averaging_scripts")
 
@@ -190,17 +184,6 @@ class AdfDiag(AdfWeb):
         # modify this variable:
         return copy.copy(self.__plotting_scripts)
 
-    #########
-    # Variable extraction functions
-    #########
-
-    def get_cvdp_info(self, var_str, required=False):
-        """
-        Return the config variable from 'diag_cvdp_info' as requested by
-        the user. If 'diag_cvdp_info' is not found then try grabbing the
-        variable from the top level of the YAML config file dictionary
-        instead.
-        """
 
         return self.read_config_var(
             var_str, conf_dict=self.__cvdp_info, required=required
@@ -370,6 +353,8 @@ class AdfDiag(AdfWeb):
             overwrite_ts = [self.get_baseline_info("cam_overwrite_ts")]
             start_years = [self.climo_yrs["syear_baseline"]]
             end_years = [self.climo_yrs["eyear_baseline"]]
+            case_type_string = "baseline"
+
         else:
             # Use test case settings, which are already lists:
             case_names = self.get_cam_info("cam_case_name", required=True)
@@ -379,15 +364,18 @@ class AdfDiag(AdfWeb):
             overwrite_ts = self.get_cam_info("cam_overwrite_ts")
             start_years = self.climo_yrs["syears"]
             end_years = self.climo_yrs["eyears"]
+            case_type_string="case"
+
+        # Notify user that script has started:
+        print("\n  Generating CAM time series files for {case_type_string}...")
+
         # End if
 
         # Read hist_str (component.hist_num) from the yaml file, or set to default
-        hist_str = self.get_basic_info("hist_str")
-        # If hist_str is not present, then default to 'cam.h0':
-        if not hist_str:
-            hist_str = "cam.h0"
-        # End if
-
+        hist_str_list = self.get_cam_info("hist_str")
+        dmsg = f"reading from {hist_str_list} files"
+        self.debug_log(dmsg)
+    
         # get info about variable defaults
         res = self.variable_defaults
 
@@ -401,8 +389,6 @@ class AdfDiag(AdfWeb):
                 continue
             # End if
 
-            print(f"\t Processing time series for case '{case_name}' :")
-
             # Extract start and end year values:
             start_year = start_years[case_idx]
             end_year = end_years[case_idx]
@@ -412,243 +398,270 @@ class AdfDiag(AdfWeb):
 
             # Check that path actually exists:
             if not starting_location.is_dir():
-                if baseline:
-                    emsg = f"Provided baseline 'cam_hist_loc' directory '{starting_location}' "
-                    emsg += "not found.  Script is ending here."
-                else:
-                    emsg = f"Provided 'cam_hist_loc' directory '{starting_location}' not found."
+                emsg = f"Provided {case_type_string} 'cam_hist_loc' directory '{starting_location}' "
+                emsg += "not found.  Script is ending here."
+                self.end_diag_fail(emsg)
+            # End if
+
+            # Check if history files actually exqist. If not then kill script:
+            hist_str_case = hist_str_list[case_idx]
+            for hist_str in hist_str_case:
+
+                print(f"\t Processing time series for {case_type_string} {case_name=}, {hist_str=} files:")
+                if not list(starting_location.glob("*" + hist_str + ".*.nc")):
+                    emsg = (
+                        f"No history *{hist_str}.*.nc files found in '{starting_location}'."
+                    )
                     emsg += " Script is ending here."
+                    self.end_diag_fail(emsg)
                 # End if
 
-                self.end_diag_fail(emsg)
-            # End if
+                # Create empty list:
+                files_list = []
 
-            # Check if history files actually exist. If not then kill script:
-            if not list(starting_location.glob("*" + hist_str + ".*.nc")):
-                emsg = (
-                    f"No history *{hist_str}.*.nc files found in '{starting_location}'."
-                )
-                emsg += " Script is ending here."
-                self.end_diag_fail(emsg)
-            # End if
-
-            # Create empty list:
-            files_list = []
-
-            # Loop over start and end years:
-            for year in range(start_year, end_year + 1):
-                # Add files to main file list:
-                for fname in starting_location.glob(
-                    f"*{hist_str}.*{str(year).zfill(4)}*.nc"
-                ):
-                    files_list.append(fname)
+                # Loop over start and end years:
+                for year in range(start_year, end_year + 1):
+                    # Add files to main file list:
+                    for fname in starting_location.glob(
+                        f"*{hist_str}.*{str(year).zfill(4)}*.nc"
+                    ):
+                        files_list.append(fname)
+                    # End for
                 # End for
-            # End for
 
-            # Create ordered list of CAM history files:
-            hist_files = sorted(files_list)
+                # Create ordered list of CAM history files:
+                hist_files = sorted(files_list)
 
-            # Open an xarray dataset from the first model history file:
-            hist_file_ds = xr.open_dataset(
-                hist_files[0], decode_cf=False, decode_times=False
-            )
+                # Open an xarray dataset from the first model history file:
+                hist_file_ds = xr.open_dataset(
+                    hist_files[0], decode_cf=False, decode_times=False
+                )
 
-            # Get a list of data variables in the 1st hist file:
-            hist_file_var_list = list(hist_file_ds.data_vars)
-            # Note: could use `open_mfdataset`, but that can become very slow;
-            #      This approach effectively assumes that all files contain the same variables.
+                # Get a list of data variables in the 1st hist file:
+                hist_file_var_list = list(hist_file_ds.data_vars)
+                # Note: could use `open_mfdataset`, but that can become very slow;
+                #      This approach effectively assumes that all files contain the same variables.
 
 
-            # Check what kind of vertical coordinate (if any) is being used for this model run:
-            # ------------------------
-            if "lev" in hist_file_ds:
-                # Extract vertical level attributes:
-                lev_attrs = hist_file_ds["lev"].attrs
+                # Check what kind of vertical coordinate (if any) is being used for this model run:
+                # ------------------------
+                if "lev" in hist_file_ds:
+                    # Extract vertical level attributes:
+                    lev_attrs = hist_file_ds["lev"].attrs
 
-                # First check if there is a "vert_coord" attribute:
-                if "vert_coord" in lev_attrs:
-                    vert_coord_type = lev_attrs["vert_coord"]
-                else:
-                    # Next check that the "long_name" attribute exists:
-                    if "long_name" in lev_attrs:
-                        # Extract long name:
-                        lev_long_name = lev_attrs["long_name"]
+                    # First check if there is a "vert_coord" attribute:
+                    if "vert_coord" in lev_attrs:
+                        vert_coord_type = lev_attrs["vert_coord"]
+                    else:
+                        # Next check that the "long_name" attribute exists:
+                        if "long_name" in lev_attrs:
+                            # Extract long name:
+                            lev_long_name = lev_attrs["long_name"]
 
-                        # Check for "keywords" in the long name:
-                        if "hybrid level" in lev_long_name:
-                            # Set model to hybrid vertical levels:
-                            vert_coord_type = "hybrid"
-                        elif "zeta level" in lev_long_name:
-                            # Set model to height (z) vertical levels:
-                            vert_coord_type = "height"
+                            # Check for "keywords" in the long name:
+                            if "hybrid level" in lev_long_name:
+                                # Set model to hybrid vertical levels:
+                                vert_coord_type = "hybrid"
+                            elif "zeta level" in lev_long_name:
+                                # Set model to height (z) vertical levels:
+                                vert_coord_type = "height"
+                            else:
+                                # Print a warning, and assume that no vertical
+                                # level information is needed.
+                                wmsg = (
+                                    "WARNING! Unable to determine the vertical coordinate"
+                                )
+                                wmsg += f" type from the 'lev' long name, which is:\n'{lev_long_name}'."
+                                wmsg += "\nNo additional vertical coordinate information will be"
+                                wmsg += " transferred beyond the 'lev' dimension itself."
+                                print(wmsg)
+
+                                vert_coord_type = None
+                            # End if
                         else:
-                            # Print a warning, and assume that no vertical
-                            # level information is needed.
-                            wmsg = (
-                                "WARNING! Unable to determine the vertical coordinate"
+                            # Print a warning, and assume hybrid levels (for now):
+                            wmsg = "WARNING!  No long name found for the 'lev' dimension,"
+                            wmsg += (
+                                " so no additional vertical coordinate information will be"
                             )
-                            wmsg += f" type from the 'lev' long name, which is:\n'{lev_long_name}'."
-                            wmsg += "\nNo additional vertical coordinate information will be"
                             wmsg += " transferred beyond the 'lev' dimension itself."
                             print(wmsg)
 
                             vert_coord_type = None
-                        # End if
-                    else:
-                        # Print a warning, and assume hybrid levels (for now):
-                        wmsg = "WARNING!  No long name found for the 'lev' dimension,"
-                        wmsg += (
-                            " so no additional vertical coordinate information will be"
-                        )
-                        wmsg += " transferred beyond the 'lev' dimension itself."
-                        print(wmsg)
+                        # End if (long name)
+                    # End if (vert_coord)
+                else:
+                    # No level dimension found, so assume there is no vertical coordinate:
+                    vert_coord_type = None
+                # End if (lev existence)
+                # ------------------------
 
-                        vert_coord_type = None
-                    # End if (long name)
-                # End if (vert_coord)
-            else:
-                # No level dimension found, so assume there is no vertical coordinate:
-                vert_coord_type = None
-            # End if (lev existence)
-            # ------------------------
+                # Check if time series directory exists, and if not, then create it:
+                # Use pathlib to create parent directories, if necessary.
+                Path(ts_dir[case_idx]).mkdir(parents=True, exist_ok=True)
 
-            # Check if time series directory exists, and if not, then create it:
-            # Use pathlib to create parent directories, if necessary.
-            Path(ts_dir[case_idx]).mkdir(parents=True, exist_ok=True)
+                # INPUT NAME TEMPLATE: $CASE.$scomp.[$type.][$string.]$date[$ending]
+                first_file_split = str(hist_files[0]).split(".")
+                if first_file_split[-1] == "nc":
+                    time_string_start = first_file_split[-2].replace("-", "")
+                else:
+                    time_string_start = first_file_split[-1].replace("-", "")
+                last_file_split = str(hist_files[-1]).split(".")
+                if last_file_split[-1] == "nc":
+                    time_string_finish = last_file_split[-2].replace("-", "")
+                else:
+                    time_string_finish = last_file_split[-1].replace("-", "")
+                time_string = "-".join([time_string_start, time_string_finish])
 
-            # INPUT NAME TEMPLATE: $CASE.$scomp.[$type.][$string.]$date[$ending]
-            first_file_split = str(hist_files[0]).split(".")
-            if first_file_split[-1] == "nc":
-                time_string_start = first_file_split[-2].replace("-", "")
-            else:
-                time_string_start = first_file_split[-1].replace("-", "")
-            last_file_split = str(hist_files[-1]).split(".")
-            if last_file_split[-1] == "nc":
-                time_string_finish = last_file_split[-2].replace("-", "")
-            else:
-                time_string_finish = last_file_split[-1].replace("-", "")
-            time_string = "-".join([time_string_start, time_string_finish])
+                # Loop over CAM history variables:
+                list_of_commands = []
+                vars_to_derive = []
+                # create copy of var list that can be modified for derivable variables
+                diag_var_list = self.diag_var_list
+                for var in diag_var_list:
+                    if var not in hist_file_var_list:
+                        vres = res.get(var, {})
+                        if "derivable_from" in vres:
+                            constit_list = vres["derivable_from"]
+                            for constit in constit_list:
+                                if constit not in diag_var_list:
+                                    diag_var_list.append(constit)
+                            vars_to_derive.append(var)
+                            continue
+                # INPUT NAME TEMPLATE: $CASE.$scomp.[$type.][$string.]$date[$ending]
+                first_file_split = str(hist_files[0]).split(".")
+                if first_file_split[-1] == "nc":
+                    time_string_start = first_file_split[-2].replace("-", "")
+                else:
+                    time_string_start = first_file_split[-1].replace("-", "")
+                last_file_split = str(hist_files[-1]).split(".")
+                if last_file_split[-1] == "nc":
+                    time_string_finish = last_file_split[-2].replace("-", "")
+                else:
+                    time_string_finish = last_file_split[-1].replace("-", "")
+                time_string = "-".join([time_string_start, time_string_finish])
 
-            # Loop over CAM history variables:
-            list_of_commands = []
-            vars_to_derive = []
-            # create copy of var list that can be modified for derivable variables
-            diag_var_list = self.diag_var_list
+                # Loop over CAM history variables:
+                list_of_commands = []
+                vars_to_derive = []
+                # create copy of var list that can be modified for derivable variables
+                diag_var_list = self.diag_var_list
 
-            # Aerosol Calcs
-            #--------------
-            #Always make sure PMID is made if aerosols are desired in config file
-            if "PMID" not in diag_var_list:
-                if any(item in res["aerosol_zonal_list"] for item in diag_var_list):
-                    diag_var_list += ["PMID"]
-            if "T" not in diag_var_list:
-                if any(item in res["aerosol_zonal_list"] for item in diag_var_list):
-                    diag_var_list += ["T"]
-            #End aerosol calcs
+                # Aerosol Calcs
+                #--------------
+                #Always make sure PMID is made if aerosols are desired in config file
+                if "PMID" not in diag_var_list:
+                    if any(item in res["aerosol_zonal_list"] for item in diag_var_list):
+                        diag_var_list += ["PMID"]
+                if "T" not in diag_var_list:
+                    if any(item in res["aerosol_zonal_list"] for item in diag_var_list):
+                        diag_var_list += ["T"]
+                #End aerosol calcs
 
-            for var in diag_var_list:
-                if var not in hist_file_var_list:
-                    vres = res.get(var, {})
-                    if "derivable_from" in vres:
-                        constit_list = vres["derivable_from"]
-                        for constit in constit_list:
-                            if constit not in diag_var_list:
-                                diag_var_list.append(constit)
-                        vars_to_derive.append(var)
-                        continue
-                    else:
-                        msg = f"WARNING: {var} is not in the file {hist_files[0]}."
-                        msg += " No time series will be generated."
-                        print(msg)
-                        continue
-
-                # Check if variable has a "lev" dimension according to first file:
-                has_lev = bool("lev" in hist_file_ds[var].dims)
-
-                # Create full path name, file name template:
-                # $cam_case_name.$hist_str.$variable.YYYYMM-YYYYMM.nc
-
-                ts_outfil_str = (
-                    ts_dir[case_idx]
-                    + os.sep
-                    + ".".join([case_name, hist_str, var, time_string, "nc"])
-                )
-
-                # Check if files already exist in time series directory:
-                ts_file_list = glob.glob(ts_outfil_str)
-
-                # If files exist, then check if over-writing is allowed:
-                if ts_file_list:
-                    if not overwrite_ts[case_idx]:
-                        # If not, then simply skip this variable:
-                        continue
-
-                # Notify user of new time series file:
-                print(f"\t - time series for {var}")
-
-                # Variable list starts with just the variable
-                ncrcat_var_list = f"{var}"
-
-                # Determine "ncrcat" command to generate time series file:
-                if "date" in hist_file_ds[var].dims:
-                    ncrcat_var_list = ncrcat_var_list + ",date"
-                if "datesec" in hist_file_ds[var].dims:
-                    ncrcat_var_list = ncrcat_var_list + ",datesec"
-
-                if has_lev and vert_coord_type:
-                    # For now, only add these variables if using CAM:
-                    if "cam" in hist_str:
-                        # PS might be in a different history file. If so, continue without error.
-                        ncrcat_var_list = ncrcat_var_list + ",hyam,hybm,hyai,hybi"
-
-                        if "PS" in hist_file_var_list:
-                            ncrcat_var_list = ncrcat_var_list + ",PS"
-                            print("Adding PS to file")
+                for var in diag_var_list:
+                    if var not in hist_file_var_list:
+                        vres = res.get(var, {})
+                        if "derivable_from" in vres:
+                            constit_list = vres["derivable_from"]
+                            for constit in constit_list:
+                                if constit not in diag_var_list:
+                                    diag_var_list.append(constit)
+                            vars_to_derive.append(var)
+                            continue
                         else:
-                            wmsg = "WARNING: PS not found in history file."
-                            wmsg += " It might be needed at some point."
-                            print(wmsg)
-                        # End if
+                            msg = f"WARNING: {var} is not in the file {hist_files[0]}."
+                            msg += " No time series will be generated."
+                            print(msg)
+                            continue
 
-                        if vert_coord_type == "height":
-                            # Adding PMID here works, but significantly increases
-                            # the storage (disk usage) requirements of the ADF.
-                            # This can be alleviated in the future by figuring out
-                            # a way to determine all of the regridding targets at
-                            # the start of the ADF run, and then regridding a single
-                            # PMID file to each one of those targets separately. -JN
-                            if "PMID" in hist_file_var_list:
-                                ncrcat_var_list = ncrcat_var_list + ",PMID"
-                                print("Adding PMID to file")
+                    # Check if variable has a "lev" dimension according to first file:
+                    has_lev = bool("lev" in hist_file_ds[var].dims)
+
+                    # Create full path name, file name template:
+                    # $cam_case_name.$hist_str.$variable.YYYYMM-YYYYMM.nc
+
+                    ts_outfil_str = (
+                        ts_dir[case_idx]
+                        + os.sep
+                        + ".".join([case_name, hist_str, var, time_string, "nc"])
+                    )
+
+                    # Check if files already exist in time series directory:
+                    ts_file_list = glob.glob(ts_outfil_str)
+
+                    # If files exist, then check if over-writing is allowed:
+                    if ts_file_list:
+                        if not overwrite_ts[case_idx]:
+                            # If not, then simply skip this variable:
+                            continue
+
+                    # Notify user of new time series file:
+                    print(f"\t - time series for {var}")
+
+                    # Variable list starts with just the variable
+                    ncrcat_var_list = f"{var}"
+
+                    # Determine "ncrcat" command to generate time series file:
+                    if "date" in hist_file_ds[var].dims:
+                        ncrcat_var_list = ncrcat_var_list + ",date"
+                    if "datesec" in hist_file_ds[var].dims:
+                        ncrcat_var_list = ncrcat_var_list + ",datesec"
+
+                    if has_lev and vert_coord_type:
+                        # For now, only add these variables if using CAM:
+                        if "cam" in hist_str:
+                            # PS might be in a different history file. If so, continue without error.
+                            ncrcat_var_list = ncrcat_var_list + ",hyam,hybm,hyai,hybi"
+
+                            if "PS" in hist_file_var_list:
+                                ncrcat_var_list = ncrcat_var_list + ",PS"
+                                print("Adding PS to file")
                             else:
-                                wmsg = "WARNING: PMID not found in history file."
+                                wmsg = "WARNING: PS not found in history file."
                                 wmsg += " It might be needed at some point."
                                 print(wmsg)
-                            # End if PMID
-                        # End if height
-                    # End if cam
-                # End if has_lev
+                            # End if
 
-                cmd = (
-                    ["ncrcat", "-O", "-4", "-h", "--no_cll_mth", "-v", ncrcat_var_list]
-                    + hist_files
-                    + ["-o", ts_outfil_str]
-                )
+                            if vert_coord_type == "height":
+                                # Adding PMID here works, but significantly increases
+                                # the storage (disk usage) requirements of the ADF.
+                                # This can be alleviated in the future by figuring out
+                                # a way to determine all of the regridding targets at
+                                # the start of the ADF run, and then regridding a single
+                                # PMID file to each one of those targets separately. -JN
+                                if "PMID" in hist_file_var_list:
+                                    ncrcat_var_list = ncrcat_var_list + ",PMID"
+                                    print("Adding PMID to file")
+                                else:
+                                    wmsg = "WARNING: PMID not found in history file."
+                                    wmsg += " It might be needed at some point."
+                                    print(wmsg)
+                                # End if PMID
+                            # End if height
+                        # End if cam
+                    # End if has_lev
 
-                # Add to command list for use in multi-processing pool:
-                list_of_commands.append(cmd)
+                    cmd = (
+                        ["ncrcat", "-O", "-4", "-h", "--no_cll_mth", "-v", ncrcat_var_list]
+                        + hist_files
+                        + ["-o", ts_outfil_str]
+                    )
 
-            # End variable loop
+                    # Add to command list for use in multi-processing pool:
+                    list_of_commands.append(cmd)
 
-            # Now run the "ncrcat" subprocesses in parallel:
-            with mp.Pool(processes=self.num_procs) as mpool:
-                _ = mpool.map(call_ncrcat, list_of_commands)
+                # End variable loop
 
-            if vars_to_derive:
-                self.derive_variables(
-                    res=res, vars_to_derive=vars_to_derive, ts_dir=ts_dir[case_idx]
-                )
-            # End with
+                # Now run the "ncrcat" subprocesses in parallel:
+                with mp.Pool(processes=self.num_procs) as mpool:
+                    _ = mpool.map(call_ncrcat, list_of_commands)
+
+                if vars_to_derive:
+                    self.derive_variables(
+                        res=res, vars_to_derive=vars_to_derive, ts_dir=ts_dir[case_idx]
+                    )
+                # End with
+            # End for hist_str
 
         # End cases loop
 
@@ -1158,3 +1171,225 @@ def _load_dataset(fils):
     #End if
 #End def
 ########
+
+
+######### MDTF functions #########
+def move_tsfiles_for_mdtf(self, verbose):
+    """
+    Move ts files to the directory structure and names required by MDTF
+    Should change with data catalogues
+    """
+    cam_ts_loc = self.get_cam_info("cam_ts_loc", required=True)
+    self.expand_references({"cam_ts_loc": cam_ts_loc})
+    if verbose > 1:
+        print(f"\t Using timeseries files from {cam_ts_loc[0]}")
+
+    mdtf_model_data_root = self.get_mdtf_info("MODEL_DATA_ROOT")
+
+    # These MDTF words for day & month .But CESM will have hour_6 and hour_3, etc.
+    # Going to need a dict to translate.
+    # Use cesm_freq_strings = freq_string_options.keys
+    # and then freq = freq_string_option(freq_string_found)
+    freq_string_options = ["month", "day", "6hr", "3hr", "1hr"]
+
+    hist_str_list = self.get_cam_info("hist_str")
+    case_names = self.get_cam_info("cam_case_name", required=True)
+    var_list = self.diag_var_list
+
+    for case_idx, case_name in enumerate(case_names):
+
+        hist_str_case = hist_str_list[case_idx]
+        for hist_str in hist_str_case:
+            if verbose > 1:
+                print(f"\t looking for {hist_str} in {cam_ts_loc[0]}")
+            for var in var_list:
+
+                #
+                # Source file is ADF time series file
+                #
+                adf_file_str = (
+                    cam_ts_loc[case_idx]
+                    + os.sep
+                    + ".".join([case_name, hist_str, var, "*"])
+                )  # * to match timestamp: could be multiples
+                adf_file_list = glob.glob(adf_file_str)
+
+                if len(adf_file_list) == 1:
+                    if verbose > 2:
+                        print(f"Copying ts file: {adf_file_list} to MDTF dir")
+                elif len(adf_file_list) > 1:
+                    if verbose > 0:
+                        print(
+                            f"WARNING: found multiple timeseries files {adf_file_list}. Continuing with best guess; suggest cleaning up multiple dates in ts dir"
+                        )
+                else:
+                    if verbose > 0:
+                        print(
+                            f"WARNING: No files matching {case_name}.{hist_str}.{var} found in {adf_file_str}. Skipping"
+                        )
+                    continue  # skip this case/hist_str/var file
+                adf_file = adf_file_list[0]
+
+                # If freq is not set, it means we just started this hist_str. So check the first ADF file to find it
+                hist_file_ds = xr.open_dataset(
+                    adf_file, decode_cf=False, decode_times=False
+                )
+                if "time_period_freq" in hist_file_ds.attrs:
+                    dataset_freq = hist_file_ds.attrs["time_period_freq"]
+                    if verbose > 2:
+                        print(f"time_period_freq attribute found: {dataset_freq}")
+                else:
+                    if verbose > 0:
+                        print(
+                            f"WARNING: Necessary 'time_period_freq' attribute missing from {adf_file}. Skipping file."
+                        )
+                    continue
+
+                found_strings = [
+                    word for word in freq_string_options if word in dataset_freq
+                ]
+                if len(found_strings) == 1:
+                    if verbose > 2:
+                        print(
+                            f"Found dataset_freq {dataset_freq} matches {found_strings}"
+                        )
+                elif len(found_strings) > 1:
+                    if verbose > 0:
+                        print(
+                            f"WARNING: Found dataset_freq {dataset_freq} matches multiple string possibilities:{', '.join(found_strings)}"
+                        )
+                else:
+                    if verbose > 0:
+                        print(
+                            f"WARNING: None of the frequency options {freq_string_options} are present in the time_period_freq attribute {time_perido_freq}"
+                        )
+                        print(f"Skipping {adf_file}")
+                        freq = "frequency_missing"
+                    continue
+                freq = found_strings[0]
+
+                #
+                # Destination file is MDTF directory and name structure
+                #
+                mdtf_dir = os.path.join(mdtf_model_data_root, case_name, freq)
+
+                os.makedirs(mdtf_dir, exist_ok=True)
+                mdtf_file = (
+                    mdtf_dir + os.sep + ".".join([case_name, var, freq, "nc"])
+                )
+                mdtf_file_list = glob.glob(
+                    mdtf_file
+                )  # Check if file already exists in MDTF directory
+                if (
+                    mdtf_file_list
+                ):  # If file exists, don't overwrite:
+                    # To do in the future: add logic that says to over-write or not  
+                    if verbose > 1:
+                        print(
+                            f"\t   INFO: not clobbering existing mdtf file {mdtf_file_list}"
+                        )
+                    continue  # simply skip file copy for this variable:
+
+                if verbose > 1:
+                    print(f"copying {adf_file} to {mdtf_file}")
+                shutil.copyfile(adf_file, mdtf_file)
+            # end for hist_str
+        # end for var
+    # end for case
+
+def setup_run_mdtf(self):
+    """
+    Create MDTF directory tree, generate input setttings jsonc file
+    Submit MDTF diagnostics.
+
+    """
+
+    
+    copy_files_only = False  # True (copy files but don't run), False (copy files and run MDTF)
+    # Note that the MDTF variable test_mode (set in the mdtf_info of the yaml file) 
+    # has a different meaning: Data is fetched but PODs are not run.
+
+    print("\n  Setting up MDTF...")
+    # We want access to the entire dict of mdtf_info
+    mdtf_info = self.get_mdtf_info("ALL")  
+    verbose = mdtf_info["verbose"]
+
+    #
+    # Create a dict with all the case info needed for MDTF case_list
+    #     Note that model and convention are hard-coded to CESM because that's all we expect here
+    #     This could be changed by inputing them into ADF with other MDTF-specific variables
+    #
+    case_list_keys = ["CASENAME", "FIRSTYR", "LASTYR", "model", "convention"]
+
+    # Casenames, paths and start/end years come through the ADF
+    case_names = self.get_cam_info("cam_case_name", required=True)
+    start_years = self.climo_yrs["syears"]
+    end_years = self.climo_yrs["eyears"]
+
+    case_list_all = []
+    for icase, case in enumerate(case_names):
+        case_list_values = [
+            case,
+            start_years[icase],
+            end_years[icase],
+            "CESM",
+            "CESM",
+        ]
+        case_list_all.append(dict(zip(case_list_keys, case_list_values)))
+    mdtf_info["case_list"] = (
+        case_list_all  # this list of dicts is the format wanted by MDTF
+    )
+
+    # The plot_path is given by case in ADF but MDTF needs one top dir, so use case 0
+    # Working dir and output dir can be different. These could be set in config.yaml
+    # but then we don't get the nicely formated plot_location
+    case_idx = 0
+    plot_path = os.path.join(self.plot_location[case_idx], "mdtf")
+    for var in ["WORKING_DIR", "OUTPUT_DIR"]:
+        if mdtf_info[var] == "default":
+            mdtf_info[var] = plot_path
+
+
+    #
+    # Write the input settings json file
+    #
+    mdtf_input_settings_filename = self.get_mdtf_info(
+        "mdtf_input_settings_filename", required=True
+    )
+
+    with open(
+        mdtf_input_settings_filename,
+        "w",
+        encoding="utf-8",
+    ) as out_file:
+        json.dump(mdtf_info, out_file, sort_keys=True, indent=4, ensure_ascii=False)
+    mdtf_codebase = self.get_mdtf_info("mdtf_codebase_loc")
+    print(f"\t Using MDTF code base {mdtf_codebase}")
+
+    #
+    # Move the data to the dir structure and file names expected by the MDTF
+    #    model_input_data/case/freq/case.VAR.freq.nc
+
+    self.move_tsfiles_for_mdtf(verbose)
+
+    #
+    # Submit the MDTF script in background mode, send output to mdtf.out file
+    #
+    mdtf_log = "mdtf.out" # maybe set this to cam_diag_plot_loc: /glade/scratch/${user}/ADF/plots
+    mdtf_exe = mdtf_codebase + os.sep + "mdtf -f " + mdtf_input_settings_filename
+    if copy_files_only:
+        print("\t ...Copy files only. NOT Running MDTF")
+        print(f"\t    Command: {mdtf_exe} Log: {mdtf_log}")
+    else:
+        print(
+            f"\t ...Running MDTF in background. Command: {mdtf_exe} Log: {mdtf_log}"
+        )
+        print(f"Running MDTF in background. Command: {mdtf_exe} Log: {mdtf_log}")
+        with open(mdtf_log, "w", encoding="utf-8") as subout:
+            _ = subprocess.Popen(
+                [mdtf_exe],
+                shell=True,
+                stdout=subout,
+                stderr=subout,
+                close_fds=True,
+            )

--- a/lib/adf_diag.py
+++ b/lib/adf_diag.py
@@ -874,9 +874,6 @@ class AdfDiag(AdfWeb):
 
         """
 
-        # import needed standard modules:
-        import shutil
-
         # Case names:
         case_names = self.get_cam_info("cam_case_name", required=True)
 

--- a/lib/adf_diag.py
+++ b/lib/adf_diag.py
@@ -546,39 +546,42 @@ class AdfDiag(AdfWeb):
 
                     #Check if current variable is a derived quantity
                     if var not in hist_file_var_list:
+
+                        #Try to get varible defaults dictionary for
+                        #non-present quantity
                         vres = res.get(var, {})
 
-                    #Initialiaze list for constituents
-                    #NOTE: This is if the variable is NOT derivable but needs
-                    # an empty list as a check later
-                    constit_list = []
+                        #Initialiaze list for constituents
+                        #NOTE: This is if the variable is NOT derivable but needs
+                        # an empty list as a check later
+                        constit_list = []
 
-                    #intialize boolean to check if variable is derivable
-                    derive = False # assume it can't be derived and update if it can
+                        #intialize boolean to check if variable is derivable
+                        derive = False # assume it can't be derived and update if it can
 
-                    #intialize boolean for regular CAM variable constituents
-                    try_cam_constits = True
+                        #intialize boolean for regular CAM variable constituents
+                        try_cam_constits = True
 
-                    #Check first if variable is potentially part of a CAM-CHEM run
-                    if "derivable_from_cam_chem" in vres:
-                        constit_list = vres["derivable_from_cam_chem"]
-                        if constit_list:
-                            if all(item in hist_file_ds.data_vars for item in constit_list):
-                                #Set check to look for regular CAM constituents in variable defaults
-                                try_cam_constits = False
-                                derive = True
-                                msg = f"create time series for {case_name}:"
-                                msg += "\n\tLooks like this a CAM-CHEM run, "
-                                msg += f"checking constituents for '{var}'"
-                                self.debug_log(msg)
-                        else:
-                            self.debug_log(constit_errmsg)
+                        #Check first if variable is potentially part of a CAM-CHEM run
+                        if "derivable_from_cam_chem" in vres:
+                            constit_list = vres["derivable_from_cam_chem"]
+                            if constit_list:
+                                if all(item in hist_file_ds.data_vars for item in constit_list):
+                                    #Set check to look for regular CAM constituents in variable defaults
+                                    try_cam_constits = False
+                                    derive = True
+                                    msg = f"create time series for {case_name}:"
+                                    msg += "\n\tLooks like this a CAM-CHEM run, "
+                                    msg += f"checking constituents for '{var}'"
+                                    self.debug_log(msg)
+                            else:
+                                self.debug_log(constit_errmsg)
+                            #End if
                         #End if
-                    #End if
 
-                    #If not CAM-CHEM, check regular CAM runs
-                    if try_cam_constits:
-                        if "derivable_from" in vres:
+                        #If not CAM-CHEM, check regular CAM runs
+                        if try_cam_constits:
+                            if "derivable_from" in vres:
                             derive = True
                             constit_list = vres["derivable_from"]
                         else:
@@ -592,31 +595,31 @@ class AdfDiag(AdfWeb):
                             der_from_msg += "defaults yaml file."
                             self.debug_log(der_from_msg)
                         #End if
-                    #End if
 
-                    #Check if this variable can be derived
-                    if (derive) and (constit_list):
-                        for constit in constit_list:
-                            if constit not in diag_var_list:
-                                diag_var_list.append(constit)
-                        #Add variable to list to derive
-                        vars_to_derive.append(var)
-                        #Add constituent list to variable key in dictionary
-                        constit_dict[var] = constit_list
-                        continue
-                    #Log if this variable can be derived but is missing list of constituents
-                    elif (derive) and (not constit_list):
-                        self.debug_log(constit_errmsg)
-                        continue
-                    #Lastly, raise error if the variable is not a derived quanitity but is also not
-                    #in the history file(s)
-                    else:
-                        msg = f"WARNING: {var} is not in the file {hist_files[0]} "
-                        msg += "nor can it be derived.\n"
-                        msg += "\t  ** No time series will be generated."
-                        print(msg)
-                        continue
-                    #End if
+                        #Check if this variable can be derived
+                        if (derive) and (constit_list):
+                            for constit in constit_list:
+                                if constit not in diag_var_list:
+                                    diag_var_list.append(constit)
+                            #Add variable to list to derive
+                            vars_to_derive.append(var)
+                            #Add constituent list to variable key in dictionary
+                            constit_dict[var] = constit_list
+                            continue
+                        #Log if this variable can be derived but is missing list of constituents
+                        elif (derive) and (not constit_list):
+                            self.debug_log(constit_errmsg)
+                            continue
+                        #Lastly, raise error if the variable is not a derived quanitity but is also not
+                        #in the history file(s)
+                        else:
+                            msg = f"WARNING: {var} is not in the file {hist_files[0]} "
+                            msg += "nor can it be derived.\n"
+                            msg += "\t  ** No time series will be generated."
+                            print(msg)
+                            continue
+                        #End if
+                    #End if (var in var_diag_list)
 
                     # Check if variable has a "lev" dimension according to first file:
                     has_lev = bool("lev" in hist_file_ds[var].dims)
@@ -1122,16 +1125,16 @@ class AdfDiag(AdfWeb):
                 if constit_files:
                     #Add what's missing to debug log
                     dmsg = "create time series:"
-                    dmsg += f"\n\tneeded constituents for derivation of "
+                    dmsg += "\n\tneeded constituents for derivation of "
                     dmsg += f"{var}:\n\t\t- {constit_list}\n\tfound constituent file(s) in "
                     dmsg += f"{Path(constit_files[0]).parent}:\n\t\t"
                     dmsg += f"- {[Path(f).parts[-1] for f in constit_files if Path(f).is_file()]}"
                     self.debug_log(dmsg)
                 else:
                     dmsg = "create time series:"
-                    dmsg += f"\n\tneeded constituents for derivation of "
+                    dmsg += "\n\tneeded constituents for derivation of "
                     dmsg += f"{var}:\n\t\t- {constit_list}\n"
-                    dmsg += f"\tNo constituent(s) found in history files"
+                    dmsg += "\tNo constituent(s) found in history files"
                     self.debug_log(dmsg)
 
             else:

--- a/lib/adf_diag.py
+++ b/lib/adf_diag.py
@@ -1138,7 +1138,7 @@ class AdfDiag(AdfWeb):
     ######### MDTF functions #########
     def setup_run_mdtf(self):
         """
-        Create MDTF directory tree, generate input setttings jsonc file
+        Create MDTF directory tree, generate input settings jsonc file
         Submit MDTF diagnostics.
 
         """

--- a/lib/adf_diag.py
+++ b/lib/adf_diag.py
@@ -339,8 +339,7 @@ class AdfDiag(AdfWeb):
 
         # End def
 
-        # Notify user that script has started:
-        print("\n  Generating CAM time series files...")
+        print(f"\n  Generating CAM time series files...")
 
         # Check if baseline time-series files are being created:
         if baseline:
@@ -367,7 +366,6 @@ class AdfDiag(AdfWeb):
             case_type_string="case"
 
         # Notify user that script has started:
-        print("\n  Generating CAM time series files for {case_type_string}...")
 
         # End if
 
@@ -407,7 +405,7 @@ class AdfDiag(AdfWeb):
             hist_str_case = hist_str_list[case_idx]
             for hist_str in hist_str_case:
 
-                print(f"\t Processing time series for {case_type_string} {case_name=}, {hist_str=} files:")
+                print(f"\t Processing time series for {case_type_string} {case_name}, {hist_str} files:")
                 if not list(starting_location.glob("*" + hist_str + ".*.nc")):
                     emsg = (
                         f"No history *{hist_str}.*.nc files found in '{starting_location}'."
@@ -1133,9 +1131,234 @@ class AdfDiag(AdfWeb):
                 ds_final = ds.drop_vars(constit_list)
                 ds_final.to_netcdf(derived_file, unlimited_dims='time', mode='w')
 
+    ######### MDTF functions #########
+    def setup_run_mdtf(self):
+        """
+        Create MDTF directory tree, generate input setttings jsonc file
+        Submit MDTF diagnostics.
+
+        """
+
+        
+        copy_files_only = False  # True (copy files but don't run), False (copy files and run MDTF)
+        # Note that the MDTF variable test_mode (set in the mdtf_info of the yaml file) 
+        # has a different meaning: Data is fetched but PODs are not run.
+
+        print("\n  Setting up MDTF...")
+        # We want access to the entire dict of mdtf_info
+        mdtf_info = self.get_mdtf_info("ALL")  
+        verbose = mdtf_info["verbose"]
+
+        #
+        # Create a dict with all the case info needed for MDTF case_list
+        #     Note that model and convention are hard-coded to CESM because that's all we expect here
+        #     This could be changed by inputing them into ADF with other MDTF-specific variables
+        #
+        case_list_keys = ["CASENAME", "FIRSTYR", "LASTYR", "model", "convention"]
+
+        # Casenames, paths and start/end years come through the ADF
+        case_names = self.get_cam_info("cam_case_name", required=True)
+        start_years = self.climo_yrs["syears"]
+        end_years = self.climo_yrs["eyears"]
+
+        case_list_all = []
+        for icase, case in enumerate(case_names):
+            case_list_values = [
+                case,
+                start_years[icase],
+                end_years[icase],
+                "CESM",
+                "CESM",
+            ]
+            case_list_all.append(dict(zip(case_list_keys, case_list_values)))
+        mdtf_info["case_list"] = (
+            case_list_all  # this list of dicts is the format wanted by MDTF
+        )
+
+        # The plot_path is given by case in ADF but MDTF needs one top dir, so use case 0
+        # Working dir and output dir can be different. These could be set in config.yaml
+        # but then we don't get the nicely formated plot_location
+        case_idx = 0
+        plot_path = os.path.join(self.plot_location[case_idx], "mdtf")
+        for var in ["WORKING_DIR", "OUTPUT_DIR"]:
+            if mdtf_info[var] == "default":
+                mdtf_info[var] = plot_path
+
+
+        #
+        # Write the input settings json file
+        #
+        mdtf_input_settings_filename = self.get_mdtf_info(
+            "mdtf_input_settings_filename", required=True
+        )
+
+        with open(
+            mdtf_input_settings_filename,
+            "w",
+            encoding="utf-8",
+        ) as out_file:
+            json.dump(mdtf_info, out_file, sort_keys=True, indent=4, ensure_ascii=False)
+        mdtf_codebase = self.get_mdtf_info("mdtf_codebase_loc")
+        print(f"\t Using MDTF code base {mdtf_codebase}")
+
+        #
+        # Move the data to the dir structure and file names expected by the MDTF
+        #    model_input_data/case/freq/case.VAR.freq.nc
+
+        self.move_tsfiles_for_mdtf(verbose)
+
+        #
+        # Submit the MDTF script in background mode, send output to mdtf.out file
+        #
+        mdtf_log = "mdtf.out" # maybe set this to cam_diag_plot_loc: /glade/scratch/${user}/ADF/plots
+        mdtf_exe = mdtf_codebase + os.sep + "mdtf -f " + mdtf_input_settings_filename
+        if copy_files_only:
+            print("\t ...Copy files only. NOT Running MDTF")
+            print(f"\t    Command: {mdtf_exe} Log: {mdtf_log}")
+        else:
+            print(
+                f"\t ...Running MDTF in background. Command: {mdtf_exe} Log: {mdtf_log}"
+            )
+            print(f"Running MDTF in background. Command: {mdtf_exe} Log: {mdtf_log}")
+            with open(mdtf_log, "w", encoding="utf-8") as subout:
+                _ = subprocess.Popen(
+                    [mdtf_exe],
+                    shell=True,
+                    stdout=subout,
+                    stderr=subout,
+                    close_fds=True,
+                )
+
+    def move_tsfiles_for_mdtf(self, verbose):
+        """
+        Move ts files to the directory structure and names required by MDTF
+        Should change with data catalogues
+        """
+        cam_ts_loc = self.get_cam_info("cam_ts_loc", required=True)
+        self.expand_references({"cam_ts_loc": cam_ts_loc})
+        if verbose > 1:
+            print(f"\t Using timeseries files from {cam_ts_loc[0]}")
+
+        mdtf_model_data_root = self.get_mdtf_info("MODEL_DATA_ROOT")
+
+        # These MDTF words for day & month .But CESM will have hour_6 and hour_3, etc.
+        # Going to need a dict to translate.
+        # Use cesm_freq_strings = freq_string_options.keys
+        # and then freq = freq_string_option(freq_string_found)
+        freq_string_options = ["month", "day", "6hr", "3hr", "1hr"]
+
+        hist_str_list = self.get_cam_info("hist_str")
+        case_names = self.get_cam_info("cam_case_name", required=True)
+        var_list = self.diag_var_list
+
+        for case_idx, case_name in enumerate(case_names):
+
+            hist_str_case = hist_str_list[case_idx]
+            for hist_str in hist_str_case:
+                if verbose > 1:
+                    print(f"\t looking for {hist_str} in {cam_ts_loc[0]}")
+                for var in var_list:
+
+                    #
+                    # Source file is ADF time series file
+                    #
+                    adf_file_str = (
+                        cam_ts_loc[case_idx]
+                        + os.sep
+                        + ".".join([case_name, hist_str, var, "*"])
+                    )  # * to match timestamp: could be multiples
+                    adf_file_list = glob.glob(adf_file_str)
+
+                    if len(adf_file_list) == 1:
+                        if verbose > 2:
+                            print(f"Copying ts file: {adf_file_list} to MDTF dir")
+                    elif len(adf_file_list) > 1:
+                        if verbose > 0:
+                            print(
+                                f"WARNING: found multiple timeseries files {adf_file_list}. Continuing with best guess; suggest cleaning up multiple dates in ts dir"
+                            )
+                    else:
+                        if verbose > 0:
+                            print(
+                                f"WARNING: No files matching {case_name}.{hist_str}.{var} found in {adf_file_str}. Skipping"
+                            )
+                        continue  # skip this case/hist_str/var file
+                    adf_file = adf_file_list[0]
+
+                    # If freq is not set, it means we just started this hist_str. So check the first ADF file to find it
+                    hist_file_ds = xr.open_dataset(
+                        adf_file, decode_cf=False, decode_times=False
+                    )
+                    if "time_period_freq" in hist_file_ds.attrs:
+                        dataset_freq = hist_file_ds.attrs["time_period_freq"]
+                        if verbose > 2:
+                            print(f"time_period_freq attribute found: {dataset_freq}")
+                    else:
+                        if verbose > 0:
+                            print(
+                                f"WARNING: Necessary 'time_period_freq' attribute missing from {adf_file}. Skipping file."
+                            )
+                        continue
+
+                    found_strings = [
+                        word for word in freq_string_options if word in dataset_freq
+                    ]
+                    if len(found_strings) == 1:
+                        if verbose > 2:
+                            print(
+                                f"Found dataset_freq {dataset_freq} matches {found_strings}"
+                            )
+                    elif len(found_strings) > 1:
+                        if verbose > 0:
+                            print(
+                                f"WARNING: Found dataset_freq {dataset_freq} matches multiple string possibilities:{', '.join(found_strings)}"
+                            )
+                    else:
+                        if verbose > 0:
+                            print(
+                                f"WARNING: None of the frequency options {freq_string_options} are present in the time_period_freq attribute {time_period_freq}"
+                            )
+                            print(f"Skipping {adf_file}")
+                            freq = "frequency_missing"
+                        continue
+                    freq = found_strings[0]
+
+                    #
+                    # Destination file is MDTF directory and name structure
+                    #
+                    mdtf_dir = os.path.join(mdtf_model_data_root, case_name, freq)
+
+                    os.makedirs(mdtf_dir, exist_ok=True)
+                    mdtf_file = (
+                        mdtf_dir + os.sep + ".".join([case_name, var, freq, "nc"])
+                    )
+                    mdtf_file_list = glob.glob(
+                        mdtf_file
+                    )  # Check if file already exists in MDTF directory
+                    if (
+                        mdtf_file_list
+                    ):  # If file exists, don't overwrite:
+                        # To do in the future: add logic that says to over-write or not  
+                        if verbose > 1:
+                            print(
+                                f"\t   INFO: not clobbering existing mdtf file {mdtf_file_list}"
+                            )
+                        continue  # simply skip file copy for this variable:
+
+                    if verbose > 1:
+                        print(f"copying {adf_file} to {mdtf_file}")
+                    shutil.copyfile(adf_file, mdtf_file)
+                # end for hist_str
+            # end for var
+        # end for case
+
+
+
 ########
 
 #Helper Function(s)
+
+
 def _load_dataset(fils):
     """
     This method exists to get an xarray Dataset from input file information that can be passed into the plotting methods.
@@ -1173,223 +1396,3 @@ def _load_dataset(fils):
 ########
 
 
-######### MDTF functions #########
-def move_tsfiles_for_mdtf(self, verbose):
-    """
-    Move ts files to the directory structure and names required by MDTF
-    Should change with data catalogues
-    """
-    cam_ts_loc = self.get_cam_info("cam_ts_loc", required=True)
-    self.expand_references({"cam_ts_loc": cam_ts_loc})
-    if verbose > 1:
-        print(f"\t Using timeseries files from {cam_ts_loc[0]}")
-
-    mdtf_model_data_root = self.get_mdtf_info("MODEL_DATA_ROOT")
-
-    # These MDTF words for day & month .But CESM will have hour_6 and hour_3, etc.
-    # Going to need a dict to translate.
-    # Use cesm_freq_strings = freq_string_options.keys
-    # and then freq = freq_string_option(freq_string_found)
-    freq_string_options = ["month", "day", "6hr", "3hr", "1hr"]
-
-    hist_str_list = self.get_cam_info("hist_str")
-    case_names = self.get_cam_info("cam_case_name", required=True)
-    var_list = self.diag_var_list
-
-    for case_idx, case_name in enumerate(case_names):
-
-        hist_str_case = hist_str_list[case_idx]
-        for hist_str in hist_str_case:
-            if verbose > 1:
-                print(f"\t looking for {hist_str} in {cam_ts_loc[0]}")
-            for var in var_list:
-
-                #
-                # Source file is ADF time series file
-                #
-                adf_file_str = (
-                    cam_ts_loc[case_idx]
-                    + os.sep
-                    + ".".join([case_name, hist_str, var, "*"])
-                )  # * to match timestamp: could be multiples
-                adf_file_list = glob.glob(adf_file_str)
-
-                if len(adf_file_list) == 1:
-                    if verbose > 2:
-                        print(f"Copying ts file: {adf_file_list} to MDTF dir")
-                elif len(adf_file_list) > 1:
-                    if verbose > 0:
-                        print(
-                            f"WARNING: found multiple timeseries files {adf_file_list}. Continuing with best guess; suggest cleaning up multiple dates in ts dir"
-                        )
-                else:
-                    if verbose > 0:
-                        print(
-                            f"WARNING: No files matching {case_name}.{hist_str}.{var} found in {adf_file_str}. Skipping"
-                        )
-                    continue  # skip this case/hist_str/var file
-                adf_file = adf_file_list[0]
-
-                # If freq is not set, it means we just started this hist_str. So check the first ADF file to find it
-                hist_file_ds = xr.open_dataset(
-                    adf_file, decode_cf=False, decode_times=False
-                )
-                if "time_period_freq" in hist_file_ds.attrs:
-                    dataset_freq = hist_file_ds.attrs["time_period_freq"]
-                    if verbose > 2:
-                        print(f"time_period_freq attribute found: {dataset_freq}")
-                else:
-                    if verbose > 0:
-                        print(
-                            f"WARNING: Necessary 'time_period_freq' attribute missing from {adf_file}. Skipping file."
-                        )
-                    continue
-
-                found_strings = [
-                    word for word in freq_string_options if word in dataset_freq
-                ]
-                if len(found_strings) == 1:
-                    if verbose > 2:
-                        print(
-                            f"Found dataset_freq {dataset_freq} matches {found_strings}"
-                        )
-                elif len(found_strings) > 1:
-                    if verbose > 0:
-                        print(
-                            f"WARNING: Found dataset_freq {dataset_freq} matches multiple string possibilities:{', '.join(found_strings)}"
-                        )
-                else:
-                    if verbose > 0:
-                        print(
-                            f"WARNING: None of the frequency options {freq_string_options} are present in the time_period_freq attribute {time_perido_freq}"
-                        )
-                        print(f"Skipping {adf_file}")
-                        freq = "frequency_missing"
-                    continue
-                freq = found_strings[0]
-
-                #
-                # Destination file is MDTF directory and name structure
-                #
-                mdtf_dir = os.path.join(mdtf_model_data_root, case_name, freq)
-
-                os.makedirs(mdtf_dir, exist_ok=True)
-                mdtf_file = (
-                    mdtf_dir + os.sep + ".".join([case_name, var, freq, "nc"])
-                )
-                mdtf_file_list = glob.glob(
-                    mdtf_file
-                )  # Check if file already exists in MDTF directory
-                if (
-                    mdtf_file_list
-                ):  # If file exists, don't overwrite:
-                    # To do in the future: add logic that says to over-write or not  
-                    if verbose > 1:
-                        print(
-                            f"\t   INFO: not clobbering existing mdtf file {mdtf_file_list}"
-                        )
-                    continue  # simply skip file copy for this variable:
-
-                if verbose > 1:
-                    print(f"copying {adf_file} to {mdtf_file}")
-                shutil.copyfile(adf_file, mdtf_file)
-            # end for hist_str
-        # end for var
-    # end for case
-
-def setup_run_mdtf(self):
-    """
-    Create MDTF directory tree, generate input setttings jsonc file
-    Submit MDTF diagnostics.
-
-    """
-
-    
-    copy_files_only = False  # True (copy files but don't run), False (copy files and run MDTF)
-    # Note that the MDTF variable test_mode (set in the mdtf_info of the yaml file) 
-    # has a different meaning: Data is fetched but PODs are not run.
-
-    print("\n  Setting up MDTF...")
-    # We want access to the entire dict of mdtf_info
-    mdtf_info = self.get_mdtf_info("ALL")  
-    verbose = mdtf_info["verbose"]
-
-    #
-    # Create a dict with all the case info needed for MDTF case_list
-    #     Note that model and convention are hard-coded to CESM because that's all we expect here
-    #     This could be changed by inputing them into ADF with other MDTF-specific variables
-    #
-    case_list_keys = ["CASENAME", "FIRSTYR", "LASTYR", "model", "convention"]
-
-    # Casenames, paths and start/end years come through the ADF
-    case_names = self.get_cam_info("cam_case_name", required=True)
-    start_years = self.climo_yrs["syears"]
-    end_years = self.climo_yrs["eyears"]
-
-    case_list_all = []
-    for icase, case in enumerate(case_names):
-        case_list_values = [
-            case,
-            start_years[icase],
-            end_years[icase],
-            "CESM",
-            "CESM",
-        ]
-        case_list_all.append(dict(zip(case_list_keys, case_list_values)))
-    mdtf_info["case_list"] = (
-        case_list_all  # this list of dicts is the format wanted by MDTF
-    )
-
-    # The plot_path is given by case in ADF but MDTF needs one top dir, so use case 0
-    # Working dir and output dir can be different. These could be set in config.yaml
-    # but then we don't get the nicely formated plot_location
-    case_idx = 0
-    plot_path = os.path.join(self.plot_location[case_idx], "mdtf")
-    for var in ["WORKING_DIR", "OUTPUT_DIR"]:
-        if mdtf_info[var] == "default":
-            mdtf_info[var] = plot_path
-
-
-    #
-    # Write the input settings json file
-    #
-    mdtf_input_settings_filename = self.get_mdtf_info(
-        "mdtf_input_settings_filename", required=True
-    )
-
-    with open(
-        mdtf_input_settings_filename,
-        "w",
-        encoding="utf-8",
-    ) as out_file:
-        json.dump(mdtf_info, out_file, sort_keys=True, indent=4, ensure_ascii=False)
-    mdtf_codebase = self.get_mdtf_info("mdtf_codebase_loc")
-    print(f"\t Using MDTF code base {mdtf_codebase}")
-
-    #
-    # Move the data to the dir structure and file names expected by the MDTF
-    #    model_input_data/case/freq/case.VAR.freq.nc
-
-    self.move_tsfiles_for_mdtf(verbose)
-
-    #
-    # Submit the MDTF script in background mode, send output to mdtf.out file
-    #
-    mdtf_log = "mdtf.out" # maybe set this to cam_diag_plot_loc: /glade/scratch/${user}/ADF/plots
-    mdtf_exe = mdtf_codebase + os.sep + "mdtf -f " + mdtf_input_settings_filename
-    if copy_files_only:
-        print("\t ...Copy files only. NOT Running MDTF")
-        print(f"\t    Command: {mdtf_exe} Log: {mdtf_log}")
-    else:
-        print(
-            f"\t ...Running MDTF in background. Command: {mdtf_exe} Log: {mdtf_log}"
-        )
-        print(f"Running MDTF in background. Command: {mdtf_exe} Log: {mdtf_log}")
-        with open(mdtf_log, "w", encoding="utf-8") as subout:
-            _ = subprocess.Popen(
-                [mdtf_exe],
-                shell=True,
-                stdout=subout,
-                stderr=subout,
-                close_fds=True,
-            )

--- a/lib/adf_info.py
+++ b/lib/adf_info.py
@@ -240,6 +240,8 @@ class AdfInfo(AdfConfig):
 
             # Check if history file path exists:
             if any(baseline_hist_locs):
+                if not isinstance(baseline_hist_str, list):
+                    baseline_hist_str = [baseline_hist_str]
                 hist_str = baseline_hist_str[0]
                 starting_location = Path(baseline_hist_locs)
                 file_list = sorted(starting_location.glob("*" + hist_str + ".*.nc"))

--- a/lib/adf_info.py
+++ b/lib/adf_info.py
@@ -124,15 +124,14 @@ class AdfInfo(AdfConfig):
                 self.__cam_climo_info[conf_var] = [conf_val]
             #End if
         #End for
-        #-------------------------------------------
 
-        #Read hist_str (component.hist_num) from the yaml file, or set to default
-        hist_str = self.__cam_climo_info('hist_str')
-        #If hist_str is not present, then default to 'cam.h0a':
+        #If hist_str (component.hist_num) was not in yaml file, set to default
+        hist_str = self.__cam_climo_info['hist_str']
         if not hist_str:
             hist_str = [['cam.h0a']]*self.__num_cases
         #End if
-        self.__hist_str = hist_str
+
+        #-------------------------------------------
 
         #Initialize ADF variable list:
         self.__diag_var_list = self.read_config_var('diag_var_list', required=True)
@@ -338,7 +337,7 @@ class AdfInfo(AdfConfig):
         cam_hist_locs = self.get_cam_info('cam_hist_loc')
 
         # Read hist_str (component.hist_num, eg cam.h0) from the yaml file
-        cam_hist_str = self.__hist_str
+        cam_hist_str = self.get_cam_info('hist_str')
 
         #Check if using pre-made ts files
         cam_ts_done   = self.get_cam_info("cam_ts_done")

--- a/lib/adf_info.py
+++ b/lib/adf_info.py
@@ -183,6 +183,9 @@ class AdfInfo(AdfConfig):
             #Get climo years for verification or assignment if missing
             baseline_hist_locs = self.get_baseline_info('cam_hist_loc')
 
+            # Read hist_str (component.hist_num, eg cam.h0) from the yaml file
+            baseline_hist_str = self.get_baseline_info("hist_str")
+
             #Check if any time series files are pre-made
             baseline_ts_done   = self.get_baseline_info("cam_ts_done")
 

--- a/lib/adf_info.py
+++ b/lib/adf_info.py
@@ -31,12 +31,15 @@ dictionaries.
 from pathlib import Path
 import copy
 import os
-import numpy as np
-import xarray as xr
 
 #+++++++++++++++++++++++++++++++++++++++++++++++++
 #import non-standard python modules, including ADF
 #+++++++++++++++++++++++++++++++++++++++++++++++++
+
+# pylint: disable=unused-import
+import numpy as np
+import xarray as xr
+# pylint: enable=unused-import
 
 #ADF modules:
 from adf_config import AdfConfig
@@ -90,7 +93,7 @@ class AdfInfo(AdfConfig):
         if self.__mdtf_info is not None:
             self.expand_references(self.__mdtf_info)
         # End if
-        
+
         # Check if inputs are of the correct type:
         # -------------------------------------------
 
@@ -329,7 +332,7 @@ class AdfInfo(AdfConfig):
 
         #Check if using pre-made ts files
         cam_ts_done   = self.get_cam_info("cam_ts_done")
-        
+
         #Grab case time series file location(s)
         input_ts_locs = self.get_cam_info("cam_ts_loc", required=True)
 
@@ -439,6 +442,7 @@ class AdfInfo(AdfConfig):
             self.__plot_location.append(os.path.join(plot_dir, direc_name))
 
             #If first iteration, then save directory name for use by baseline:
+            first_case_dir = ''
             if case_idx == 0:
                 first_case_dir = direc_name
             #End if
@@ -525,7 +529,7 @@ class AdfInfo(AdfConfig):
         else:  # one case, one hist str
             hist_str = [
                 conf_val
-            ]  
+            ]
         self.__cam_climo_info[conf_var] = [hist_str]
         # -----------------------------------------
 
@@ -617,7 +621,7 @@ class AdfInfo(AdfConfig):
     def get_basic_info(self, var_str, required=False):
         """
         Return the config variable from 'diag_basic_info' as requested by
-        the user.  
+        the user.
         """
 
         return self.read_config_var(var_str,
@@ -706,10 +710,10 @@ class AdfInfo(AdfConfig):
         return self.read_config_var(
             var_str, conf_dict=self.__mdtf_info, required=required
         )
- 
-        
+
+
     #########
-   
+
     # Utility function to grab climo years from pre-made time series files:
     def get_climo_yrs_from_ts(self, input_ts_loc, case_name):
         """
@@ -747,7 +751,7 @@ class AdfInfo(AdfConfig):
         #Average time dimension over time bounds, if bounds exist:
         if 'time_bnds' in cam_ts_data:
             time = cam_ts_data['time']
-            #NOTE: force `load` here b/c if dask & time is cftime, 
+            #NOTE: force `load` here b/c if dask & time is cftime,
             #throws a NotImplementedError:
             time = xr.DataArray(cam_ts_data['time_bnds'].load().mean(dim='nbnd').values, dims=time.dims, attrs=time.attrs)
             cam_ts_data['time'] = time

--- a/lib/adf_info.py
+++ b/lib/adf_info.py
@@ -524,7 +524,7 @@ class AdfInfo(AdfConfig):
         """
         Make hist_str a nested list [ncases,nfiles] of the given value(s)
         """
-        if isinstance(self.get_cam_info("hist_str", required=True), list):
+        if isinstance(conf_val, list):
             hist_str = conf_val
         else:  # one case, one hist str
             hist_str = [

--- a/run_adf_diag
+++ b/run_adf_diag
@@ -157,6 +157,10 @@ if __name__ == "__main__":
     if diag.get_cvdp_info('cvdp_run'):
        diag.setup_run_cvdp()
 
+    #Call the MDTF:
+    if diag.get_mdtf_info('mdtf_run'):
+       diag.setup_run_mdtf()
+
     #Create model climatology (climo) files.
     #This call uses the "time_averaging_scripts" specified
     #in the config file:

--- a/scripts/averaging/create_climo_files.py
+++ b/scripts/averaging/create_climo_files.py
@@ -160,8 +160,8 @@ def create_climo_files(adf, clobber=False, search=None):
             ts_filenames = search.format(CASE=case_name, HIST_STR="h0", VARIABLE=var)
             ts_files = sorted(list(input_location.glob(ts_filenames)))
 
-            #If no files exist, try to move to next variable. --> Means we can not proceed with this variable, and it'll be problematic later.
-            # unless there are multiple hist file streams and the variable is in the others
+            #If no files exist, try to move to next variable. --> Means we can not proceed with this variable,
+            # and it'll be problematic later unless there are multiple hist file streams and the variable is in the others
             if not ts_files:
                 errmsg = "Time series files for variable '{}' not found.  Script will continue to next variable.".format(var)
                 print(f"The input location searched was: {input_location}. The glob pattern was {ts_filenames}.")

--- a/scripts/averaging/create_climo_files.py
+++ b/scripts/averaging/create_climo_files.py
@@ -137,7 +137,7 @@ def create_climo_files(adf, clobber=False, search=None):
 
         #Time series file search
         if search is None:
-            search = "{CASE}*.{VARIABLE}.*nc"  # NOTE: maybe we should not care about the file extension part at all, but check file type later?
+            search = "{CASE}*{HIST_STR}*.{VARIABLE}.*nc"  # NOTE: maybe we should not care about the file extension part at all, but check file type later?
 
         #Check model year bounds:
         syr, eyr = check_averaging_interval(start_year[case_idx], end_year[case_idx])
@@ -156,10 +156,12 @@ def create_climo_files(adf, clobber=False, search=None):
                 print(f"\t    INFO: Climo file exists for {var}, but clobber is {clobber}, so will OVERWRITE it.")
 
             #Create list of time series files present for variable:
-            ts_filenames = search.format(CASE=case_name, VARIABLE=var)
+            # Note that we hard-code for h0 because we only want to make climos of monthly output
+            ts_filenames = search.format(CASE=case_name, HIST_STR="h0", VARIABLE=var)
             ts_files = sorted(list(input_location.glob(ts_filenames)))
 
             #If no files exist, try to move to next variable. --> Means we can not proceed with this variable, and it'll be problematic later.
+            # unless there are multiple hist file streams and the variable is in the others
             if not ts_files:
                 errmsg = "Time series files for variable '{}' not found.  Script will continue to next variable.".format(var)
                 print(f"The input location searched was: {input_location}. The glob pattern was {ts_filenames}.")


### PR DESCRIPTION
- Call [MDTF](https://mdtf-diagnostics.readthedocs.io/en/main/) from ADF

This adds a section in the config and run files so the ADF can directly call the [MDTF (Model Diagnostics Task Force (MDTF)-Diagnostics package) ](https://www.gfdl.noaa.gov/mdtf-diagnostics/).

This is the simplest possible implementation that calls an existing, installed version of the MDTF using existing, installed conda envs. For now, timeseries files will be copied to the requested MDTF directory/filenames. Imminent data catalogue functionality in MDTF might change this.

Basic documentation of new functionality:
in config.yaml, there is a new section:

> 
> diag_mdtf_info:
> mdtf_run: false [default]

If `mdtf_run:true:`
in run_adf_diag
>
> #Call the MDTF:
> if diag.get_mdtf_info('mdtf_run'):
> diag.setup_run_mdtf()

[Detailed documentation of implementation/call tree]
(https://www2.cgd.ucar.edu/cms/bundy/Projects/diagnostics/mdtf/notes/run_mdtf_from_adf.html#Documentation)


- Allow hist_str to be a list, and to be different for each cam case (and baseline)
The config.yaml file variable can now be a list, and is specified within the `diag_cam_climo` and `diag_cam_baseline_climo` lists
>
>hist_str: [cam.h2,cam.h0]

These timeseries files are all placed in the same ts/ directory, which may need to be modified for multiple component hist strings. (The MDTF checks file types for time frequency for its own purposes).