### PR TITLE
Update python version list for unit tests.

### DIFF
--- a/.github/workflows/ADF_unit_tests.yaml
+++ b/.github/workflows/ADF_unit_tests.yaml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       matrix:
         #All of these python versions will be used to run tests:
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
       fail-fast: false
     steps:
     # Acquire github action routines:


### PR DESCRIPTION
This PR removes end-of-life versions of python (3.7 and 3.8) from the automated unit testing workflow, and adds two newer language versions that are currently missing from the test list (3.12 and 3.13).

