### PR TITLE
Address python generated warnings

### DIFF
--- a/lib/plotting_functions.py
+++ b/lib/plotting_functions.py
@@ -1218,7 +1218,7 @@ def plot_map_and_save(wks, case_nickname, base_nickname,
 
     # get statistics (from non-wrapped)
     fields = (mdlfld, obsfld, diffld, pctld)
-    area_avg = [global_average(x, wgt) for x in fields]
+    [spatial_average(x, weights=wgt, spatial_dims=None) for x in fields]
 
     d_rmse = wgt_rmse(mdlfld, obsfld, wgt)  # correct weighted RMSE for (lat,lon) fields.
 

--- a/scripts/analysis/amwg_table.py
+++ b/scripts/analysis/amwg_table.py
@@ -180,7 +180,7 @@ def amwg_table(adf):
 
         #Notify user that script has started:
         print(f"\n  Creating table for '{case_name}'...")
-        if eyear_cases[case_idx]-syear_cases[case_idx] < 1:
+        if eyear_cases[case_idx]-syear_cases[case_idx] == 0:
             calc_stats = False
             print("\t INFO: Looks like there is only one year of data, will skip statistics and just add means to table")
         else:


### PR DESCRIPTION
This PR will clean up some warnings that python prints to console (not ADF warnings). 

amwg_table: - Add check if case has only one year of data. If so, ignore statistics and just add means to table.
* python warning was justified, but now is good

plotting_functions: - Change global average function from `global_average` to  `spatial_average` to suppress the warnings that come from the spurious underflow error bug in numpy's mean calculation. 
* python warning is due to bug; can't fix. This is a warning that shows up if there is a very small number involved in the calculation. Verified that was not the case in the ADF run. 
* Instead xarray will be used in `spatial_average()` method in`lib/plotting_functions.py`
* 10+ year old issue https://github.com/numpy/numpy/issues/4895

Thanks 