### PR TITLE
Small fixes

### DIFF
--- a/config_amwg_default_plots.yaml
+++ b/config_amwg_default_plots.yaml
@@ -66,8 +66,8 @@ diag_basic_info:
     #History file string to match (eg. cam.h0 or ocn.pop.h.ecosys.nday1)
     # Only affects timeseries as everything else uses timeseries
     # Leave off trailing '.'
-    #Default: cam.h0
-    hist_str: cam.h0
+    #Default: cam.h0a
+    hist_str: cam.h0a
 
     #Is this a model vs observations comparison?
     #If "false" or missing, then a model-model comparison is assumed:
@@ -86,7 +86,7 @@ diag_basic_info:
     obs_data_loc: /glade/campaign/cgd/amp/amwg/ADF_obs
 
     #Location where re-gridded and interpolated CAM climatology files are stored:
-    cam_regrid_loc: /glade/scratch/${user}/ADF/regrid
+    cam_regrid_loc: /glade/derecho/scratch/${user}/ADF/regrid
 
     #Overwrite CAM re-gridded files?
     #If false, or missing, then regridding will be skipped for regridded variables
@@ -94,7 +94,7 @@ diag_basic_info:
     cam_overwrite_regrid: false
 
     #Location where diagnostic plots are stored:
-    cam_diag_plot_loc: /glade/scratch/${user}/ADF/plots
+    cam_diag_plot_loc: /glade/derecho/scratch/${user}/ADF/plots
 
     #Location of ADF variable plotting defaults YAML file:
     #If left blank or missing, ADF/lib/adf_variable_defaults.yaml will be used
@@ -139,7 +139,7 @@ diag_cam_climo:
     cam_overwrite_climo: false
 
     #Name of CAM case (or CAM run name):
-    cam_case_name: b.e20.BHIST.f09_g17.20thC.297_05
+    cam_case_name: b.e23_alpha17f.BLT1850.ne30_t232.098
 
     #Case nickname
     #NOTE: if nickname starts with '0' - nickname must be in quotes!
@@ -149,20 +149,20 @@ diag_cam_climo:
 
     #Location of CAM history (h0) files:
     #Example test files
-    cam_hist_loc: /glade/p/cesm/ADF/${diag_cam_climo.cam_case_name}
+    cam_hist_loc: /glade/campaign/cgd/amp/amwg/ADF_test_cases/${diag_cam_climo.cam_case_name}
 
     #Location of CAM climatologies (to be created and then used by this script)
-    cam_climo_loc: /glade/scratch/${user}/ADF/${diag_cam_climo.cam_case_name}/climo
+    cam_climo_loc: /glade/derecho/scratch/${user}/ADF/${diag_cam_climo.cam_case_name}/climo
 
     #model year when time series files should start:
     #Note:  Leaving this entry blank will make time series
     #       start at earliest available year.
-    start_year: 1990
+    start_year: 10
 
     #model year when time series files should end:
     #Note:  Leaving this entry blank will make time series
     #       end at latest available year.
-    end_year: 1999
+    end_year: 14
 
     #Do time series files exist?
     #If True, then diagnostics assumes that model files are already time series.
@@ -180,7 +180,7 @@ diag_cam_climo:
     cam_overwrite_ts: false
 
     #Location where time series files are (or will be) stored:
-    cam_ts_loc: /glade/scratch/${user}/ADF/${diag_cam_climo.cam_case_name}/ts
+    cam_ts_loc: /glade/derecho/scratch/${user}/ADF/${diag_cam_climo.cam_case_name}/ts
 
     #TEM diagnostics
     #---------------
@@ -190,7 +190,7 @@ diag_cam_climo:
 
     #Location where TEM files are stored:
     #NOTE: If path not specified or commented out, TEM calculation/plots will be skipped!
-    cam_tem_loc: /glade/scratch/${user}/${diag_cam_climo.cam_case_name}/tem/
+    cam_tem_loc: /glade/derecho/scratch/${user}/${diag_cam_climo.cam_case_name}/tem/
 
     #Overwrite TEM files, if found?
     #If set to false, then TEM creation will be skipped if files are found:
@@ -211,7 +211,7 @@ diag_cam_baseline_climo:
     cam_overwrite_climo: false
 
     #Name of CAM baseline case:
-    cam_case_name: b.e20.BHIST.f09_g16.20thC.125.02
+    cam_case_name: b.e23_alpha17f.BLT1850.ne30_t232.093
 
     #Baseline case nickname
     #NOTE: if nickname starts with '0' - nickname must be in quotes!
