### PR TITLE
Global mean time series plotting script

### DIFF
--- a/lib/adf_dataset.py
+++ b/lib/adf_dataset.py
@@ -106,6 +106,7 @@ class AdfData:
     def get_ref_timeseries_file(self, field):
         """Return list of reference time series files"""
         if self.adf.compare_obs:
+            warnings.warn("ADF does not currently expect observational time series files.")
             return None
         else:
             ts_loc = Path(self.adf.get_baseline_info("cam_ts_loc", required=True))
@@ -141,6 +142,33 @@ class AdfData:
         else:
             warnings.warn("Timeseries file does not have time bounds info.")
         return xr.decode_cf(ds)
+
+    def load_timeseries_da(self, case, variablename):
+        """Return DataArray from time series file(s).
+           Uses defaults file to convert units.
+        """
+        add_offset, scale_factor = self.get_value_converters(case, variablename)
+        fils = self.get_timeseries_file(case, variablename)
+        return self.load_da(fils, variablename, add_offset=add_offset, scale_factor=scale_factor)
+    
+    def load_reference_timeseries_da(self, field):
+        """Return a DataArray time series to be used as reference 
+          (aka baseline) for variable field.
+        """
+        fils = self.get_ref_timeseries_file(field)
+        if not fils:
+            warnings.warn(f"WARNING: Did not find time series file(s), variable: {field}")
+            return None
+        #Change the variable name from CAM standard to what is
+        # listed in variable defaults for this observation field
+        if self.adf.compare_obs:
+            field = self.ref_var_nam[field]
+            add_offset = 0
+            scale_factor = 1
+        else:
+            add_offset, scale_factor = self.get_value_converters(self.ref_case_label, field)
+
+        return self.load_da(fils, field, add_offset=add_offset, scale_factor=scale_factor)
 
 
     #------------------

--- a/lib/adf_dataset.py
+++ b/lib/adf_dataset.py
@@ -344,12 +344,13 @@ class AdfData:
         res = self.adf.variable_defaults
         if variablename in res:
             vres = res[variablename]
-            if (case == self.ref_labels[variablename]) and (self.adf.compare_obs):
-                scale_factor = vres.get("obs_scale_factor",1)
-                add_offset = vres.get("obs_add_offset", 0)
-            else:
-                scale_factor = vres.get("scale_factor",1)
-                add_offset = vres.get("add_offset", 0)
+            if variablename in self.ref_labels:
+                if (case == self.ref_labels[variablename]) and (self.adf.compare_obs):
+                    scale_factor = vres.get("obs_scale_factor",1)
+                    add_offset = vres.get("obs_add_offset", 0)
+                else:
+                    scale_factor = vres.get("scale_factor",1)
+                    add_offset = vres.get("add_offset", 0)
         return add_offset, scale_factor
 
     #------------------

--- a/lib/adf_info.py
+++ b/lib/adf_info.py
@@ -250,7 +250,7 @@ class AdfInfo(AdfConfig):
 
                 #Grab first possible hist string, just looking for years of run
                 base_hist_str = baseline_hist_str[0]
-                print(f"CHECK BASE_HIST_STR: {base_hist_str}")
+
                 starting_location = Path(baseline_hist_locs)
                 file_list = sorted(starting_location.glob("*" + base_hist_str + ".*.nc"))
                 # Partition string to find exactly where h-number is
@@ -262,7 +262,7 @@ class AdfInfo(AdfConfig):
                 #  $CASE.cam.h#.YYYY<other date info>.nc
                 base_climo_yrs = [int(str(i).partition(f"{base_hist_str}.")[2][0:4]) for i in file_list]
                 base_climo_yrs = sorted(np.unique(base_climo_yrs))
-                print(f"CHECK YEARS: {base_climo_yrs}")
+
                 base_found_syr = int(base_climo_yrs[0])
                 base_found_eyr = int(base_climo_yrs[-1])
 

--- a/lib/adf_info.py
+++ b/lib/adf_info.py
@@ -250,6 +250,7 @@ class AdfInfo(AdfConfig):
 
                 #Grab first possible hist string, just looking for years of run
                 base_hist_str = baseline_hist_str[0]
+                print(f"CHECK BASE_HIST_STR: {base_hist_str}")
                 starting_location = Path(baseline_hist_locs)
                 file_list = sorted(starting_location.glob("*" + base_hist_str + ".*.nc"))
                 # Partition string to find exactly where h-number is
@@ -261,7 +262,7 @@ class AdfInfo(AdfConfig):
                 #  $CASE.cam.h#.YYYY<other date info>.nc
                 base_climo_yrs = [int(str(i).partition(f"{base_hist_str}.")[2][0:4]) for i in file_list]
                 base_climo_yrs = sorted(np.unique(base_climo_yrs))
