### PR TITLE
Add AOD 4 panel plots of difference with MERRA and MODIS data

### DIFF
--- a/lib/adf_dataset.py
+++ b/lib/adf_dataset.py
@@ -175,6 +175,12 @@ class AdfData:
 
 
     # Reference case (baseline/obs)
+    def load_reference_climo_da(self, case, variablename):
+        """Return DataArray from reference (aka baseline) climo file"""
+        add_offset, scale_factor = self.get_value_converters(case, variablename)
+        fils = self.get_reference_climo_file(variablename)
+        return self.load_da(fils, variablename, add_offset=add_offset, scale_factor=scale_factor)
+
     def get_reference_climo_file(self, var):
         """Return a list of files to be used as reference (aka baseline) for variable var."""
         if self.adf.compare_obs:

--- a/lib/adf_diag.py
+++ b/lib/adf_diag.py
@@ -347,7 +347,7 @@ class AdfDiag(AdfWeb):
             case_names = [self.get_baseline_info("cam_case_name", required=True)]
             cam_ts_done = [self.get_baseline_info("cam_ts_done")]
             cam_hist_locs = [self.get_baseline_info("cam_hist_loc")]
-            ts_dir = [self.get_baseline_info("cam_ts_loc", required=True)]
+            ts_dirs = [self.get_baseline_info("cam_ts_loc", required=True)]
             overwrite_ts = [self.get_baseline_info("cam_overwrite_ts")]
             start_years = [self.climo_yrs["syear_baseline"]]
             end_years = [self.climo_yrs["eyear_baseline"]]
@@ -359,16 +359,12 @@ class AdfDiag(AdfWeb):
             case_names = self.get_cam_info("cam_case_name", required=True)
             cam_ts_done = self.get_cam_info("cam_ts_done")
             cam_hist_locs = self.get_cam_info("cam_hist_loc")
-            ts_dir = self.get_cam_info("cam_ts_loc", required=True)
+            ts_dirs = self.get_cam_info("cam_ts_loc", required=True)
             overwrite_ts = self.get_cam_info("cam_overwrite_ts")
             start_years = self.climo_yrs["syears"]
             end_years = self.climo_yrs["eyears"]
             case_type_string="case"
             hist_str_list = self.hist_string["test_hist_str"]
-
-        # Notify user that script has started:
-        print(f"\n  Writing time series files to {ts_dir}")
-
         # End if
 
         # Read hist_str (component.hist_num) from the yaml file, or set to default
@@ -402,6 +398,9 @@ class AdfDiag(AdfWeb):
                 self.end_diag_fail(emsg)
             # End if
 
+            # Extract time series file location
+            ts_dir = ts_dirs[case_idx]
+
             # Check if history files actually exqist. If not then kill script:
             hist_str_case = hist_str_list[case_idx]
             for hist_str in hist_str_case:
@@ -415,7 +414,7 @@ class AdfDiag(AdfWeb):
                     self.end_diag_fail(emsg)
                 # End if
 
-                 # Notify user that script has started:
+                # Notify user that script has started:
                 print(f"\n  Writing time series files to {ts_dir}")
 
                 # Create empty list:
@@ -500,7 +499,7 @@ class AdfDiag(AdfWeb):
 
                 # Check if time series directory exists, and if not, then create it:
                 # Use pathlib to create parent directories, if necessary.
-                Path(ts_dir[case_idx]).mkdir(parents=True, exist_ok=True)
+                Path(ts_dir).mkdir(parents=True, exist_ok=True)
 
                 # INPUT NAME TEMPLATE: $CASE.$scomp.[$type.][$string.]$date[$ending]
                 first_file_split = str(hist_files[0]).split(".")
@@ -634,7 +633,7 @@ class AdfDiag(AdfWeb):
                     # $cam_case_name.$hist_str.$variable.YYYYMM-YYYYMM.nc
 
                     ts_outfil_str = (
-                        ts_dir[case_idx]
+                        ts_dir
                         + os.sep
                         + ".".join([case_name, hist_str, var, time_string, "nc"])
                     )