@@ -221,20 +221,20 @@ diag_cam_baseline_climo:
 
     #Location of CAM baseline history (h0) files:
     #Example test files
-    cam_hist_loc: /glade/p/cesm/ADF/${diag_cam_baseline_climo.cam_case_name}
+    cam_hist_loc: /glade/campaign/cgd/amp/amwg/ADF_test_cases/${diag_cam_baseline_climo.cam_case_name}
 
     #Location of baseline CAM climatologies:
-    cam_climo_loc: /glade/scratch/${user}/ADF/${diag_cam_baseline_climo.cam_case_name}/climo
+    cam_climo_loc: /glade/derecho/scratch/${user}/ADF/${diag_cam_baseline_climo.cam_case_name}/climo
 
     #model year when time series files should start:
     #Note:  Leaving this entry blank will make time series
     #       start at earliest available year.
-    start_year: 1990
+    start_year: 10
 
     #model year when time series files should end:
     #Note:  Leaving this entry blank will make time series
     #       end at latest available year.
-    end_year: 1999
+    end_year: 14
 
     #Do time series files need to be generated?
     #If True, then diagnostics assumes that model files are already time series.
@@ -251,7 +251,7 @@ diag_cam_baseline_climo:
     cam_overwrite_ts: false
 
     #Location where time series files are (or will be) stored:
-    cam_ts_loc: /glade/scratch/${user}/ADF/${diag_cam_baseline_climo.cam_case_name}/ts
+    cam_ts_loc: /glade/derecho/scratch/${user}/ADF/${diag_cam_baseline_climo.cam_case_name}/ts
 
     #TEM diagnostics
     #---------------
@@ -261,7 +261,7 @@ diag_cam_baseline_climo:
 
     #Location where TEM files are stored:
     #NOTE: If path not specified or commented out, TEM calculation/plots will be skipped!
-    cam_tem_loc: /glade/scratch/${user}/${diag_cam_baseline_climo.cam_case_name}/tem/
+    cam_tem_loc: /glade/derecho/scratch/${user}/${diag_cam_baseline_climo.cam_case_name}/tem/
 
     #Overwrite TEM files, if found?
     #If set to false, then TEM creation will be skipped if files are found:
@@ -285,7 +285,7 @@ diag_cvdp_info:
     cvdp_codebase_loc: /glade/u/home/asphilli/CESM-diagnostics/CVDP/Release/v5.2.0/
 
     # Location where cvdp codebase will be copied to and diagnostic plots will be stored
-    cvdp_loc: /glade/scratch/asphilli/ADF-Sandbox/cvdp/      #MUST EDIT!
+    cvdp_loc: /glade/derecho/scratch/asphilli/ADF-Sandbox/cvdp/      #MUST EDIT!
 
     # tar up CVDP results?
     cvdp_tar: false

--- a/config_amwg_default_plots.yaml
+++ b/config_amwg_default_plots.yaml
@@ -291,7 +291,7 @@ diag_cvdp_info:
     cvdp_codebase_loc: /glade/u/home/asphilli/CESM-diagnostics/CVDP/Release/v5.2.0/
 
     # Location where cvdp codebase will be copied to and diagnostic plots will be stored
-    cvdp_loc: /glade/derecho/scratch/asphilli/ADF-Sandbox/cvdp/      #MUST EDIT!
+    cvdp_loc: /glade/derecho/scratch/${user}/ADF/cvdp/
 
     # tar up CVDP results?
     cvdp_tar: false

--- a/config_amwg_default_plots.yaml
+++ b/config_amwg_default_plots.yaml
@@ -63,12 +63,6 @@ user: 'USER-NAME-NOT-SET'
 #This first set of variables specify basic info used by all diagnostic runs:
 diag_basic_info:
 
-    #History file string to match (eg. cam.h0 or ocn.pop.h.ecosys.nday1)
-    # Only affects timeseries as everything else uses timeseries
-    # Leave off trailing '.'
-    #Default: cam.h0a
-    hist_str: cam.h0a
-
     #Is this a model vs observations comparison?
     #If "false" or missing, then a model-model comparison is assumed:
     compare_obs: false
@@ -129,6 +123,12 @@ diag_basic_info:
 
 #This second set of variables provides info for the CAM simulation(s) being diagnosed:
 diag_cam_climo:
+
+    # History file list of strings to match
+    # eg. cam.h0 or ocn.pop.h.ecosys.nday1 or hist_str: [cam.h2,cam.h0]  
+    # Only affects timeseries as everything else uses the created timeseries 
+    # Default: 
+    hist_str: cam.h0
 
     #Calculate climatologies?
     #If false, the climatology files will not be created:
@@ -201,6 +201,12 @@ diag_cam_climo:
 #This third set of variables provide info for the CAM baseline climatologies.
 #This only matters if "compare_obs" is false:
 diag_cam_baseline_climo:
+
+    # History file list of strings to match
+    # eg. cam.h0 or ocn.pop.h.ecosys.nday1 or hist_str: [cam.h2,cam.h0]  
+    # Only affects timeseries as everything else uses the created timeseries 
+    # Default: 
+    hist_str: cam.h0
 
     #Calculate cam baseline climatologies?
     #If false, the climatology files will not be created:

--- a/config_cam_baseline_example.yaml
+++ b/config_cam_baseline_example.yaml
@@ -376,7 +376,7 @@ diag_cvdp_info:
     cvdp_codebase_loc: /glade/u/home/asphilli/CESM-diagnostics/CVDP/Release/v5.2.0/
 
     # Location where cvdp codebase will be copied to and diagnostic plots will be stored
-    cvdp_loc: /glade/derecho/scratch/asphilli/ADF-Sandbox/cvdp/      #MUST EDIT!
+    cvdp_loc: /glade/derecho/scratch/${user}/ADF/cvdp/
 
     # tar up CVDP results?
     cvdp_tar: false

--- a/config_cam_baseline_example.yaml
+++ b/config_cam_baseline_example.yaml
@@ -67,8 +67,8 @@ diag_basic_info:
     #History file string to match (eg. cam.h0 or ocn.pop.h.ecosys.nday1)
     # Only affects timeseries as everything else uses timeseries
     # Leave off trailing '.'
-    #Default: cam.h0
-    hist_str: cam.h0
+    #Default: cam.h0a
+    hist_str: cam.h0a
 
     #Is this a model vs observations comparison?
     #If "false" or missing, then a model-model comparison is assumed:
@@ -87,7 +87,7 @@ diag_basic_info:
     obs_data_loc: /glade/campaign/cgd/amp/amwg/ADF_obs
 
     #Location where re-gridded and interpolated CAM climatology files are stored:
-    cam_regrid_loc: /glade/scratch/${user}/ADF/regrid
+    cam_regrid_loc: /glade/derecho/scratch/${user}/ADF/regrid
 
     #Overwrite CAM re-gridded files?
     #If false, or missing, then regridding will be skipped for regridded variables
@@ -95,7 +95,7 @@ diag_basic_info:
     cam_overwrite_regrid: false
 
     #Location where diagnostic plots are stored:
-    cam_diag_plot_loc: /glade/scratch/${user}/ADF/plots
+    cam_diag_plot_loc: /glade/derecho/scratch/${user}/ADF/plots
 
     #Location of ADF variable plotting defaults YAML file:
     #If left blank or missing, ADF/lib/adf_variable_defaults.yaml will be used
@@ -139,7 +139,7 @@ diag_cam_climo:
     cam_overwrite_climo: false
 
     #Name of CAM case (or CAM run name):
-    cam_case_name: b.e20.BHIST.f09_g17.20thC.297_05
+    cam_case_name: b.e23_alpha17f.BLT1850.ne30_t232.098
 
     #Case nickname
     #NOTE: if nickname starts with '0' - nickname must be in quotes!
@@ -149,20 +149,20 @@ diag_cam_climo:
 
     #Location of CAM history (h0) files:
     #Example test files
-    cam_hist_loc: /glade/p/cesm/ADF/${diag_cam_climo.cam_case_name}
+    cam_hist_loc: /glade/campaign/cgd/amp/amwg/ADF_test_cases/${diag_cam_climo.cam_case_name}
 
     #Location of CAM climatologies (to be created and then used by this script)
-    cam_climo_loc: /glade/scratch/${user}/ADF/${diag_cam_climo.cam_case_name}/climo
+    cam_climo_loc: /glade/derecho/scratch/${user}/ADF/${diag_cam_climo.cam_case_name}/climo
 
     #model year when time series files should start:
     #Note:  Leaving this entry blank will make time series
     #       start at earliest available year.
-    start_year: 1990
+    start_year: 10
 
     #model year when time series files should end:
     #Note:  Leaving this entry blank will make time series
     #       end at latest available year.
-    end_year: 1999
+    end_year: 14
 
     #Do time series files exist?
     #If True, then diagnostics assumes that model files are already time series.