-
+                print(f"CHECK YEARS: {base_climo_yrs}")
                 base_found_syr = int(base_climo_yrs[0])
                 base_found_eyr = int(base_climo_yrs[-1])
 

--- a/lib/adf_variable_defaults.yaml
+++ b/lib/adf_variable_defaults.yaml
@@ -69,7 +69,7 @@
 # Available ADF Default Plot Types
 #+++++++++++++
 default_ptypes: ["Tables","LatLon","LatLon_Vector","Zonal","Meridional",
-                  "NHPolar","SHPolar","Special"]
+                  "NHPolar","SHPolar","TimeSeries","Special"]
 
 #+++++++++++++
 # Constants

--- a/lib/adf_web.py
+++ b/lib/adf_web.py
@@ -684,7 +684,7 @@ class AdfWeb(AdfObs):
 
             #List of ADF default plot types
             avail_plot_types = res["default_ptypes"]
-            
+           
             #Check if current plot type is in ADF default.
             #If not, add it so the index.html file can include it
             for ptype in plot_types.keys():

--- a/lib/plotting_functions.py
+++ b/lib/plotting_functions.py
@@ -406,7 +406,7 @@ def spatial_average(indata, weights=None, spatial_dims=None):
         emsg += " so can not perform average."
         raise AdfError(emsg)
 
-    return weighted.mean(dim=spatial_dims)
+    return weighted.mean(dim=spatial_dims, keep_attrs=True)
 
 
 def wgt_rmse(fld1, fld2, wgt):
@@ -494,6 +494,7 @@ def annual_mean(data, whole_years=False, time_name='time'):
     # weighted average with normalized weights: <x> = SUM x_i * w_i  (implied division by SUM w_i)
     result =  (data_to_avg * days_gb).groupby('time.year').sum(dim='time')
     result.attrs['averaging_period'] = date_range_string
+    result.attrs['units'] = data.attrs.get("units",None)
     return result
 
 

--- a/scripts/plotting/global_mean_timeseries.py
+++ b/scripts/plotting/global_mean_timeseries.py
@@ -86,12 +86,12 @@ def global_mean_timeseries(adfobj):
         for case_name in adfobj.data.case_names:
             c_ts_da = adfobj.data.load_timeseries_da(case_name, field)
 
-            # If no reference, we still neeed to check if this is a "2-d" varaible:
+            # If no reference, we still need to check if this is a "2-d" varaible:
             if ref_ts_da is None:
                 has_lat_ref, has_lev_ref = pf.zm_validate_dims(c_ts_da)
             # End if
 
