### PR TITLE
fix MDTF implementation

### DIFF
--- a/config_amwg_default_plots.yaml
+++ b/config_amwg_default_plots.yaml
@@ -343,8 +343,8 @@ diag_mdtf_info:
     # Intermediate/output file settings
     make_variab_tar: false     # tar up MDTF results
     save_ps : false     # save postscript figures in addition to bitmaps
-    save_nc : true      # save netCDF files of processed data (recommend true when starting with new model data)
-    overwrite: true     # overwrite results in OUTPUT_DIR; otherwise results saved under a unique name
+    save_nc : false      # save netCDF files of processed data (recommend true when starting with new model data)
+    overwrite: true     # overwrite results in OUTPUT_DIR; otherwise results will be saved under a unique name
 
     # Settings used in debugging:
     verbose  : 3       # Log verbosity level.

--- a/config_cam_baseline_example.yaml
+++ b/config_cam_baseline_example.yaml
@@ -428,8 +428,8 @@ diag_mdtf_info:
     # Intermediate/output file settings
     make_variab_tar: false     # tar up MDTF results
     save_ps : false     # save postscript figures in addition to bitmaps
-    save_nc : true      # save netCDF files of processed data (recommend true when starting with new model data)
-    overwrite: true     # overwrite results in OUTPUT_DIR; otherwise results saved under a unique name
+    save_nc : false      # save netCDF files of processed data (recommend true when starting with new model data)
+    overwrite: true     # overwrite results in OUTPUT_DIR; otherwise results will be saved under a unique name
 
     # Settings used in debugging:
     verbose  : 3       # Log verbosity level.

--- a/lib/adf_diag.py
+++ b/lib/adf_diag.py
@@ -1222,6 +1222,7 @@ class AdfDiag(AdfWeb):
         """
         Create MDTF directory tree, generate input settings jsonc file
         Submit MDTF diagnostics.
+        Returns mdtf_proc for sub-process control (waits for it to finish in run_adf_diag)
 
         """
 
@@ -1298,19 +1299,21 @@ class AdfDiag(AdfWeb):
         if copy_files_only:
             print("\t ...Copy files only. NOT Running MDTF")
             print(f"\t    Command: {mdtf_exe} Log: {mdtf_log}")
+            return 0
         else:
             print(
                 f"\t ...Running MDTF in background. Command: {mdtf_exe} Log: {mdtf_log}"
             )
             print(f"Running MDTF in background. Command: {mdtf_exe} Log: {mdtf_log}")
             with open(mdtf_log, "w", encoding="utf-8") as subout:
-                _ = subprocess.Popen(
+                mdtf_proc_var = subprocess.Popen(
                     [mdtf_exe],
                     shell=True,
                     stdout=subout,
                     stderr=subout,
                     close_fds=True,
                 )
+            return mdtf_proc_var
 
     def move_tsfiles_for_mdtf(self, verbose):
         """

--- a/run_adf_diag
+++ b/run_adf_diag
@@ -159,7 +159,7 @@ if __name__ == "__main__":
 
     #Call the MDTF:
     if diag.get_mdtf_info('mdtf_run'):
-       diag.setup_run_mdtf()
+        mdtf_proc = diag.setup_run_mdtf()  #returns mdtf_proc for subprocess control
 
     #Create model climatology (climo) files.
     #This call uses the "time_averaging_scripts" specified
@@ -193,6 +193,13 @@ if __name__ == "__main__":
     if diag.create_html:
         diag.create_website()
 
+    # Check if sub-processes are still running (CVDP, MDTF)
+    mdtf_status = mdtf_proc.wait(timeout=None)
+    if (mdtf_status != 0):
+        print(f"ERROR: MDTF finished with code {mdtf_status}")
+    else:
+        print("MDTF finished successfully")
+        
     #+++++++++++++++
     #End diag script
     #+++++++++++++++


### PR DESCRIPTION
Improves the functionality of MDTF
- ADF now waits for the MDTF to be done before exiting
- The default settings for MDTF to save_nc = false and make_tar = false, so that the output can just be tarred with ADF output
- The file permissions are fixed so that figures are viewable from the webpag