### PR TITLE
Add check in case MDTF is missing in config yaml file

### DIFF
--- a/run_adf_diag
+++ b/run_adf_diag
@@ -160,6 +160,8 @@ if __name__ == "__main__":
     #Call the MDTF:
     if diag.get_mdtf_info('mdtf_run'):
         mdtf_proc = diag.setup_run_mdtf()  #returns mdtf_proc for subprocess control
+    else:
+        mdtf_proc = None
 
     #Create model climatology (climo) files.
     #This call uses the "time_averaging_scripts" specified
@@ -194,11 +196,12 @@ if __name__ == "__main__":
         diag.create_website()
 
     # Check if sub-processes are still running (CVDP, MDTF)
-    mdtf_status = mdtf_proc.wait(timeout=None)
-    if (mdtf_status != 0):
-        print(f"ERROR: MDTF finished with code {mdtf_status}")
-    else:
-        print("MDTF finished successfully")
+    if mdtf_proc:
+        mdtf_status = mdtf_proc.wait(timeout=None)
+        if (mdtf_status != 0):
+            print(f"ERROR: MDTF finished with code {mdtf_status}")
+        else:
+            print("MDTF finished successfully")
         
     #+++++++++++++++
     #End diag script


### PR DESCRIPTION
ADF fails if MDTF is not present in config yaml file. This will ensure the ADF finishes if the MDTF section is missing.