### PR TITLE
Add more robust error handling and notifications

### DIFF
--- a/scripts/analysis/amwg_table.py
+++ b/scripts/analysis/amwg_table.py
@@ -102,10 +102,6 @@ def amwg_table(adf):
     # VARIABLE-NAME, RUN VALUE, OBS VALUE, RUN-OBS, RMSE
     #----------------------
 
-    #Notify user that script has started:
-    print("\n  Calculating AMWG variable table...")
-
-
     #Extract needed quantities from ADF object:
     #-----------------------------------------
     var_list     = adf.diag_var_list
@@ -167,6 +163,9 @@ def amwg_table(adf):
         #Write to debug log if enabled:
         adf.debug_log(f"DEBUG: location of files is {str(input_location)}")
 
+        #Notify user that script has started:
+        print(f"\n  Calculating AMWG variable table for '{case_name}'...")
+
         #Create output file name:
         output_csv_file = output_location / f"amwg_table_{case_name}.csv"
 
@@ -216,7 +215,7 @@ def amwg_table(adf):
 
             #Check if variable has a vertical coordinate:
             if 'lev' in data.coords or 'ilev' in data.coords:
-                print(f"\t   Variable '{var}' has a vertical dimension, "+\
+                print(f"\t    ** Variable '{var}' has a vertical dimension, "+\
                       "which is currently not supported for the AMWG Table. Skipping...")
                 #Skip this variable and move to the next variable in var_list:
                 continue


### PR DESCRIPTION
The main part of this PR is to address the ambiguous error message in `adf_info.py` when either the climo years for history files are wrong or if there is a problem with the history file location or case name. Now anything that breaks in this regard will be logged to the debugger.

Similarly, in the `amwg_table.py` just add some more print statements for tracking progress to the user.