@@ -180,7 +180,7 @@ diag_cam_climo:
     cam_overwrite_ts: false
 
     #Location where time series files are (or will be) stored:
-    cam_ts_loc: /glade/scratch/${user}/ADF/${diag_cam_climo.cam_case_name}/ts
+    cam_ts_loc: /glade/derecho/scratch/${user}/ADF/${diag_cam_climo.cam_case_name}/ts
 
     #TEM diagnostics
     #---------------
@@ -190,7 +190,7 @@ diag_cam_climo:
 
     #Location where TEM files are stored:
     #NOTE: If path not specified or commented out, TEM calculation/plots will be skipped!
-    cam_tem_loc: /glade/scratch/${user}/${diag_cam_climo.cam_case_name}/tem/
+    cam_tem_loc: /glade/derecho/scratch/${user}/${diag_cam_climo.cam_case_name}/tem/
 
     #Overwrite TEM files, if found?
     #If set to false, then TEM creation will be skipped if files are found:
@@ -208,8 +208,8 @@ diag_cam_climo:
     #Also please note that config keywords cannot currently be used in list mode.
 
     #cam_case_name:
-    #    - b.e20.BHIST.f09_g17.20thC.297_05
-    #    - b1850.f19_g17.validation_mct.004
+    #    - b.e23_alpha17f.BLT1850.ne30_t232.098
+    #    - b.e23_alpha17f.BLT1850.ne30_t232.095
 
     #Case nickname
     #NOTE: if nickname starts with '0' - nickname must be in quotes!
@@ -228,20 +228,20 @@ diag_cam_climo:
     #    - false
 
     #cam_hist_loc:
-    #    - /glade/p/cesm/ADF/b.e20.BHIST.f09_g17.20thC.297_05
-    #    - /glade/p/cesm/ADF/b1850.f19_g17.validation_mct.004
+    #    - /glade/campaign/cgd/amp/amwg/ADF_test_cases/b.e23_alpha17f.BLT1850.ne30_t232.098
+    #    - /glade/campaign/cgd/amp/amwg/ADF_test_cases/b.e23_alpha17f.BLT1850.ne30_t232.095
 
     #cam_climo_loc:
     #    - /some/where/you/want/to/have/climo_files/ #MUST EDIT!
     #    - /the/same/or/some/other/climo/files/location
 
     #start_year:
-    #    - 1990
-    #    - 90
+    #    - 10
+    #    - 10
 
     #end_year:
-    #    - 1999
-    #    - 99
+    #    - 14
+    #    - 14
 
     #cam_ts_done:
     #    - false
@@ -295,7 +295,7 @@ diag_cam_baseline_climo:
     cam_overwrite_climo: false
 
     #Name of CAM baseline case:
-    cam_case_name: b.e20.BHIST.f09_g16.20thC.125.02
+    cam_case_name: b.e23_alpha17f.BLT1850.ne30_t232.093
 
     #Baseline case nickname
     #NOTE: if nickname starts with '0' - nickname must be in quotes!
@@ -305,20 +305,20 @@ diag_cam_baseline_climo:
 
     #Location of CAM baseline history (h0) files:
     #Example test files
-    cam_hist_loc: /glade/p/cesm/ADF/${diag_cam_baseline_climo.cam_case_name}
+    cam_hist_loc: /glade/campaign/cgd/amp/amwg/ADF_test_cases/${diag_cam_baseline_climo.cam_case_name}
 
     #Location of baseline CAM climatologies:
-    cam_climo_loc: /glade/scratch/${user}/ADF/${diag_cam_baseline_climo.cam_case_name}/climo
+    cam_climo_loc: /glade/derecho/scratch/${user}/ADF/${diag_cam_baseline_climo.cam_case_name}/climo
 
     #model year when time series files should start:
     #Note:  Leaving this entry blank will make time series
     #       start at earliest available year.
-    start_year: 1990
+    start_year: 10
 
     #model year when time series files should end:
     #Note:  Leaving this entry blank will make time series
     #       end at latest available year.
-    end_year: 1999
+    end_year: 14
 
     #Do time series files need to be generated?
     #If True, then diagnostics assumes that model files are already time series.
@@ -335,7 +335,7 @@ diag_cam_baseline_climo:
     cam_overwrite_ts: false
 
     #Location where time series files are (or will be) stored:
-    cam_ts_loc: /glade/scratch/${user}/ADF/${diag_cam_baseline_climo.cam_case_name}/ts
+    cam_ts_loc: /glade/derecho/scratch/${user}/ADF/${diag_cam_baseline_climo.cam_case_name}/ts
 
     #TEM diagnostics
     #---------------