@@ -751,7 +750,7 @@ class AdfDiag(AdfWeb):
                 if vars_to_derive:
                     self.derive_variables(
                         res=res, hist_str=hist_str, vars_to_derive=vars_to_derive,
-                        constit_dict=constit_dict, ts_dir=ts_dir[case_idx]
+                        constit_dict=constit_dict, ts_dir=ts_dir
                     )
                 # End with
             # End for hist_str

--- a/lib/adf_diag.py
+++ b/lib/adf_diag.py
@@ -415,6 +415,9 @@ class AdfDiag(AdfWeb):
                     self.end_diag_fail(emsg)
                 # End if
 
+                 # Notify user that script has started:
+                print(f"\n  Writing time series files to {ts_dir}")
+
                 # Create empty list:
                 files_list = []
 

--- a/lib/adf_info.py
+++ b/lib/adf_info.py
@@ -458,7 +458,7 @@ class AdfInfo(AdfConfig):
                 file_list = sorted(starting_location.glob('*'+hist_str+'.*.nc'))
                 if len(file_list) == 0:
                     msg = "Checking history files:\n"
-                    msg += f"\tYThere are no history files in '{starting_location}'."
+                    msg += f"\tThere are no history files in '{starting_location}'."
                     self.debug_log(msg)
                     emsg = f"{case_name} starting_location {starting_location}: No history files found!\n"
                     emsg += "\tTry checking the path 'cam_hist_loc' or the 'hist_str' in 'diag_cam_climo' "

--- a/lib/adf_info.py
+++ b/lib/adf_info.py
@@ -260,7 +260,7 @@ class AdfInfo(AdfConfig):
                 #Check if the history file location exists
                 if not starting_location.is_dir():
                     msg = "Checking history file location:\n"
-                    msg += f"\tYeah, there's no history file location: '{starting_location}'."
+                    msg += f"\tThere is no history file location: '{starting_location}'."
                     self.debug_log(msg)
                     emsg = f"{data_name} starting_location: History file location not found!\n"
                     emsg += "\tTry checking the path 'cam_hist_loc' in 'diag_cam_baseline_climo' "
@@ -458,7 +458,7 @@ class AdfInfo(AdfConfig):
                 file_list = sorted(starting_location.glob('*'+hist_str+'.*.nc'))
                 if len(file_list) == 0:
                     msg = "Checking history files:\n"
-                    msg += f"\tYeah, there's no history files in '{starting_location}'."
+                    msg += f"\tYThere are no history files in '{starting_location}'."
                     self.debug_log(msg)
                     emsg = f"{case_name} starting_location {starting_location}: No history files found!\n"
                     emsg += "\tTry checking the path 'cam_hist_loc' or the 'hist_str' in 'diag_cam_climo' "

--- a/lib/adf_info.py
+++ b/lib/adf_info.py
@@ -255,7 +255,29 @@ class AdfInfo(AdfConfig):
                 #Grab first possible hist string, just looking for years of run
                 base_hist_str = baseline_hist_str[0]
                 starting_location = Path(baseline_hist_locs)
+                print(f"Checking history files in '{starting_location}'")
+
+                #Check if the history file location exists
+                if not starting_location.is_dir():
+                    msg = "Checking history file location:\n"
+                    msg += f"\tYeah, there's no history file location: '{starting_location}'."
+                    self.debug_log(msg)
+                    emsg = f"{data_name} starting_location: History file location not found!\n"
+                    emsg += "\tTry checking the path 'cam_hist_loc' in 'diag_cam_baseline_climo' "
+                    emsg += "section in your config file is correct..."
+                    self.end_diag_fail(emsg)
                 file_list = sorted(starting_location.glob("*" + base_hist_str + ".*.nc"))
+
+                #Check if there are any history files
+                if len(file_list) == 0:
+                    msg = "Checking history files:\n"
+                    msg += f"\tThere are no history files in '{starting_location}'."
+                    self.debug_log(msg)
+                    emsg = f"{data_name} starting_location '{starting_location}': No history files found!\n"
+                    emsg += "\tTry checking the path 'cam_hist_loc' or the 'hist_str' in 'diag_cam_baseline_climo' "
+                    emsg += "section in your config file are correct..."
+                    self.end_diag_fail(emsg)
+
                 # Partition string to find exactly where h-number is
                 # This cuts the string before and after the `{hist_str}.` sub-string
                 # so there will always be three parts:
@@ -420,7 +442,29 @@ class AdfInfo(AdfConfig):
 
                 #Get climo years for verification or assignment if missing
                 starting_location = Path(cam_hist_locs[case_idx])
+                print(f"Checking history files in '{starting_location}'")
+
+                #Check if the history file location exists
+                if not starting_location.is_dir():
+                    msg = "Checking history file location:\n"
+                    msg += f"\tThere is no history file location: '{starting_location}'."
+                    self.debug_log(msg)
+                    emsg = f"{case_name} starting_location: History file location not found!\n"
+                    emsg += "\tTry checking the path 'cam_hist_loc' in 'diag_cam_climo' "
+                    emsg += "section in your config file is correct..."
+                    self.end_diag_fail(emsg)
+                
+                #Check if there are any history files
                 file_list = sorted(starting_location.glob('*'+hist_str+'.*.nc'))
+                if len(file_list) == 0:
+                    msg = "Checking history files:\n"
+                    msg += f"\tYeah, there's no history files in '{starting_location}'."
+                    self.debug_log(msg)
+                    emsg = f"{case_name} starting_location {starting_location}: No history files found!\n"
+                    emsg += "\tTry checking the path 'cam_hist_loc' or the 'hist_str' in 'diag_cam_climo' "
+                    emsg += "section in your config file are correct..."
+                    self.end_diag_fail(emsg)
+
                 #Partition string to find exactly where h-number is
                 #This cuts the string before and after the `{hist_str}.` sub-string
                 # so there will always be three parts:

--- a/lib/adf_info.py
+++ b/lib/adf_info.py
@@ -256,6 +256,7 @@ class AdfInfo(AdfConfig):
                 base_hist_str = baseline_hist_str[0]
                 starting_location = Path(baseline_hist_locs)
                 print(f"Checking history files in '{starting_location}'")
+                file_list = sorted(starting_location.glob("*" + base_hist_str + ".*.nc"))
 
                 #Check if the history file location exists
                 if not starting_location.is_dir():
@@ -273,8 +274,10 @@ class AdfInfo(AdfConfig):
                     msg = "Checking history files:\n"
                     msg += f"\tThere are no history files in '{starting_location}'."
                     self.debug_log(msg)
-                    emsg = f"{data_name} starting_location '{starting_location}': No history files found!\n"
-                    emsg += "\tTry checking the path 'cam_hist_loc' or the 'hist_str' in 'diag_cam_baseline_climo' "
+                    emsg = f"{data_name} starting_location {starting_location}: "
+                    emsg += f"No history files found for {base_hist_str}!\n"
+                    emsg += "\tTry checking the path 'cam_hist_loc' or the 'hist_str' "
+                    emsg += " in 'diag_cam_baseline_climo' "
                     emsg += "section in your config file are correct..."
                     self.end_diag_fail(emsg)
 
@@ -286,6 +289,10 @@ class AdfInfo(AdfConfig):
                 #NOTE: this is based off the current CAM file name structure in the form:
                 #  $CASE.cam.h#.YYYY<other date info>.nc
                 base_climo_yrs = [int(str(i).partition(f"{base_hist_str}.")[2][0:4]) for i in file_list]
+                if not base_climo_yrs:
+                    msg = f"No climo years found in {baseline_hist_locs}, "
+                    raise AdfError(msg)
+
                 base_climo_yrs = sorted(np.unique(base_climo_yrs))
 
                 base_found_syr = int(base_climo_yrs[0])
@@ -444,6 +451,8 @@ class AdfInfo(AdfConfig):
                 starting_location = Path(cam_hist_locs[case_idx])
                 print(f"Checking history files in '{starting_location}'")
 
+                file_list = sorted(starting_location.glob('*'+hist_str+'.*.nc'))
+
                 #Check if the history file location exists
                 if not starting_location.is_dir():
                     msg = "Checking history file location:\n"
@@ -460,8 +469,10 @@ class AdfInfo(AdfConfig):
                     msg = "Checking history files:\n"
                     msg += f"\tThere are no history files in '{starting_location}'."
                     self.debug_log(msg)
