### PR TITLE
Update history string objects

### DIFF
--- a/lib/adf_diag.py
+++ b/lib/adf_diag.py
@@ -351,7 +351,8 @@ class AdfDiag(AdfWeb):
             start_years = [self.climo_yrs["syear_baseline"]]
             end_years = [self.climo_yrs["eyear_baseline"]]
             case_type_string = "baseline"
-            hist_str_list = [self.hist_string["base_hist_str"]]
+            #Don't make this a list, it will come as one from the adf object
+            hist_str_list = self.hist_string["base_hist_str"]
 
         else:
             # Use test case settings, which are already lists:

--- a/lib/adf_diag.py
+++ b/lib/adf_diag.py
@@ -351,6 +351,7 @@ class AdfDiag(AdfWeb):
             start_years = [self.climo_yrs["syear_baseline"]]
             end_years = [self.climo_yrs["eyear_baseline"]]
             case_type_string = "baseline"
+            hist_str_list = [self.hist_string["base_hist_str"]]
 
         else:
             # Use test case settings, which are already lists:
@@ -362,13 +363,13 @@ class AdfDiag(AdfWeb):
             start_years = self.climo_yrs["syears"]
             end_years = self.climo_yrs["eyears"]
             case_type_string="case"
+            hist_str_list = self.hist_string["test_hist_str"]
 
         # Notify user that script has started:
 
         # End if
 
         # Read hist_str (component.hist_num) from the yaml file, or set to default
-        hist_str_list = self.get_cam_info("hist_str")
         dmsg = f"reading from {hist_str_list} files"
         self.debug_log(dmsg)
 

--- a/lib/adf_diag.py
+++ b/lib/adf_diag.py
@@ -351,8 +351,7 @@ class AdfDiag(AdfWeb):
             start_years = [self.climo_yrs["syear_baseline"]]
             end_years = [self.climo_yrs["eyear_baseline"]]
             case_type_string = "baseline"
-            #Don't make this a list, it will come as one from the adf object
-            hist_str_list = self.hist_string["base_hist_str"]
+            hist_str_list = [self.hist_string["base_hist_str"]]
 
         else:
             # Use test case settings, which are already lists:

--- a/lib/adf_info.py
+++ b/lib/adf_info.py
@@ -124,13 +124,6 @@ class AdfInfo(AdfConfig):
                 self.__cam_climo_info[conf_var] = [conf_val]
             #End if
         #End for
-
-        #If hist_str (component.hist_num) was not in yaml file, set to default
-        hist_str = self.__cam_climo_info['hist_str']
-        if not hist_str:
-            hist_str = [['cam.h0a']]*self.__num_cases
-        #End if
-
         #-------------------------------------------
 
         #Initialize ADF variable list:
@@ -239,11 +232,20 @@ class AdfInfo(AdfConfig):
 
             # Check if history file path exists:
             if any(baseline_hist_locs):
-                if not isinstance(baseline_hist_str, list):
-                    baseline_hist_str = [baseline_hist_str]
-                hist_str = baseline_hist_str[0]
+                #Check if user provided
+                if not baseline_hist_str:
+                    baseline_hist_str = ['cam.h0a']
+                else:
+                    #Make list if not already
+                    if not isinstance(baseline_hist_str, list):
+                        baseline_hist_str = [baseline_hist_str]
+                #Initialize baseline history string list
+                self.__base_hist_str = baseline_hist_str
+
+                #Grab first possible hist string, just looking for years of run
+                base_hist_str = baseline_hist_str[0]
                 starting_location = Path(baseline_hist_locs)
-                file_list = sorted(starting_location.glob("*" + hist_str + ".*.nc"))
+                file_list = sorted(starting_location.glob("*" + base_hist_str + ".*.nc"))
                 # Partition string to find exactly where h-number is
                 # This cuts the string before and after the `{hist_str}.` sub-string
                 # so there will always be three parts:
@@ -251,7 +253,7 @@ class AdfInfo(AdfConfig):
                 #Since the last part always includes the time range, grab that with last index (2)
                 #NOTE: this is based off the current CAM file name structure in the form:
                 #  $CASE.cam.h#.YYYY<other date info>.nc
-                base_climo_yrs = [int(str(i).partition(f"{hist_str}.")[2][0:4]) for i in file_list]
+                base_climo_yrs = [int(str(i).partition(f"{base_hist_str}.")[2][0:4]) for i in file_list]
                 base_climo_yrs = sorted(np.unique(base_climo_yrs))
 
                 base_found_syr = int(base_climo_yrs[0])
@@ -336,8 +338,17 @@ class AdfInfo(AdfConfig):
         #Extract cam history files location:
         cam_hist_locs = self.get_cam_info('cam_hist_loc')
 
-        # Read hist_str (component.hist_num, eg cam.h0) from the yaml file
-        cam_hist_str = self.get_cam_info('hist_str')
+        #Get cleaned nested list of hist_str for test case(s) (component.hist_num, eg cam.h0)
+        cam_hist_str = self.__cam_climo_info['hist_str']
+
+        if not cam_hist_str:
+            hist_str = [['cam.h0a']]*self.__num_cases
+        else:
+            hist_str = cam_hist_str
+        #End if
+
+        #Initialize CAM history string nested list
+        self.__hist_str = hist_str
 
         #Check if using pre-made ts files
         cam_ts_done   = self.get_cam_info("cam_ts_done")
@@ -391,8 +402,9 @@ class AdfInfo(AdfConfig):
             #End if
 
             #Check if history file path exists:
-            hist_str_case = cam_hist_str[case_idx]
+            hist_str_case = hist_str[case_idx]
             if any(cam_hist_locs):
+                #Grab first possible hist string, just looking for years of run
                 hist_str = hist_str_case[0]
 
                 #Get climo years for verification or assignment if missing
@@ -632,8 +644,11 @@ class AdfInfo(AdfConfig):
 
     @property
     def hist_string(self):
-        """ Return the history string name to the user if requested."""
-        return self.__hist_str
+        """ Return the CAM history string list to the user if requested."""
+        cam_hist_strs = copy.copy(self.__hist_str)
+        base_hist_strs = copy.copy(self.__base_hist_str)
+        hist_strs = {"test_hist_str":cam_hist_strs, "base_hist_str":base_hist_strs}
+        return hist_strs
 
     #########
 

--- a/lib/adf_info.py
+++ b/lib/adf_info.py
@@ -339,7 +339,7 @@ class AdfInfo(AdfConfig):
         cam_hist_locs = self.get_cam_info('cam_hist_loc')
 
         #Get cleaned nested list of hist_str for test case(s) (component.hist_num, eg cam.h0)
-        cam_hist_str = self.__cam_climo_info['hist_str']
+        cam_hist_str = self.__cam_climo_info.get('hist_str', None)
 
         if not cam_hist_str:
             hist_str = [['cam.h0a']]*self.__num_cases

--- a/scripts/plotting/tape_recorder.py
+++ b/scripts/plotting/tape_recorder.py
@@ -46,16 +46,15 @@ def tape_recorder(adfobj):
     cam_hist_strs = adfobj.hist_string["test_hist_str"]
 
     # Filter the list to include only strings that are exactly in the possible h0 strings
-    # - Search for either h0 of h0a
-    substrings = ["cam.h0","cam.h0a"]
+    # - Search for either h0 or h0a
+    substrings = {"cam.h0","cam.h0a"}
     case_hist_strs = []
-    for i,cam_case_str in enumerate(cam_hist_strs):
-        cam_hist_str = []
+    for cam_case_str in cam_hist_strs:
         # Check each possible h0 string
         for string in cam_case_str:
             if string in substrings:
-                cam_hist_str.append(string)
-        case_hist_strs.append(cam_hist_str[0])
+               case_hist_strs.append(string)
+               break
 
     #Grab test case climo years
     start_years = adfobj.climo_yrs["syears"]

