### PR TITLE
Add global attrs to all ADF generated files

### DIFF
--- a/lib/adf_diag.py
+++ b/lib/adf_diag.py
@@ -523,7 +523,8 @@ class AdfDiag(AdfWeb):
                 # Aerosol Calcs
                 # --------------
                 # Always make sure PMID is made if aerosols are desired in config file
-                # Since there's no requirement for `aerosol_zonal_list` to be included, allow it to be absent:
+                # Since there's no requirement for `aerosol_zonal_list` to be included,
+                # allow it to be absent:
 
                 azl = res.get("aerosol_zonal_list", [])
                 if "PMID" not in diag_var_list:
@@ -569,7 +570,7 @@ class AdfDiag(AdfWeb):
                             constit_list = vres["derivable_from_cam_chem"]
                             if constit_list:
                                 if all(item in hist_file_ds.data_vars for item in constit_list):
-                                    # Set check to look for regular CAM constituents in variable defaults
+                                    # Set check to look for regular CAM constituents
                                     try_cam_constits = False
                                     derive = True
                                     msg = f"create time series for {case_name}:"
@@ -608,12 +609,12 @@ class AdfDiag(AdfWeb):
                             # Add constituent list to variable key in dictionary
                             constit_dict[var] = constit_list
                             continue
-                            # Log if this variable can be derived but is missing list of constituents
+                            # Log if variable can be derived but is missing list of constituents
                         elif (derive) and (not constit_list):
                             self.debug_log(constit_errmsg)
                             continue
-                        # Lastly, raise error if the variable is not a derived quanitity but is also not
-                        # in the history file(s)
+                        # Lastly, raise error if the variable is not a derived quanitity
+                        # but is also not in the history file(s)
                         else:
                             msg = f"WARNING: {var} is not in the file {hist_files[0]} "
                             msg += "nor can it be derived.\n"
@@ -656,7 +657,7 @@ class AdfDiag(AdfWeb):
                     if has_lev and vert_coord_type:
                         # For now, only add these variables if using CAM:
                         if "cam" in hist_str:
-                            # PS might be in a different history file. If so, continue without error.
+                            # PS might be in a different history file. If so, continue w/o error.
                             ncrcat_var_list = ncrcat_var_list + ",hyam,hybm,hyai,hybi"
 
                             if "PS" in hist_file_var_list:
@@ -1377,7 +1378,6 @@ class AdfDiag(AdfWeb):
         freq_string_options = ["month", "day", "6hr", "3hr", "1hr"]           #values
         freq_string_dict    = dict(zip(freq_string_cesm,freq_string_options)) #make dict
 
-        
         hist_str_list = self.get_cam_info("hist_str")
         case_names = self.get_cam_info("cam_case_name", required=True)
         var_list = self.diag_var_list
@@ -1454,7 +1454,7 @@ class AdfDiag(AdfWeb):
                         continue
                     freq = freq_string_dict.get(found_strings[0])
                     print(f"Translated {found_strings[0]} to {freq}")
-                    
+
                     #
                     # Destination file is MDTF directory and name structure
                     #

--- a/lib/adf_info.py
+++ b/lib/adf_info.py
@@ -31,6 +31,7 @@ dictionaries.
 from pathlib import Path
 import copy
 import os
+import getpass
 
 #+++++++++++++++++++++++++++++++++++++++++++++++++
 #import non-standard python modules, including ADF
@@ -93,6 +94,9 @@ class AdfInfo(AdfConfig):
         if self.__mdtf_info is not None:
             self.expand_references(self.__mdtf_info)
         # End if
+
+        # Get the current system user
+        self.__user = getpass.getuser()
 
         # Check if inputs are of the correct type:
         # -------------------------------------------
@@ -568,6 +572,12 @@ class AdfInfo(AdfConfig):
         # -----------------------------------------
 
     #########
+
+    # Create property needed to return "user" name to user:
+    @property
+    def user(self):
+        """Return the "user" name if requested."""
+        return self.__user
 
     # Create property needed to return "compare_obs" logical to user:
     @property

--- a/scripts/averaging/create_climo_files.py
+++ b/scripts/averaging/create_climo_files.py
@@ -178,7 +178,7 @@ def create_climo_files(adf, clobber=False, search=None):
                 warnings.warn(errmsg)
                 continue
 
-            list_of_arguments.append((ts_files, syr, eyr, output_file))
+            list_of_arguments.append((adf, ts_files, syr, eyr, output_file))
 
 
         #End of var_list loop
@@ -198,7 +198,7 @@ def create_climo_files(adf, clobber=False, search=None):
 #
 # Local functions
 #
-def process_variable(ts_files, syr, eyr, output_file):
+def process_variable(adf, ts_files, syr, eyr, output_file):
     '''
     Compute and save the climatology file.
     '''