-                    emsg = f"{case_name} starting_location {starting_location}: No history files found!\n"
-                    emsg += "\tTry checking the path 'cam_hist_loc' or the 'hist_str' in 'diag_cam_climo' "
+                    emsg = f"{case_name} starting_location {starting_location}: "
+                    emsg += f"No history files found for {hist_str}!\n"
+                    emsg += "\tTry checking the path 'cam_hist_loc' or the 'hist_str' "
+                    emsg += "in 'diag_cam_climo' "
                     emsg += "section in your config file are correct..."
                     self.end_diag_fail(emsg)
 
@@ -473,6 +484,9 @@ class AdfInfo(AdfConfig):
                 #NOTE: this is based off the current CAM file name structure in the form:
                 #  $CASE.cam.h#.YYYY<other date info>.nc
                 case_climo_yrs = [int(str(i).partition(f"{hist_str}.")[2][0:4]) for i in file_list]
+                if not case_climo_yrs:
+                    msg = f"No climo years found in {cam_hist_locs[case_idx]}, "
+                    raise AdfError(msg)
                 case_climo_yrs = sorted(np.unique(case_climo_yrs))
 
                 case_found_syr = int(case_climo_yrs[0])
@@ -845,7 +859,7 @@ class AdfInfo(AdfConfig):
                 break
             else:
                 logmsg = "get years for time series:"
-                logmsg = f"\tVar '{var}' not in dataset, skip to next to try and find climo years..."
+                logmsg = f"\n\tVar '{var}' not in dataset, skip to next to try and find climo years..."
                 self.debug_log(logmsg)
 
         #Read in file(s)

--- a/lib/adf_variable_defaults.yaml
+++ b/lib/adf_variable_defaults.yaml
@@ -1195,4 +1195,24 @@ utendwtem:
   obs_var_name: "utendwtem"
 
 #-----------
+
+
+# Plot Specific formatting
+##########################
+
+# AOD 4-Panel plots vs MERRA and MODIS
+#-------------------------------------
+aod_diags:
+    plot_params:
+      range_min: -0.4
+      range_max: 0.4
+      nlevel: 17
+
+    plot_params_relerr:
+      range_max: 100
+      range_min: -100
+      nlevel: 21
+
+#-----------
+
 #End of File

--- a/lib/adf_variable_defaults.yaml
+++ b/lib/adf_variable_defaults.yaml
@@ -1207,11 +1207,13 @@ aod_diags:
       range_min: -0.4
       range_max: 0.4
       nlevel: 17
+      colormap: "bwr"
 
     plot_params_relerr:
       range_max: 100
       range_min: -100
       nlevel: 21
+      colormap: "PuOr_r"
 
 #-----------
 

--- a/lib/adf_web.py
+++ b/lib/adf_web.py
@@ -164,9 +164,6 @@ class AdfWeb(AdfObs):
                                                 'assets_dir': assets_dir,
                                                 'table_pages_dir': table_pages_dir,
                                                 'css_files_dir': css_files_dir}
-
-
-
         #End for
         #--------------------------------
 
@@ -186,8 +183,6 @@ class AdfWeb(AdfObs):
                                                    'css_files_dir': css_files_dir}
         #End if
 
-
-        
     #########
 
     # Create property needed to return "create_html" logical to user:
@@ -352,10 +347,13 @@ class AdfWeb(AdfObs):
             self.end_diag_fail(emsg)
         #End except
 
-        #Make a jinja function that mimics python list object. This will allow for
-        # the use of 'list' in the html rendering.
+        #Make jinja functions that mimics python functions.
+        #  - This will allow for the use of 'list' in the html rendering.
         def jinja_list(seas_list):
             return list(seas_list)
+        #   - This will allow for the use of 'enumerate' in the html rendering.
+        def jinja_enumerate(arg):
+            return enumerate(arg)
 
         #Notify user that script has started:
         print("\n  Generating Diagnostics webpages...")
@@ -622,10 +620,8 @@ class AdfWeb(AdfObs):
                 if not mean_table_file.exists():
                     #Construct mean_table.html
                     mean_table_tmpl = jinenv.get_template('template_mean_tables.html')