--- a/scripts/plotting/tape_recorder.py
+++ b/scripts/plotting/tape_recorder.py
@@ -36,14 +36,26 @@ def tape_recorder(adfobj):
     plot_location = adfobj.plot_location
     plot_loc = Path(plot_location[0])
 
-    #Grab history string:
-    hist_str = adfobj.hist_string
-
     #Grab test case name(s)
     case_names = adfobj.get_cam_info('cam_case_name', required=True)
 
     #Grab test case time series locs(s)
     case_ts_locs = adfobj.get_cam_info("cam_ts_loc", required=True)
+
+    #Grab history strings:
+    cam_hist_strs = adfobj.hist_string["test_hist_str"]
+
+    # Filter the list to include only strings that are exactly in the possible h0 strings
+    # - Search for either h0 of h0a
+    substrings = ["cam.h0","cam.h0a"]
+    case_hist_strs = []
+    for i,cam_case_str in enumerate(cam_hist_strs):
+        cam_hist_str = []
+        # Check each possible h0 string
+        for string in cam_case_str:
+            if string in substrings:
+                cam_hist_str.append(string)
+        case_hist_strs.append(cam_hist_str[0])
 
     #Grab test case climo years
     start_years = adfobj.climo_yrs["syears"]
@@ -72,7 +84,24 @@ def tape_recorder(adfobj):
         data_end_year = adfobj.climo_yrs["eyear_baseline"]
         start_years = start_years+[data_start_year]
         end_years = end_years+[data_end_year]
+
+        #Grab history string:
+        baseline_hist_strs = adfobj.hist_string["base_hist_str"]
+        # Filter the list to include only strings that are exactly in the substrings list
+        base_hist_strs = [string for string in baseline_hist_strs if string in substrings]
+        hist_strs = case_hist_strs + base_hist_strs
     #End if
+
+    if not case_ts_locs:
+        exitmsg = "WARNING: No time series files in any case directory."
+        exitmsg += " No tape recorder plots will be made."
+        print(exitmsg)
+        logmsg = "create tape recorder:"
+        logmsg += f"\n Tape recorder plots require monthly mean h0 time series files."
+        logmsg += f"\n None were found for any case. Please check the time series paths."
+        adfobj.debug_log(logmsg)
+        #End tape recorder plotting script:
+        return
 
     # Default colormap
     cmap='precip_nowhite'
@@ -110,10 +139,10 @@ def tape_recorder(adfobj):
     elif (redo_plot) and plot_name.is_file():
         plot_name.unlink()
     
-    #Make dictionary for case names and associated timeseries file locations
+    #Make dictionary for case names and associated timeseries file locations and hist strings
     runs_LT2={}
     for i,val in enumerate(test_nicknames):
-        runs_LT2[val] = case_ts_locs[i]
+        runs_LT2[val] = [case_ts_locs[i], hist_strs[i]]
 
     # MLS data
     mls = xr.open_dataset(obs_loc / "mls_h2o_latNpressNtime_3d_monthly_v5.nc")
@@ -133,7 +162,10 @@ def tape_recorder(adfobj):
     alldat=[]
     runname_LT=[]
     for idx,key in enumerate(runs_LT2):
-        fils= sorted(Path(runs_LT2[key]).glob(f'*{hist_str}.{var}.*.nc'))
+        # Search for files
+        ts_loc = Path(runs_LT2[key][0])
+        hist_str = runs_LT2[key][1]
+        fils= sorted(ts_loc.glob(f'*{hist_str}.{var}.*.nc'))
         dat = pf.load_dataset(fils)
         if not dat:
             dmsg = f"No data for `{var}` found in {fils}, case will be skipped in tape recorder plot."


### PR DESCRIPTION
Clean up the history string objects in `adf_info.py`:
 - clean up naming of history string variables

 - Make baseline history info more robust; set default if not provided
 - Give full dictionary of test and baseline case(s) history string lists to adf object 

Update `tape_recorder.py` for new history string format:
 - Add check in history string lists for h0 time series files

Closes #315 