### PR TITLE
Update arguments for derive_variables

### DIFF
--- a/lib/adf_diag.py
+++ b/lib/adf_diag.py
@@ -702,7 +702,8 @@ class AdfDiag(AdfWeb):
 
                     if vars_to_derive:
                         self.derive_variables(
-                            res=res, vars_to_derive=vars_to_derive, ts_dir=ts_dir[case_idx]
+                            res=res, hist_str=hist_str, vars_to_derive=vars_to_derive,
+                            constit_dict=constit_dict, ts_dir=ts_dir[case_idx]
                         )
                 # End with
             # End for hist_str


### PR DESCRIPTION
With the transition to the new `hist_str` format, some needed arguments to `derive_variables` in `lib/adf_diag.py` were missing, this PR will fix that.