-                    #Reuse the rend_kwarg_dict, but ignore certain keys
-                    #since all others are the same
-                    new_dict = {k: rend_kwarg_dict[k] for k in rend_kwarg_dict.keys() - {'table_name', 'table_html'}}
-                    mean_table_rndr = mean_table_tmpl.render(new_dict)
+                    #Reuse the rend_kwarg_dict
+                    mean_table_rndr = mean_table_tmpl.render(rend_kwarg_dict)
                     #Write mean diagnostic tables HTML file:
                     with open(mean_table_file, 'w', encoding='utf-8') as ofil:
                         ofil.write(mean_table_rndr)
@@ -650,18 +646,19 @@ class AdfWeb(AdfObs):
                 #End if
 
                 rend_kwarg_dict = {"title": main_title,
-                                       "var_title": web_data.name,
-                                       "season_title": web_data.season,
-                                       "case_name": web_data.case,
-                                       "case_yrs": case_yrs,
-                                       "base_name": data_name,
-                                       "baseline_yrs": baseline_yrs,
-                                       "plottype_title": web_data.plot_type,
-                                       "imgs": img_data,
-                                       "mydata": mean_html_info[web_data.plot_type],
-                                       "plot_types": plot_types,
-                                       "seasons": seasons,
-                                       "non_seasons": non_seasons[web_data.plot_type]}
+                                   "var_title": web_data.name,
+                                   "season_title": web_data.season,
+                                   "case_name": web_data.case,
+                                   "case_yrs": case_yrs,
+                                   "base_name": data_name,
+                                   "baseline_yrs": baseline_yrs,
+                                   "plottype_title": web_data.plot_type,
+                                   "imgs": img_data,
+                                   "mydata": mean_html_info[web_data.plot_type],
+                                   "plot_types": plot_types,
+                                   "seasons": seasons,
+                                   "non_seasons": non_seasons[web_data.plot_type]}
+
                 tmpl = jinenv.get_template('template.html')  #Set template
                 rndr = tmpl.render(rend_kwarg_dict) #The template rendered
 
@@ -676,10 +673,9 @@ class AdfWeb(AdfObs):
                 #Construct individual plot type mean_diag html files
                 mean_tmpl = jinenv.get_template('template_mean_diag.html')
 
-                #Remove keys from main dictionary for this html page
-                templ_rend_kwarg_dict = {k: rend_kwarg_dict[k] for k in rend_kwarg_dict.keys() - {'imgs', 'var_title', 'season_title'}}
-                templ_rend_kwarg_dict["list"] = jinja_list
-                mean_rndr = mean_tmpl.render(templ_rend_kwarg_dict)
+                rend_kwarg_dict["enumerate"] = jinja_enumerate
+                rend_kwarg_dict["list"] = jinja_list
+                mean_rndr = mean_tmpl.render(rend_kwarg_dict)
 
                 #Write mean diagnostic plots HTML file:
                 with open(mean_ptype_file,'w', encoding='utf-8') as ofil:

--- a/lib/website_templates/template.html
+++ b/lib/website_templates/template.html
@@ -56,9 +56,9 @@
               {% if non_seasons[category][var_name] == False %}
                 {% for season in seasons %}
                   {% if season in ptype_seas.keys() %}
-                      <div class="grid-item">
-                        <a href="../html_img/{{ ptype_seas[season] }}">{{ season }}</a>
-                      </div><!--grid-item-->
+                    <div class="grid-item">
+                      <a href="../html_img/{{ ptype_seas[season] }}">{{ season }}</a>
+                    </div><!--grid-item-->
                   {% else %}
                     <div class="grid-item-blocked">
                       <a-blocked>{{ season }}</a-blocked>
@@ -70,7 +70,7 @@
                   <div class="grid-item">
                     <a href="../html_img/{{ ptype_seas[season] }}">{{ season }}</a>
                   </div><!--grid-item-->
-                  {% endfor %}<!-- ptype_seas.keys() -->
+                {% endfor %}<!-- ptype_seas.keys() -->
               {% endif %}<!-- non_season -->
             {% endif %}<!-- var_name == var_title -->
           {% endfor %}<!-- var_seas.items() -->

--- a/lib/website_templates/template_mean_diag.html
+++ b/lib/website_templates/template_mean_diag.html
@@ -48,13 +48,13 @@
           <h3 class="block">{{ category }}</h3>
             <div class="grid-container" style="column-gap: 5px; row-gap: 5px; padding:2px">
               {% for var_name, ptype_seas in var_seas.items() %}
