### PR TITLE
generalize create_climo_files.py

### DIFF
--- a/scripts/averaging/create_climo_files.py
+++ b/scripts/averaging/create_climo_files.py
@@ -127,6 +127,10 @@ def create_climo_files(adf, clobber=False, search=None):
         #Notify user of model case being processed:
         print(f"\t Calculating climatologies for case '{case_name}' :")
 
+        is_baseline = False
+        if (not adf.get_basic_info("compare_obs")) and (case_name == baseline_name):
+            is_baseline = True
+
         #Create "Path" objects:
         input_location  = Path(input_ts_locs[case_idx])
         output_location = Path(output_locs[case_idx])
@@ -144,9 +148,10 @@ def create_climo_files(adf, clobber=False, search=None):
             print(f"\t    {output_location} not found, making new directory")
             output_location.mkdir(parents=True)
 
-        #Time series file search
-        if search is None:
-            search = "{CASE}*{HIST_STR}*.{VARIABLE}.*nc"  # NOTE: maybe we should not care about the file extension part at all, but check file type later?
+        # If we need to allow custom search, could put it into adf.data
+        # #Time series file search
+        # if search is None:
+        #     search = "{CASE}*{HIST_STR}*.{VARIABLE}.*nc"  # NOTE: maybe we should not care about the file extension part at all, but check file type later?
 
         #Check model year bounds:
         syr, eyr = check_averaging_interval(start_year[case_idx], end_year[case_idx])
@@ -166,14 +171,18 @@ def create_climo_files(adf, clobber=False, search=None):
 
             #Create list of time series files present for variable:
             # Note that we hard-code for h0 because we only want to make climos of monthly output
-            ts_filenames = search.format(CASE=case_name, HIST_STR="h0", VARIABLE=var)
-            ts_files = sorted(list(input_location.glob(ts_filenames)))
+            if is_baseline:
+                ts_files = adf.data.get_ref_timeseries_file(var)
+            else:
+                ts_files = adf.data.get_timeseries_file(case_name, var)
+            # ts_filenames = search.format(CASE=case_name, HIST_STR="h0", VARIABLE=var)
+            # ts_files = sorted(list(input_location.glob(ts_filenames)))
 
             #If no files exist, try to move to next variable. --> Means we can not proceed with this variable,
             # and it'll be problematic later unless there are multiple hist file streams and the variable is in the others
             if not ts_files:
                 errmsg = "Time series files for variable '{}' not found.  Script will continue to next variable.".format(var)
-                print(f"The input location searched was: {input_location}. The glob pattern was {ts_filenames}.")
+                print(f"The input location searched was: {input_location}.")
                 #  end_diag_script(errmsg) # Previously we would kill the run here.
                 warnings.warn(errmsg)
                 continue


### PR DESCRIPTION
This changes `create_climo_files.py` to use `adf.data.get_ref_timeseries_file` and `adf.data.get_timeseries_file` to locate the names of the time series files.

This removes the option to provide a custom search string for the time series files, but this could be added to `adf.data` if needed.

The advantage of this approach is that it means that `create_climo_files.py` doesn't have to deal with particular history file strings. In cases where the user has supplied a list of history files in the YAML file, the time series generation will loop through the history files, and then `create_climo_files.py` just finds those time series files. This does mean that if the user provides history file streams that contain the same variable there will be some kind of conflict. 

This PR is a step toward being able to include COSP variables back into ADF because currently they have to be written on the CAM native grid (and therefore usually in a separate history stream). 