@@ -345,7 +345,7 @@ diag_cam_baseline_climo:
 
     #Location where TEM files are stored:
     #NOTE: If path not specified or commented out, TEM calculation/plots will be skipped!
-    cam_tem_loc: /glade/scratch/${user}/${diag_cam_baseline_climo.cam_case_name}/tem/
+    cam_tem_loc: /glade/derecho/scratch/${user}/${diag_cam_baseline_climo.cam_case_name}/tem/
 
     #Overwrite TEM files, if found?
     #If set to false, then TEM creation will be skipped if files are found:
@@ -370,7 +370,7 @@ diag_cvdp_info:
     cvdp_codebase_loc: /glade/u/home/asphilli/CESM-diagnostics/CVDP/Release/v5.2.0/
 
     # Location where cvdp codebase will be copied to and diagnostic plots will be stored
-    cvdp_loc: /glade/scratch/asphilli/ADF-Sandbox/cvdp/      #MUST EDIT!
+    cvdp_loc: /glade/derecho/scratch/asphilli/ADF-Sandbox/cvdp/      #MUST EDIT!
 
     # tar up CVDP results?
     cvdp_tar: false

--- a/config_cam_baseline_example.yaml
+++ b/config_cam_baseline_example.yaml
@@ -64,12 +64,6 @@ user: 'USER-NAME-NOT-SET'
 #This first set of variables specify basic info used by all diagnostic runs:
 diag_basic_info:
 
-    #History file string to match (eg. cam.h0 or ocn.pop.h.ecosys.nday1)
-    # Only affects timeseries as everything else uses timeseries
-    # Leave off trailing '.'
-    #Default: cam.h0a
-    hist_str: cam.h0a
-
     #Is this a model vs observations comparison?
     #If "false" or missing, then a model-model comparison is assumed:
     compare_obs: false
@@ -129,6 +123,12 @@ diag_basic_info:
 
 #This second set of variables provides info for the CAM simulation(s) being diagnosed:
 diag_cam_climo:
+
+    # History file list of strings to match
+    # eg. cam.h0 or ocn.pop.h.ecosys.nday1 or hist_str: [cam.h2,cam.h0]  
+    # Only affects timeseries as everything else uses the created timeseries 
+    # Default: 
+    hist_str: cam.h0
 
     #Calculate climatologies?
     #If false, the climatology files will not be created:
@@ -285,6 +285,12 @@ diag_cam_climo:
 #This third set of variables provide info for the CAM baseline climatologies.
 #This only matters if "compare_obs" is false:
 diag_cam_baseline_climo:
+
+    # History file list of strings to match
+    # eg. cam.h0 or ocn.pop.h.ecosys.nday1 or hist_str: [cam.h2,cam.h0]  
+    # Only affects timeseries as everything else uses the created timeseries 
+    # Default: 
+    hist_str: cam.h0
 
     #Calculate cam baseline climatologies?
     #If false, the climatology files will not be created:

--- a/scripts/plotting/tape_recorder.py
+++ b/scripts/plotting/tape_recorder.py
@@ -186,10 +186,10 @@ def tape_recorder(adfobj):
 
     #Shift colorbar if there are less than 5 subplots
     # There will always be at least 2 (MLS and ERA5)
-    if len(case_ts_locs) == 1:
+    if len(runname_LT) == 1:
         x1_loc = (x1[1]-x1[0])/2
         x2_loc = ((x2[2]-x2[1])/2)+x2[1]
-    elif len(case_ts_locs) == 2:
+    elif len(runname_LT) == 2:
         x1_loc = (x1[1]-x1[0])/2
         x2_loc = ((x2[3]-x2[2])/2)+x2[2]
     else:


### PR DESCRIPTION
Update the config yaml files for updated example CAM cases and history files. 

&nbsp; &nbsp; There are now 4 example coupled cases in: `/glade/campaign/cgd/amp/amwg/ADF_test_cases`:
&emsp;&nbsp;&nbsp;  - 3 recent cases with h0a history files
&emsp;&nbsp;&nbsp;  - 1 semi-recent case with old h0 history files

&nbsp; &nbsp; Each with 10 years of data

&nbsp; &nbsp; Additionally, update paths for Derecho scratch locations and update `hist_str` argument to default to `cam.h0a`.

In `tape_recorder.py`, add check for scenario where no test case data is available and exit script if so.

Closes #289