### PR TITLE
Update FSNT variable for obs data set

### DIFF
--- a/lib/adf_variable_defaults.yaml
+++ b/lib/adf_variable_defaults.yaml
@@ -895,7 +895,7 @@ FSNT:
       label : "Wm$^{-2}$"
   obs_file: "CERES_EBAF_Ed4.1_2001-2020.nc"
   obs_name: "CERES_EBAF_Ed4.1"
-  obs_var_name: "toa_sw_all_mon"
+  obs_var_name: "fsnt"
   category: "TOA energy flux"
 
 FSNTC:


### PR DESCRIPTION
The previous variable `toa_sw_all_mon` was incorrect for representing FSNT, see [discussion](https://github.com/NCAR/ADF/discussions/328 )

The obs file `CERES_EBAF_Ed4.1_2001-2020.nc` now has variable fsnt which is `solar_mon - toa_sw_all_mon` with:

`toa_sw_all_mon` -> toa_outgoing_shortwave_flux
`solar_mon` -> toa_incoming_shortwave_flux

The new variable produces the correct plot:
![FSNT_ANN_Zonal_Mean](https://github.com/user-attachments/assets/6e924998-6284-45a6-a677-c73f56e6274f)