@@ -226,6 +226,17 @@ def process_variable(ts_files, syr, eyr, output_file):
     enc_dv = {xname: {'_FillValue': None, 'zlib': True, 'complevel': 4} for xname in cam_climo_data.data_vars}
     enc_c  = {xname: {'_FillValue': None} for xname in cam_climo_data.coords}
     enc    = {**enc_c, **enc_dv}
+
+    # Create a dictionary of attributes
+    # Convert the list to a string (join with commas)
+    ts_files_str = [str(path) for path in ts_files]
+    ts_files_str = ', '.join(ts_files_str)
+    attrs_dict = {
+        "adf_user": adf.user,
+        "climo_yrs": f"{syr}-{eyr}",
+        "time_series_files": ts_files_str,
+    }
+    cam_climo_data = cam_climo_data.assign_attrs(attrs_dict)
 
     #Output variable climatology to NetCDF-4 file:
     cam_climo_data.to_netcdf(output_file, format='NETCDF4', encoding=enc)

--- a/scripts/regridding/regrid_and_vert_interp.py
+++ b/scripts/regridding/regrid_and_vert_interp.py
@@ -59,6 +59,10 @@ def regrid_and_vert_interp(adf):
     case_names = adf.get_cam_info("cam_case_name", required=True)
     input_climo_locs = adf.get_cam_info("cam_climo_loc", required=True)
 
+    #Grab case years
+    syear_cases = adf.climo_yrs["syears"]
+    eyear_cases = adf.climo_yrs["eyears"]
+
     #Check if mid-level pressure, ocean fraction or land fraction exist
     #in the variable list:
     for var in ["PMID", "OCNFRAC", "LANDFRAC"]:
@@ -91,6 +95,9 @@ def regrid_and_vert_interp(adf):
     #Regrid target variables (either obs or a baseline run):
     if adf.compare_obs:
 
+        #Set obs name to match baseline (non-obs)
+        target_list = ["Obs"]
+
         #Extract variable-obs dictionary:
         var_obs_dict = adf.var_obs_dict
 
@@ -107,6 +114,13 @@ def regrid_and_vert_interp(adf):
         target_loc = adf.get_baseline_info("cam_climo_loc", required=True)
         target_list = [adf.get_baseline_info("cam_case_name", required=True)]
     #End if
+
+    #Grab baseline years (which may be empty strings if using Obs):
+    syear_baseline = adf.climo_yrs["syear_baseline"]
+    eyear_baseline = adf.climo_yrs["eyear_baseline"]
+
+    #Set attributes dictionary for climo years to save in the file attributes
+    base_climo_yrs_attr = f"{target_list[0]}: {syear_baseline}-{eyear_baseline}"
 
     #-----------------------------------------
 
@@ -136,6 +150,10 @@ def regrid_and_vert_interp(adf):
         #pressure and mid-level pressure fields:
         ps_loc_dict = {}
         pmid_loc_dict = {}
+
+        #Get climo years for case
+        syear = syear_cases[case_idx]
+        eyear = eyear_cases[case_idx]
 
         # probably want to do this one variable at a time:
         for var in var_list:
@@ -274,6 +292,15 @@ def regrid_and_vert_interp(adf):
                     #End if
 
                     #Finally, write re-gridded data to output file:
+                    #Convert the list of Path objects to a list of strings
+                    climatology_files_str = [str(path) for path in mclim_fils]
+                    climatology_files_str = ', '.join(climatology_files_str)
+                    test_attrs_dict = {
+                            "adf_user": adf.user,
+                            "climo_yrs": f"{case_name}: {syear}-{eyear}",
+                            "climatology_files": climatology_files_str,
+                        }
+                    rgdata_interp = rgdata_interp.assign_attrs(test_attrs_dict)
                     save_to_nc(rgdata_interp, regridded_file_loc)
                     rgdata_interp.close()  # bpm: we are completely done with this data
 
@@ -338,6 +365,17 @@ def regrid_and_vert_interp(adf):
                                 #End if
                             #End if
                         #End if
+
+                        # Convert the list to a string (join with commas or another separator)
+                        climatology_files_str = [str(path) for path in tclim_fils]
+                        climatology_files_str = ', '.join(climatology_files_str)
+                        # Create a dictionary of attributes
+                        base_attrs_dict = {
+                            "adf_user": adf.user,
+                            "climo_yrs": f"{case_name}: {syear}-{eyear}; {base_climo_yrs_attr}",
+                            "climatology_files": climatology_files_str,
+                        }
+                        tgdata_interp = tgdata_interp.assign_attrs(base_attrs_dict)
 
                         #Write interpolated baseline climatology to file:
                         save_to_nc(tgdata_interp, interp_bl_file)


### PR DESCRIPTION
This will add attributes for:
- timeseries files: ADF user, history files location, and history file name(s)
- climo files: ADF user, climo years, and time series file name(s)
- regridded files: ADF user, climo years, and climo file name(s). The regridded files will have both the test and baseline climo years in the atributes