-                {% if non_seasons[category][var_name] == False %}
-                  {% for season in ptype_seas.keys() %}
-                    {% if season=="ANN"%}
-                      <div class="grid-item-diag">
-                        <a href="../html_img/plot_page_{{ var_name }}_ANN_{{ plottype_title }}_Mean.html"> {{var_name}} </a><br>
-                      </div><!--grid-item2-->
-                    {% endif %}
+                {% if non_seasons[category][var_name] == False %}<!-- Check if these have traditional seasons, ANN, DJF, etc. -->
+                  {% for i,season in enumerate(ptype_seas.keys()) %}
+                      {% if i==0 %}<!-- Grab first available season to make as default -->
+                        <div class="grid-item-diag">
+                          <a href="../html_img/plot_page_{{ var_name }}_{{ season }}_{{ plottype_title }}_Mean.html"> {{var_name}} </a><br>
+                        </div><!--grid-item2-->
+                      {% endif %}
                   {% endfor %}<!-- ptype_seas.keys() -->
 
                 {% else %}

--- a/scripts/plotting/global_latlon_map.py
+++ b/scripts/plotting/global_latlon_map.py
@@ -13,7 +13,6 @@ plot_file_op
 """
 #Import standard modules:
 import os
-import subprocess
 from pathlib import Path
 import numpy as np
 import xarray as xr

--- a/scripts/plotting/global_latlon_map.py
+++ b/scripts/plotting/global_latlon_map.py
@@ -386,6 +386,20 @@ def plot_file_op(adfobj, plot_name, var, case_name, season, web_category, redo_p
 
 
 def aod_latlon(adfobj):
+    """
+    Function to gather data and plot parameters to plot a panel plot of model vs observation
+      difference and percent difference.
+
+    Calculate the seasonal means for DJF, MAM, JJA, SON for model and obs datasets
+
+    NOTE: The model lat/lons must be on the same grid as the observations. If they are not, they need to be
+          regridded to match both the MERRA and MODIS observation dataset! 
+
+          For details about spatial coordiantes of obs datasets, see /glade/campaign/cgd/amp/amwg/ADF_obs/:
+            - MERRA2_192x288_AOD_2001-2020_climo.nc
+            - MOD08_M3_192x288_AOD_2001-2020_climo.nc
+    """
+
     var = "AODVISdn"
     season_abbr = ['Dec-Jan-Feb', 'Mar-Apr-May', 'Jun-Jul-Aug', 'Sep-Oct-Nov']
     # Define a list of season labels
@@ -643,7 +657,22 @@ def monthly_to_seasonal(ds,obs=False):
 
 
 def aod_panel_latlon(adfobj, plot_titles, plot_params, data, season, obs_name, case_name, case_num, types, symmetric=False):
+    """
+    Function to plot a panel plot of model vs observation difference and percent difference
 