-            # If 3-d variable, notify useer, flag and move to next test case
+            # If 3-d variable, notify user, flag and move to next test case
             if has_lev_ref:
                 print(
                     f"Variable named {field} has a lev dimension for '{case_name}', which does not work with this script."

--- a/scripts/plotting/global_mean_timeseries.py
+++ b/scripts/plotting/global_mean_timeseries.py
@@ -8,9 +8,11 @@ import plotting_functions as pf
 
 import warnings  # use to warn user about missing files.
 
+
 def my_formatwarning(msg, *args, **kwargs):
     # ignore everything except the message
-    return str(msg) + '\n'
+    return str(msg) + "\n"
+
 
 warnings.formatwarning = my_formatwarning
 
@@ -27,8 +29,8 @@ def global_mean_timeseries(adfobj):
     """
     var_list = adfobj.diag_var_list
 
-    #Special ADF variable which contains the output paths for
-    #all generated plots and tables:
+    # Special ADF variable which contains the output paths for
+    # all generated plots and tables:
     basic_info_dict = adfobj.read_config_var("diag_basic_info")
     plot_locations = adfobj.plot_location
 
@@ -39,61 +41,71 @@ def global_mean_timeseries(adfobj):
     if isinstance(plot_location, list):
         for pl in plot_location:
             plpth = Path(pl)
-            #Check if plot output directory exists, and if not, then create it:
+            # Check if plot output directory exists, and if not, then create it:
             if not plpth.is_dir():
                 print(f"\t    {pl} not found, making new directory")
                 plpth.mkdir(parents=True)
         if len(plot_location) == 1:
             plot_loc = Path(plot_location[0])
         else:
-            print(f"Ambiguous plotting location since all cases go on same plot. Will put them in first location: {plot_location[0]}")
+            print(
+                f"Ambiguous plotting location since all cases go on same plot. Will put them in first location: {plot_location[0]}"
+            )
             plot_loc = Path(plot_location[0])
     else:
         plot_loc = Path(plot_location)
     print(f"YOUR PLOT LOCATION: {plot_loc}")
 
-    plot_type = basic_info_dict.get('plot_type', 'png')
+    plot_type = basic_info_dict.get("plot_type", "png")
 
     print(f"CHECK ON PLOT LOCATION: {plot_locations}")
-
 
     for field in var_list:
         # reference time series
         # files
-        ref_ts_fil = adfobj.data.get_ref_timeseries_file(field)
+        # ref_ts_fil = adfobj.data.get_ref_timeseries_file(field)
         # dataset
-        ref_ts_ds = adfobj.data.load_timeseries_dataset(ref_ts_fil)
+        # ref_ts_ds = adfobj.data.load_timeseries_dataset(ref_ts_fil)
+
+        # DataArray
+        ref_ts_da = adfobj.data.load_reference_timeseries_da(field)
         # check if this is a "2-d" varaible:
-        has_lat_ref, has_lev_ref = pf.zm_validate_dims(ref_ts_ds[field])
+        # has_lat_ref, has_lev_ref = pf.zm_validate_dims(ref_ts_ds[field])
+        has_lat_ref, has_lev_ref = pf.zm_validate_dims(ref_ts_da)
         if has_lev_ref:
-            print(f"Variable named {field} has a lev dimension, which does not work with this script.")
+            print(
+                f"Variable named {field} has a lev dimension, which does not work with this script."
+            )
             continue
 
         # dataarray (global average)
-        ref_ts_da_ga = pf.spatial_average(ref_ts_ds[field], weights=None, spatial_dims=None)
+        ref_ts_da_ga = pf.spatial_average(
+            ref_ts_da, weights=None, spatial_dims=None
+        )
         # dataarray (annually averaged)
-        ref_ts_da = pf.annual_mean(ref_ts_da_ga, whole_years=True, time_name='time')
+        ref_ts_da = pf.annual_mean(ref_ts_da_ga, whole_years=True, time_name="time")
 
         ## SPECIAL SECTION -- CESM2 LENS DATA:
         if INCLUDE_LENS2:
-            lens2_fil = Path(f"/glade/campaign/cgd/cas/islas/CESM_DATA/LENS2/global_means/annualmeans/{field}_am_LENS2_first50.nc")
+            lens2_fil = Path(
+                f"/glade/campaign/cgd/cas/islas/CESM_DATA/LENS2/global_means/annualmeans/{field}_am_LENS2_first50.nc"
+            )
         if lens2_fil.is_file():
-            print(f"Found LENS2 file! w00t!")
+            # print("Success: Found LENS2 file.")
             lens2 = xr.open_mfdataset(lens2_fil)
             have_lens = True
         else:
-            print("DID NOT FIND LENS2 FILE.")
+            warnings.warn("Failure: DID NOT FIND LENS2 FILE.")
             have_lens = False
 
-
-
-        #Loop over model cases:
-        case_ts = {} # dictionary of annual mean, global mean time series
+        # Loop over model cases:
+        case_ts = {}  # dictionary of annual mean, global mean time series
         # same steps as in ref
         for case_idx, case_name in enumerate(adfobj.data.case_names):
-            cfil = adfobj.data.get_timeseries_file(case_name, field)
-            c_ts_ds = adfobj.data.load_timeseries_dataset(cfil)
-            c_ts_da_ga = pf.spatial_average(c_ts_ds[field])
+            # cfil = adfobj.data.get_timeseries_file(case_name, field)
+            # c_ts_ds = adfobj.data.load_timeseries_dataset(cfil)
+            c_ts_da = adfobj.data.load_timeseries_da(case_name, field)
+            c_ts_da_ga = pf.spatial_average(c_ts_da)
             case_ts[case_name] = pf.annual_mean(c_ts_da_ga)
         # now have to plot the timeseries
         fig, ax = plt.subplots()
@@ -101,15 +113,49 @@ def global_mean_timeseries(adfobj):
         for c, cdata in case_ts.items():
             ax.plot(cdata.year, cdata, label=c)
         if have_lens:
-            lensmin = lens2[field].min('M')
-            lensmax = lens2[field].max('M')
-            ax.fill_between(lensmin.year, lensmin, lensmax, color='lightgray', alpha=0.5)
-            ax.plot(lens2.year, lens2[field].mean('M'), color='darkgray', linewidth=2, label='LENS2')
+            lensmin = lens2[field].min("M")
+            lensmax = lens2[field].max("M")
+            ax.fill_between(
+                lensmin.year, lensmin, lensmax, color="lightgray", alpha=0.5
+            )
+            ax.plot(
+                lens2.year,
+                lens2[field].mean("M"),
+                color="darkgray",
+                linewidth=2,
+                label="LENS2",
+            )
 
-        ax.set_title(field, loc='left')
-        ax.set_xlabel('YEAR')
+        ax.set_title(field, loc="left")
+        ax.set_xlabel("YEAR")
         fig.legend()
-        ofilename = plot_loc / f"{field}_annual_GlobalMean_TimeSeries.{plot_type}"
-        print(f"GLOBAL MEAN TIMESERIES: writing {ofilename.name}")
-        fig.savefig(ofilename)
-        plt.close(fig)
+        plot_name = plot_loc / f"{field}_GlobalMean_ANN_TimeSeries_Mean.{plot_type}"
+
+        # double check this
+        redo_plot = adfobj.get_basic_info("redo_plot")
+        file_exists = plot_name.is_file()
+        if redo_plot and file_exists:
+            # Case 1: Delete old plot, save new plot
+            plot_name.unlink()
+            fig.savefig(plot_name)
+            plt.close(fig)
+        elif not redo_plot and file_exists:
+            # Case 2: Keep old plot, do not save new plot
+            plt.close(fig)
+        elif redo_plot and not file_exists:
+            # Case 3: Save new plot
+            fig.savefig(plot_name)
+            plt.close(fig)
+        elif not redo_plot and not file_exists:
+            # Case 4: Save new plot
+            fig.savefig(plot_name)
+            plt.close(fig)
+
+        adfobj.add_website_data(
+            plot_name,
+            f"{field}_GlobalMean",
+            None,
+            season="ANN",
+            multi_case=True,
+            plot_type="TimeSeries",
+        )

--- a/scripts/plotting/global_mean_timeseries.py
+++ b/scripts/plotting/global_mean_timeseries.py
@@ -1,15 +1,19 @@
+"""Use time series files to produce global mean time series plots for ADF web site.
+
+Includes a minimal Class for bringing CESM2 LENS data 
+from I. Simpson's directory (to be generalized).
+
+"""
+
 from pathlib import Path
-import numpy as np
-import xarray as xr
-
-import matplotlib.pyplot as plt
-
-import plotting_functions as pf
-
 import warnings  # use to warn user about missing files.
+import xarray as xr
+import matplotlib.pyplot as plt
+import plotting_functions as pf
 
 
 def my_formatwarning(msg, *args, **kwargs):
+    """custom warning"""
     # ignore everything except the message
     return str(msg) + "\n"
 
@@ -17,24 +21,87 @@ def my_formatwarning(msg, *args, **kwargs):
 warnings.formatwarning = my_formatwarning
 
 
-INCLUDE_LENS2 = True
-
-
 def global_mean_timeseries(adfobj):
     """
     load time series file, calculate global mean, annual mean
     for each case
-    Make a combined plot
-    Optionally show the CESM2 LENS result.
+    Make a combined plot, save it, add it to website.
+    Include the CESM2 LENS result if it can be found.
     """
-    var_list = adfobj.diag_var_list
 
-    # Special ADF variable which contains the output paths for
-    # all generated plots and tables:
-    basic_info_dict = adfobj.read_config_var("diag_basic_info")
-    plot_locations = adfobj.plot_location
+    plot_loc = get_plot_loc(adfobj)
 
-    # ADF variable which contains the output path for plots and tables:
+    plot_type = adfobj.read_config_var("diag_basic_info").get("plot_type", "png")
+
+    for field in adfobj.diag_var_list:
+        # reference time series (DataArray)
+        ref_ts_da = adfobj.data.load_reference_timeseries_da(field)
+        # check if this is a "2-d" varaible:
+        has_lat_ref, has_lev_ref = pf.zm_validate_dims(ref_ts_da)
+        if has_lev_ref:
+            print(
+                f"Variable named {field} has a lev dimension, which does not work with this script."
+            )
+            continue
+
+        # reference time series global average
+        ref_ts_da_ga = pf.spatial_average(ref_ts_da, weights=None, spatial_dims=None)
+        # annually averaged
+        ref_ts_da = pf.annual_mean(ref_ts_da_ga, whole_years=True, time_name="time")
+
+        ## SPECIAL SECTION -- CESM2 LENS DATA:
+        lens2_data = Lens2Data(
+            field
+        )  # Provides access to LENS2 dataset when available (class defined below)
+
+        # Loop over model cases:
+        case_ts = {}  # dictionary of annual mean, global mean time series
+        for case_name in adfobj.data.case_names:
+            c_ts_da = adfobj.data.load_timeseries_da(case_name, field)
+            c_ts_da_ga = pf.spatial_average(c_ts_da)
+            case_ts[case_name] = pf.annual_mean(c_ts_da_ga)
+        # now have to plot the timeseries
+        fig, ax = make_plot(
+            ref_ts_da, case_ts, lens2_data, label=adfobj.data.ref_nickname
+        )
+        plot_name = plot_loc / f"{field}_GlobalMean_ANN_TimeSeries_Mean.{plot_type}"
+
+        conditional_save(adfobj, plot_name, fig)
+
+        adfobj.add_website_data(
+            plot_name,
+            f"{field}_GlobalMean",
+            None,
+            season="ANN",
+            multi_case=True,
+            plot_type="TimeSeries",
+        )
+
+
+def conditional_save(adfobj, plot_name, fig):
+    """Determines whether to save figure"""
+    # double check this
+    if adfobj.get_basic_info("redo_plot") and plot_name.is_file():
+        # Case 1: Delete old plot, save new plot
+        plot_name.unlink()
+        fig.savefig(plot_name)
+    elif (adfobj.get_basic_info("redo_plot") and not plot_name.is_file()) or (
+        not adfobj.get_basic_info("redo_plot") and not plot_name.is_file()
+    ):
+        # Save new plot
+        fig.savefig(plot_name)
+    elif not adfobj.get_basic_info("redo_plot") and plot_name.is_file():
+        # Case 2: Keep old plot, do not save new plot
+        print("plot file detected, redo is false, so keep existing file.")
+    else:
+        warnings.warn(f"Conditional save found unknown condition. File will not be written: {plot_name}")
+    plt.close(fig)
+
+
+def get_plot_loc(adfobj):
+    """Return the path for plot files.
+    Contains side-effect: will make the directory and parents if needed.
+    """
     plot_location = adfobj.plot_location
     if not plot_location:
         plot_location = adfobj.get_basic_info("cam_diag_plot_loc")
@@ -54,108 +121,50 @@ def global_mean_timeseries(adfobj):
             plot_loc = Path(plot_location[0])
     else:
         plot_loc = Path(plot_location)
-    print(f"YOUR PLOT LOCATION: {plot_loc}")
+    print(f"Determined plot location: {plot_loc}")
+    return plot_loc
 
-    plot_type = basic_info_dict.get("plot_type", "png")
 
-    print(f"CHECK ON PLOT LOCATION: {plot_locations}")
+class Lens2Data:
+    """Access Isla's LENS2 data to get annual means."""
+    def __init__(self, field):
+        self.field = field
+        self.has_lens, self.lens2 = self._include_lens()
 
-    for field in var_list:
-        # reference time series
-        # files
-        # ref_ts_fil = adfobj.data.get_ref_timeseries_file(field)
-        # dataset
-        # ref_ts_ds = adfobj.data.load_timeseries_dataset(ref_ts_fil)
-
-        # DataArray
-        ref_ts_da = adfobj.data.load_reference_timeseries_da(field)
-        # check if this is a "2-d" varaible:
-        # has_lat_ref, has_lev_ref = pf.zm_validate_dims(ref_ts_ds[field])
-        has_lat_ref, has_lev_ref = pf.zm_validate_dims(ref_ts_da)
-        if has_lev_ref:
-            print(
-                f"Variable named {field} has a lev dimension, which does not work with this script."
-            )
-            continue
-
-        # dataarray (global average)
-        ref_ts_da_ga = pf.spatial_average(
-            ref_ts_da, weights=None, spatial_dims=None
+    def _include_lens(self):
+        lens2_fil = Path(
+            f"/glade/campaign/cgd/cas/islas/CESM_DATA/LENS2/global_means/annualmeans/{self.field}_am_LENS2_first50.nc"
         )
-        # dataarray (annually averaged)
-        ref_ts_da = pf.annual_mean(ref_ts_da_ga, whole_years=True, time_name="time")
-
-        ## SPECIAL SECTION -- CESM2 LENS DATA:
-        if INCLUDE_LENS2:
-            lens2_fil = Path(
-                f"/glade/campaign/cgd/cas/islas/CESM_DATA/LENS2/global_means/annualmeans/{field}_am_LENS2_first50.nc"
-            )
         if lens2_fil.is_file():
-            # print("Success: Found LENS2 file.")
             lens2 = xr.open_mfdataset(lens2_fil)
-            have_lens = True
+            has_lens = True
         else:
             warnings.warn("Failure: DID NOT FIND LENS2 FILE.")
-            have_lens = False
+            has_lens = False
+            lens2 = None
+        return has_lens, lens2
 
-        # Loop over model cases:
-        case_ts = {}  # dictionary of annual mean, global mean time series
-        # same steps as in ref
-        for case_idx, case_name in enumerate(adfobj.data.case_names):
-            # cfil = adfobj.data.get_timeseries_file(case_name, field)
-            # c_ts_ds = adfobj.data.load_timeseries_dataset(cfil)
-            c_ts_da = adfobj.data.load_timeseries_da(case_name, field)
-            c_ts_da_ga = pf.spatial_average(c_ts_da)
-            case_ts[case_name] = pf.annual_mean(c_ts_da_ga)
-        # now have to plot the timeseries
-        fig, ax = plt.subplots()
-        ax.plot(ref_ts_da.year, ref_ts_da, label=adfobj.data.ref_nickname)
-        for c, cdata in case_ts.items():
-            ax.plot(cdata.year, cdata, label=c)
-        if have_lens:
-            lensmin = lens2[field].min("M")
-            lensmax = lens2[field].max("M")
-            ax.fill_between(
-                lensmin.year, lensmin, lensmax, color="lightgray", alpha=0.5
-            )
-            ax.plot(
-                lens2.year,
-                lens2[field].mean("M"),
-                color="darkgray",
-                linewidth=2,
-                label="LENS2",
-            )
 
-        ax.set_title(field, loc="left")
-        ax.set_xlabel("YEAR")
-        fig.legend()
-        plot_name = plot_loc / f"{field}_GlobalMean_ANN_TimeSeries_Mean.{plot_type}"
-
-        # double check this
-        redo_plot = adfobj.get_basic_info("redo_plot")
-        file_exists = plot_name.is_file()
-        if redo_plot and file_exists:
-            # Case 1: Delete old plot, save new plot
-            plot_name.unlink()
-            fig.savefig(plot_name)
-            plt.close(fig)
-        elif not redo_plot and file_exists:
-            # Case 2: Keep old plot, do not save new plot
-            plt.close(fig)
-        elif redo_plot and not file_exists:
-            # Case 3: Save new plot
-            fig.savefig(plot_name)
-            plt.close(fig)
-        elif not redo_plot and not file_exists:
-            # Case 4: Save new plot
-            fig.savefig(plot_name)
-            plt.close(fig)
-
-        adfobj.add_website_data(
-            plot_name,
-            f"{field}_GlobalMean",
-            None,
-            season="ANN",
-            multi_case=True,
-            plot_type="TimeSeries",
+def make_plot(ref_ts_da, case_ts, lens2, label=None):
+    """plot yearly values of ref_ts_da"""
+    fig, ax = plt.subplots()
+    ax.plot(ref_ts_da.year, ref_ts_da, label=label)
+    for c, cdata in case_ts.items():
+        ax.plot(cdata.year, cdata, label=c)
+    if lens2.has_lens:
+        field = lens2.field
+        lensmin = lens2.lens2[field].min("M")  # note: "M" is the member dimension
+        lensmax = lens2.lens2[field].max("M")
+        ax.fill_between(lensmin.year, lensmin, lensmax, color="lightgray", alpha=0.5)
+        ax.plot(
+            lens2.lens2[field].year,
+            lens2.lens2[field].mean("M"),
+            color="darkgray",
+            linewidth=2,
+            label="LENS2",
         )
+
+    ax.set_title(field, loc="left")
+    ax.set_xlabel("YEAR")
+    fig.legend()
+    return fig, ax

--- a/scripts/plotting/global_mean_timeseries.py
+++ b/scripts/plotting/global_mean_timeseries.py
@@ -1,0 +1,115 @@
+from pathlib import Path
+import numpy as np
+import xarray as xr
+
+import matplotlib.pyplot as plt
+
+import plotting_functions as pf
+
+import warnings  # use to warn user about missing files.
+
+def my_formatwarning(msg, *args, **kwargs):
+    # ignore everything except the message
+    return str(msg) + '\n'
+
+warnings.formatwarning = my_formatwarning
+
+
+INCLUDE_LENS2 = True
+
+
+def global_mean_timeseries(adfobj):
+    """
+    load time series file, calculate global mean, annual mean
+    for each case
+    Make a combined plot
+    Optionally show the CESM2 LENS result.
+    """
+    var_list = adfobj.diag_var_list
+
+    #Special ADF variable which contains the output paths for
+    #all generated plots and tables:
+    basic_info_dict = adfobj.read_config_var("diag_basic_info")
+    plot_locations = adfobj.plot_location
+
+    # ADF variable which contains the output path for plots and tables:
+    plot_location = adfobj.plot_location
+    if not plot_location:
+        plot_location = adfobj.get_basic_info("cam_diag_plot_loc")
+    if isinstance(plot_location, list):
+        for pl in plot_location:
+            plpth = Path(pl)
+            #Check if plot output directory exists, and if not, then create it:
+            if not plpth.is_dir():
+                print(f"\t    {pl} not found, making new directory")
+                plpth.mkdir(parents=True)
+        if len(plot_location) == 1:
+            plot_loc = Path(plot_location[0])
+        else:
+            print(f"Ambiguous plotting location since all cases go on same plot. Will put them in first location: {plot_location[0]}")
+            plot_loc = Path(plot_location[0])
+    else:
+        plot_loc = Path(plot_location)
+    print(f"YOUR PLOT LOCATION: {plot_loc}")
+
+    plot_type = basic_info_dict.get('plot_type', 'png')
+
+    print(f"CHECK ON PLOT LOCATION: {plot_locations}")
+
+
+    for field in var_list:
+        # reference time series
+        # files
+        ref_ts_fil = adfobj.data.get_ref_timeseries_file(field)
+        # dataset
+        ref_ts_ds = adfobj.data.load_timeseries_dataset(ref_ts_fil)
+        # check if this is a "2-d" varaible:
+        has_lat_ref, has_lev_ref = pf.zm_validate_dims(ref_ts_ds[field])
+        if has_lev_ref:
+            print(f"Variable named {field} has a lev dimension, which does not work with this script.")
+            continue
+
+        # dataarray (global average)
+        ref_ts_da_ga = pf.spatial_average(ref_ts_ds[field], weights=None, spatial_dims=None)
+        # dataarray (annually averaged)
+        ref_ts_da = pf.annual_mean(ref_ts_da_ga, whole_years=True, time_name='time')
+
+        ## SPECIAL SECTION -- CESM2 LENS DATA:
+        if INCLUDE_LENS2:
+            lens2_fil = Path(f"/glade/campaign/cgd/cas/islas/CESM_DATA/LENS2/global_means/annualmeans/{field}_am_LENS2_first50.nc")
+        if lens2_fil.is_file():
+            print(f"Found LENS2 file! w00t!")
+            lens2 = xr.open_mfdataset(lens2_fil)
+            have_lens = True
+        else:
+            print("DID NOT FIND LENS2 FILE.")
+            have_lens = False
+
+
+
+        #Loop over model cases:
+        case_ts = {} # dictionary of annual mean, global mean time series
+        # same steps as in ref
+        for case_idx, case_name in enumerate(adfobj.data.case_names):
+            cfil = adfobj.data.get_timeseries_file(case_name, field)
+            c_ts_ds = adfobj.data.load_timeseries_dataset(cfil)
+            c_ts_da_ga = pf.spatial_average(c_ts_ds[field])
+            case_ts[case_name] = pf.annual_mean(c_ts_da_ga)
+        # now have to plot the timeseries
+        fig, ax = plt.subplots()
+        ax.plot(ref_ts_da.year, ref_ts_da, label=adfobj.data.ref_nickname)
+        for c, cdata in case_ts.items():
+            ax.plot(cdata.year, cdata, label=c)
+        if have_lens:
+            lensmin = lens2[field].min('M')
+            lensmax = lens2[field].max('M')
+            ax.fill_between(lensmin.year, lensmin, lensmax, color='lightgray', alpha=0.5)
+            ax.plot(lens2.year, lens2[field].mean('M'), color='darkgray', linewidth=2, label='LENS2')
+
+        ax.set_title(field, loc='left')
+        ax.set_xlabel('YEAR')
+        fig.legend()
+        ofilename = plot_loc / f"{field}_annual_GlobalMean_TimeSeries.{plot_type}"
+        print(f"GLOBAL MEAN TIMESERIES: writing {ofilename.name}")
+        fig.savefig(ofilename)
+        plt.close(fig)

--- a/scripts/plotting/global_mean_timeseries.py
+++ b/scripts/plotting/global_mean_timeseries.py
@@ -46,6 +46,7 @@ def global_mean_timeseries(adfobj):
 
         # reference time series global average
         ref_ts_da_ga = pf.spatial_average(ref_ts_da, weights=None, spatial_dims=None)
+
         # annually averaged
         ref_ts_da = pf.annual_mean(ref_ts_da_ga, whole_years=True, time_name="time")
 
@@ -56,14 +57,27 @@ def global_mean_timeseries(adfobj):
 
         # Loop over model cases:
         case_ts = {}  # dictionary of annual mean, global mean time series
+        # use case nicknames instead of full case names if supplied:
+        labels = {
+            case_name: nickname if nickname else case_name
+            for nickname, case_name in zip(
+                adfobj.data.test_nicknames, adfobj.data.case_names
+            )
+        }
+        ref_label = (
+            adfobj.data.ref_nickname
+            if adfobj.data.ref_nickname
+            else adfobj.data.ref_case_label
+        )
         for case_name in adfobj.data.case_names:
             c_ts_da = adfobj.data.load_timeseries_da(case_name, field)
             c_ts_da_ga = pf.spatial_average(c_ts_da)
-            case_ts[case_name] = pf.annual_mean(c_ts_da_ga)
+            case_ts[labels[case_name]] = pf.annual_mean(c_ts_da_ga)
         # now have to plot the timeseries
         fig, ax = make_plot(
             ref_ts_da, case_ts, lens2_data, label=adfobj.data.ref_nickname
         )
+        ax.set_ylabel(getattr(ref_ts_da,"units", "[-]")) # add units
         plot_name = plot_loc / f"{field}_GlobalMean_ANN_TimeSeries_Mean.{plot_type}"
 
         conditional_save(adfobj, plot_name, fig)
@@ -78,7 +92,7 @@ def global_mean_timeseries(adfobj):
         )
 
 
-def conditional_save(adfobj, plot_name, fig):
+def conditional_save(adfobj, plot_name, fig, verbose=None):
     """Determines whether to save figure"""
     # double check this
     if adfobj.get_basic_info("redo_plot") and plot_name.is_file():
@@ -92,13 +106,16 @@ def conditional_save(adfobj, plot_name, fig):
         fig.savefig(plot_name)
     elif not adfobj.get_basic_info("redo_plot") and plot_name.is_file():
         # Case 2: Keep old plot, do not save new plot
-        print("plot file detected, redo is false, so keep existing file.")
+        if verbose:
+            print("plot file detected, redo is false, so keep existing file.")
     else:
-        warnings.warn(f"Conditional save found unknown condition. File will not be written: {plot_name}")
+        warnings.warn(
+            f"Conditional save found unknown condition. File will not be written: {plot_name}"
+        )
     plt.close(fig)
 
 
-def get_plot_loc(adfobj):
+def get_plot_loc(adfobj, verbose=None):
     """Return the path for plot files.
     Contains side-effect: will make the directory and parents if needed.
     """
@@ -110,14 +127,16 @@ def get_plot_loc(adfobj):
             plpth = Path(pl)
             # Check if plot output directory exists, and if not, then create it:
             if not plpth.is_dir():
-                print(f"\t    {pl} not found, making new directory")
+                if verbose:
+                    print(f"\t    {pl} not found, making new directory")
                 plpth.mkdir(parents=True)
         if len(plot_location) == 1:
             plot_loc = Path(plot_location[0])
         else:
-            print(
-                f"Ambiguous plotting location since all cases go on same plot. Will put them in first location: {plot_location[0]}"
-            )
+            if verbose:
+                print(
+                    f"Ambiguous plotting location since all cases go on same plot. Will put them in first location: {plot_location[0]}"
+                )
             plot_loc = Path(plot_location[0])
     else:
         plot_loc = Path(plot_location)
@@ -127,6 +146,7 @@ def get_plot_loc(adfobj):
 
 class Lens2Data:
     """Access Isla's LENS2 data to get annual means."""
+
     def __init__(self, field):
         self.field = field
         self.has_lens, self.lens2 = self._include_lens()
@@ -139,7 +159,7 @@ class Lens2Data:
             lens2 = xr.open_mfdataset(lens2_fil)
             has_lens = True
         else:
-            warnings.warn("Failure: DID NOT FIND LENS2 FILE.")
+            warnings.warn(f"Time Series: Did not find LENS2 file for {self.field}.")
             has_lens = False
             lens2 = None
         return has_lens, lens2
@@ -147,12 +167,12 @@ class Lens2Data:
 
 def make_plot(ref_ts_da, case_ts, lens2, label=None):
     """plot yearly values of ref_ts_da"""
+    field = lens2.field  # this will be defined even if no LENS2 data
     fig, ax = plt.subplots()
     ax.plot(ref_ts_da.year, ref_ts_da, label=label)
     for c, cdata in case_ts.items():
         ax.plot(cdata.year, cdata, label=c)
     if lens2.has_lens:
-        field = lens2.field
         lensmin = lens2.lens2[field].min("M")  # note: "M" is the member dimension
         lensmax = lens2.lens2[field].max("M")
         ax.fill_between(lensmin.year, lensmin, lensmax, color="lightgray", alpha=0.5)
@@ -163,8 +183,17 @@ def make_plot(ref_ts_da, case_ts, lens2, label=None):
             linewidth=2,
             label="LENS2",
         )
-
+    # Get the current y-axis limits
+    ymin, ymax = ax.get_ylim()
+    # Check if the y-axis crosses zero
+    if ymin < 0 < ymax:
+        ax.axhline(y=0, color="lightgray", linestyle="-", linewidth=1)
     ax.set_title(field, loc="left")
     ax.set_xlabel("YEAR")
-    fig.legend()
+    # Place the legend
+    ax.legend(
+        bbox_to_anchor=(0.5, -0.15), loc="upper center", ncol=min(len(case_ts), 3)
+    )
+    plt.tight_layout(pad=2, w_pad=1.0, h_pad=1.0)
+
     return fig, ax

--- a/scripts/plotting/global_mean_timeseries.py
+++ b/scripts/plotting/global_mean_timeseries.py
@@ -36,6 +36,11 @@ def global_mean_timeseries(adfobj):
     for field in adfobj.diag_var_list:
         # reference time series (DataArray)
         ref_ts_da = adfobj.data.load_reference_timeseries_da(field)
+        if ref_ts_da is None:
+            print(
+                f"\t Variable named {field} provides Nonetype. Skipping this variable"
+            )
+            continue
         # check if this is a "2-d" varaible:
         has_lat_ref, has_lev_ref = pf.zm_validate_dims(ref_ts_da)
         if has_lev_ref:


### PR DESCRIPTION
Add a script to plot global mean time series (annual mean only right now).

Uses time series files directly. To do this, I added some functionality to `adf_dataset.py` to get time series data.

Adds a TimeSeries type of plot category to `adf_variable_defaults.yaml`. 

Modifies `plotting_functions.py` to try to keep units in tact while doing spatial and annual averages. 

Changes in `adf_info.py` is incidental (two print statements), and can be ignored. 
The change in `adf_web.py` is literally whitespace and can be ignored. 