### PR TITLE
add website link to external packages (MDTF)

### DIFF
--- a/config_amwg_default_plots.yaml
+++ b/config_amwg_default_plots.yaml
@@ -303,6 +303,8 @@ diag_cvdp_info:
 # If mdtf_run: true, the MDTF will be set up and 
 # run in background mode, likely completing after the ADF has completed.
 #
+# WARNING: This currently only runs on CASPER (not derecho)
+#
 # The variables required depend on the diagnostics (PODs) selected. 
 # AMWG-developed PODS and their required variables:
 #   (Note that PRECT can be computed from PRECC & PRECL)

--- a/config_amwg_default_plots.yaml
+++ b/config_amwg_default_plots.yaml
@@ -332,12 +332,6 @@ diag_mdtf_info:
     conda_env_root     : ${mdtf_codebase_path}/miniconda2/envs.MDTFv3.1.20230412/
     OBS_DATA_ROOT      : ${mdtf_codebase_path}/obs_data
 
-
-
-    # Set to default for same as the ADF plot_location. Anything else here overrides that
-    OUTPUT_DIR         : default
-    WORKING_DIR        : default
-
     # SET this to a writable dir. The ADF will place ts files here for the MDTF to read (adds the casename)
     MODEL_DATA_ROOT     : ${diag_cam_climo.cam_ts_loc}/mdtf/inputdata/model     
 

--- a/config_cam_baseline_example.yaml
+++ b/config_cam_baseline_example.yaml
@@ -388,6 +388,8 @@ diag_cvdp_info:
 # If mdtf_run: true, the MDTF will be set up and 
 # run in background mode, likely completing after the ADF has completed.
 #
+# WARNING: This currently only runs on CASPER (not derecho)
+#
 # The variables required depend on the diagnostics (PODs) selected. 
 # AMWG-developed PODS and their required variables:
 #   (Note that PRECT can be computed from PRECC & PRECL)

--- a/config_cam_baseline_example.yaml
+++ b/config_cam_baseline_example.yaml
@@ -417,12 +417,6 @@ diag_mdtf_info:
     conda_env_root     : ${mdtf_codebase_path}/miniconda2/envs.MDTFv3.1.20230412/
     OBS_DATA_ROOT      : ${mdtf_codebase_path}/obs_data
 
-
-
-    # Set to default for same as the ADF plot_location. Anything else here overrides that
-    OUTPUT_DIR         : default
-    WORKING_DIR        : default
-
     # SET this to a writable dir. The ADF will place ts files here for the MDTF to read (adds the casename)
     MODEL_DATA_ROOT     : ${diag_cam_climo.cam_ts_loc}/mdtf/inputdata/model     
 
@@ -510,7 +504,8 @@ diag_var_list:
 
 #<Add more variables here.>
 # MDTF recommended variables
-#    - OMEGA
+#    - FLUT
+#    - OMEGA500
 #    - PRECT
 #    - PS
 #    - PSL

--- a/lib/adf_diag.py
+++ b/lib/adf_diag.py
@@ -1266,8 +1266,7 @@ class AdfDiag(AdfWeb):
         case_idx = 0
         plot_path = os.path.join(self.plot_location[case_idx], "mdtf")
         for var in ["WORKING_DIR", "OUTPUT_DIR"]:
-            if mdtf_info[var] == "default":
-                mdtf_info[var] = plot_path
+            mdtf_info[var] = plot_path
 
         #
         # Write the input settings json file
@@ -1357,7 +1356,7 @@ class AdfDiag(AdfWeb):
                     adf_file_list = glob.glob(adf_file_str)
 
                     if len(adf_file_list) == 1:
-                        if verbose > 2:
+                        if verbose > 1:
                             print(f"Copying ts file: {adf_file_list} to MDTF dir")
                     elif len(adf_file_list) > 1:
                         if verbose > 0:
@@ -1365,7 +1364,7 @@ class AdfDiag(AdfWeb):
                                 f"WARNING: found multiple timeseries files {adf_file_list}. Continuing with best guess; suggest cleaning up multiple dates in ts dir"
                             )
                     else:
-                        if verbose > 0:
+                        if verbose > 1:
                             print(
                                 f"WARNING: No files matching {case_name}.{hist_str}.{var} found in {adf_file_str}. Skipping"
                             )

--- a/lib/adf_web.py
+++ b/lib/adf_web.py
@@ -146,12 +146,27 @@ class AdfWeb(AdfObs):
             #Specify where CSS files will be stored:
             css_files_dir = website_dir / "templates"
 
+            #Add links to external packages (if applicable)
+            self.external_package_links = {}
+
+            #MDTF puts directory under case[0]
+            if self.get_mdtf_info('mdtf_run'):
+                syear = self.climo_yrs["syears"]
+                eyear = self.climo_yrs["eyears"]
+                mdtf_path = f"../mdtf/MDTF_{case_name}"
+                mdtf_path += f"_{syear[0]}_{eyear[0]}"
+                self.external_package_links['MDTF'] = mdtf_path
+            #End if
+            
             #Add all relevant paths to dictionary for specific case:
             self.__case_web_paths[case_name] = {'website_dir': website_dir,
                                                 'img_pages_dir': img_pages_dir,
                                                 'assets_dir': assets_dir,
                                                 'table_pages_dir': table_pages_dir,
                                                 'css_files_dir': css_files_dir}
+
+
+
         #End for
         #--------------------------------
 
@@ -171,6 +186,8 @@ class AdfWeb(AdfObs):
                                                    'css_files_dir': css_files_dir}
         #End if
 
+
+        
     #########
 
     # Create property needed to return "create_html" logical to user:
@@ -691,6 +708,10 @@ class AdfWeb(AdfObs):
                 if ptype not in avail_plot_types:
                     avail_plot_types.append(plot_types)
 
+
+            # External packages that can be run through ADF
+            avail_external_packages = {'MDTF':'mdtf_html_path', 'CVDP':'cvdp_html_path'}
+            
             #Construct index.html
             index_title = "AMP Diagnostics Prototype"
             index_tmpl = jinenv.get_template('template_index.html')
@@ -700,7 +721,9 @@ class AdfWeb(AdfObs):
                                             case_yrs=case_yrs,
                                             baseline_yrs=baseline_yrs,
                                             plot_types=plot_types,
-                                            avail_plot_types=avail_plot_types)
+                                            avail_plot_types=avail_plot_types,
+                                            avail_external_packages=avail_external_packages,
+                                            external_package_links=self.external_package_links)
 
             #Write Mean diagnostics index HTML file:
             with open(index_html_file, 'w', encoding='utf-8') as ofil:

--- a/lib/website_templates/template_index.html
+++ b/lib/website_templates/template_index.html
@@ -48,5 +48,23 @@
       {% endfor %}
     </div><!--grid-container-ptype-->
 
+    <div class="center">
+      <h1>External Diagnostic Packages</h1>
+    </div>
+    
+    <div class="grid-container">
+      {% for avail_type in avail_external_packages %}
+        {% if avail_type in external_package_links.keys() %}
+          <div class="grid-item">
+            <a href={{ external_package_links[avail_type] }} style="font-size: 30px;"> &nbsp; {{ avail_type }} </a>
+          </div><!--grid-item-->
+        {% else %}
+          <div class="grid-item-blocked">
+            <a-blocked style="font-size: 30px;">{{ avail_type }}</a-blocked>
+          </div><!--grid-item-blocked-->
+        {% endif %}
+      {% endfor %}
+    </div><!--grid-container-external-plots-->
+
   </body>
 </html>


### PR DESCRIPTION
- Add section to ADF website for external packages MDTF & CVDP
- In that section, link the MDTF package to its index.html file   (CVDP forthcoming after it is tested in latest version)
- Remove output dir options for MDTF to simplify the html paths
- Increase verbosity thresholds for MDTF output (resulting in less output)