+    This will be a 4-panel plot if model vs model run:
+        - Top left is test model minus obs
+        - Top right is baseline model minus obs
+        - Bottom left is test model minus obs percent difference
+        - Bottom right is baseline model minus obs percent difference
+    
+    This will be a 2-panel plot if model vs obs run:
+        - Top is test model minus obs
+        - Bottom is test model minus obs percent difference
+
+    NOTE: Individual plots of the panel plots will be created and saved to plotting location(s)
+          but will not be published to the webpage (if enabled)
+    """
     #Set plot details:
     # -- this should be set in basic_info_dict, but is not required
     # -- So check for it, and default to png

--- a/scripts/plotting/global_latlon_map.py
+++ b/scripts/plotting/global_latlon_map.py
@@ -412,6 +412,10 @@ def aod_latlon(adfobj):
 
     # Observational Datasets
     #-----------------------
+    # Round lat/lons to 5 decimal places
+        # NOTE: this is neccessary due to small fluctuations in insignificant decimal places
+        #       in lats/lons between models and these obs data sets. The model cases will also 
+        #       be rounded in turn.
     obs_dir = adfobj.get_basic_info("obs_data_loc")
     file_merra2 = os.path.join(obs_dir, 'MERRA2_192x288_AOD_2001-2020_climo.nc')
     file_mod08_m3 = os.path.join(obs_dir, 'MOD08_M3_192x288_AOD_2001-2020_climo.nc')
@@ -451,7 +455,7 @@ def aod_latlon(adfobj):
             adfobj.debug_log(dmsg)
             continue
         else:
-            # Round lat/lons so thaey match obs
+            # Round lat/lons so they match obs
             # NOTE: this is neccessary due to small fluctuations in insignificant decimal places
             #       that raise an error due to non-exact difference calculations.
             #       Rounding all datasets to 5 places ensures the proper difference calculation
@@ -468,6 +472,8 @@ def aod_latlon(adfobj):
                 err_msg += f"{obs_name} lat shape: {ds_ob.lat.shape}"
                 adfobj.debug_log(err_msg)
                 case_lat = False
+            # End if
+
             if ds_case['lon'].shape == ds_obs[0]['lon'].shape:
                 case_lon = True
             else:
@@ -477,6 +483,7 @@ def aod_latlon(adfobj):
                 err_msg += f"{obs_name} lon shape: {ds_ob.lon.shape}"
                 adfobj.debug_log(err_msg)
                 case_lon = False
+            # End if
             
             # Check to make sure spatial dimensions are compatible
             if (case_lat) and (case_lon):
@@ -485,6 +492,8 @@ def aod_latlon(adfobj):
                 ds_case_season['lon'] = ds_case_season['lon'].round(5)
                 ds_case_season['lat'] = ds_case_season['lat'].round(5)
                 ds_cases.append(ds_case_season)
+            # End if
+        # End if
 
     # load reference data (observational or baseline)
     if not adfobj.compare_obs:
@@ -498,7 +507,7 @@ def aod_latlon(adfobj):
             dmsg = f"No baseline climo file for {base_name} for variable `{var}`, global lat/lon plots skipped."
             adfobj.debug_log(dmsg)
         else:
-            # Round lat/lons so thaey match obs
+            # Round lat/lons so they match obs
             # NOTE: this is neccessary due to small fluctuations in insignificant decimal places
             #       that raise an error due to non-exact difference calculations.
             #       Rounding all datasets to 5 places ensures the proper difference calculation


### PR DESCRIPTION
This enhancement will bring in more AOD diagnostics against MERRA and MODIS datasets. The observation datasets will reside in the ADF default observation directory at: `/glade/campaign/cgd/amp/amwg/ADF_obs/`

* MERRA2_192x288_AOD_2001-2020_climo.nc
* MOD08_M3_192x288_AOD_2001-2020_climo.nc

These diagnostics will live in the `scripts/plotting/global_latlon_map.py` script.

In order for these diagnostics to run, `global_latlon_map.py` will need to be called in the `plotting_scripts` section of the run-time config yaml file as well as AODVISdn needs to be included in the `diag_var_list`.

The new diagnostics will include:

* Panel plots of model vs observation difference and percent difference for seasonal avgs for DJF, MAM, JJA, SON:
     - Test vs Baseline

<img src="https://github.com/user-attachments/assets/8450629d-91a1-4613-bf32-9c4556d2df85" width="650" height="480">
<br>
<img src="https://github.com/user-attachments/assets/5c035ff0-7e5a-43a9-85ef-5f2a41697409" width="650" height="480">

     - Test vs Obs - will still plot these panel plots, just with the one model case
<img src="https://github.com/user-attachments/assets/0630f9e8-0844-4faa-bc5f-954c736b924d" width="650">
<br>
<img src="https://github.com/user-attachments/assets/626ac515-aa66-4791-9890-0eaa4efe5ae3"" width="650">
<br>
<br>

* Additionally, individual plots for each case and observation will be saved (but not published to the website) for each season and difference and percent difference.

This PR will also add a little more detailing of error handling for history file info in `adf_info.py` and more flexibility for which season plot is displayed by default in the webpage.

Closes #302 

@dwfncar I am tagging you as a reviewer, if you wouldn't mind taking a look at the calculation code at the end of `global_latlon_map.py` in the function `aod_latlon` to make sure there are no glaring mistakes. Then we can move this toward the merge, thanks!