### PR TITLE
Better "pre-flight" checking and refactoring of polar maps

### DIFF
--- a/lib/plotting_functions.py
+++ b/lib/plotting_functions.py
@@ -2007,7 +2007,7 @@ def prep_contour_plot(adata, bdata, diffdata, pctdata, **kwargs):
 
 def plot_zonal_mean_and_save(wks, case_nickname, base_nickname,
                              case_climo_yrs, baseline_climo_yrs,
-                             adata, bdata, has_lev, log_p, obs=False, **kwargs):
+                             adata, bdata, has_lev, log_p=False, obs=False, **kwargs):
 
     """This is the default zonal mean plot
 
@@ -2185,7 +2185,7 @@ def plot_zonal_mean_and_save(wks, case_nickname, base_nickname,
 
 def plot_meridional_mean_and_save(wks, case_nickname, base_nickname,
                              case_climo_yrs, baseline_climo_yrs,
-                             adata, bdata, has_lev, latbounds=None, obs=False, **kwargs):
+                             adata, bdata, has_lev, log_p=False, latbounds=None, obs=False, **kwargs):
 
     """Default meridional mean plot
 
@@ -2209,6 +2209,8 @@ def plot_meridional_mean_and_save(wks, case_nickname, base_nickname,
         It must have the same dimensions and vertical levels as adata.
     has_lev : bool
         whether lev dimension is present
+    log_p : bool, optional
+        (Not implemented) use log(pressure) vertical axis
     latbounds : numbers.Number or slice, optional
         indicates latitude bounds to average over
         if it is a number, assume symmetric about equator,

--- a/lib/plotting_functions.py
+++ b/lib/plotting_functions.py
@@ -304,6 +304,38 @@ def get_central_longitude(*args):
         return 180
     #End if
 
+
+def transform_coordinates_for_projection(proj, lon, lat):
+    """
+    Explicitly project coordinates using the projection object.
+    
+    Parameters
+    ----------
+    proj : cartopy.ccrs.CRS
+        projection object
+    lat : xarray.DataArray or numpy.ndarray
+        latitudes (in degrees)
+    lon :array.DataArray or numpy.ndarray
+        longitudes (in degrees)
+        
+    Returns
+    -------
+    x_proj : numpy.ndarray
+        array of projected longitudes
+    y_proj : numpy.ndarray
+        array of projected latitudes
+
+    Notes
+    -----
+    This is what cartopy's transform_first=True *should* be doing internally.
+    We find that it sometimes fails for polar plots, so do it with this manually.
+    This dramatically speeds up polar plots.    
+    """
+    lons, lats = np.meshgrid(lon, lat)
+    x_proj, y_proj, _ = proj.transform_points(ccrs.PlateCarree(), lons, lats).T # .T to unpack, .T again to get x,y,z arrays
+    return x_proj.T, y_proj.T
+
+
 #######
 
 def global_average(fld, wgt, verbose=False):
@@ -603,10 +635,18 @@ def domain_stats(data, domain):
     x_region_max = x_region.max().item()
     return x_region_mean, x_region_max, x_region_min
 
-def make_polar_plot(wks, case_nickname, base_nickname,
-                    case_climo_yrs, baseline_climo_yrs,
-                    d1:xr.DataArray, d2:xr.DataArray, difference:Optional[xr.DataArray]=None,pctchange:Optional[xr.DataArray]=None,
-                    domain:Optional[list]=None, hemisphere:Optional[str]=None, obs=False, **kwargs):
+def make_polar_plot(wks, case_nickname, 
+                    base_nickname,
+                    case_climo_yrs, 
+                    baseline_climo_yrs,
+                    d1:xr.DataArray, 
+                    d2:xr.DataArray, 
+                    difference:Optional[xr.DataArray]=None,
+                    pctchange:Optional[xr.DataArray]=None,
+                    domain:Optional[list]=None, 
+                    hemisphere:Optional[str]=None, 
+                    obs=False, 
+                    **kwargs):
 
     """Make a stereographic polar plot for the given data and hemisphere.
 
@@ -727,7 +767,7 @@ def make_polar_plot(wks, case_nickname, base_nickname,
             levelsdiff = np.arange(*kwargs['diff_contour_range'])
     else:
         # set levels for difference plot (with a symmetric color bar):
-        levelsdiff = np.linspace(-1*absmaxdif, absmaxdif, 12)
+        levelsdiff = np.linspace(-1*absmaxdif.data, absmaxdif.data, 12)
     #End if
     
     if "pct_diff_contour_levels" in kwargs:
@@ -758,7 +798,7 @@ def make_polar_plot(wks, case_nickname, base_nickname,
     #End if
 
     if max(np.abs(levelsdiff)) > 10*absmaxdif:
-        levelsdiff = np.linspace(-1*absmaxdif, absmaxdif, 12)
+        levelsdiff = np.linspace(-1*absmaxdif.data, absmaxdif.data, 12)
     
     
     #End if
@@ -779,8 +819,7 @@ def make_polar_plot(wks, case_nickname, base_nickname,
     #End if
 
     # -- end options
-
-    lons, lats = np.meshgrid(lon_cyclic, d1.lat)
+    lons, lats = transform_coordinates_for_projection(proj, lon_cyclic, d1.lat) # Explicit coordinate transform
 
     fig = plt.figure(figsize=(10,10))
     gs = mpl.gridspec.GridSpec(2, 4, wspace=0.9)
@@ -794,27 +833,28 @@ def make_polar_plot(wks, case_nickname, base_nickname,
     levs_diff = np.unique(np.array(levelsdiff))
     levs_pctdiff = np.unique(np.array(levelspctdiff))
 
+    # BPM: removing `transform=ccrs.PlateCarree()` from contourf calls & transform_first=True
     if len(levs) < 2:
-        img1 = ax1.contourf(lons, lats, d1_cyclic, transform=ccrs.PlateCarree(), colors="w", norm=norm1)
+        img1 = ax1.contourf(lons, lats, d1_cyclic, colors="w", norm=norm1)
         ax1.text(0.4, 0.4, empty_message, transform=ax1.transAxes, bbox=props)
 
-        img2 = ax2.contourf(lons, lats, d2_cyclic, transform=ccrs.PlateCarree(), colors="w", norm=norm1)
+        img2 = ax2.contourf(lons, lats, d2_cyclic, colors="w", norm=norm1)
         ax2.text(0.4, 0.4, empty_message, transform=ax2.transAxes, bbox=props)
     else:
-        img1 = ax1.contourf(lons, lats, d1_cyclic, transform=ccrs.PlateCarree(), cmap=cmap1, norm=norm1, levels=levels1)
-        img2 = ax2.contourf(lons, lats, d2_cyclic, transform=ccrs.PlateCarree(), cmap=cmap1, norm=norm1, levels=levels1)
+        img1 = ax1.contourf(lons, lats, d1_cyclic, cmap=cmap1, norm=norm1, levels=levels1)
+        img2 = ax2.contourf(lons, lats, d2_cyclic, cmap=cmap1, norm=norm1, levels=levels1)
 
     if len(levs_pctdiff) < 2:
-        img3 = ax3.contourf(lons, lats, pct_cyclic, transform=ccrs.PlateCarree(), colors="w", norm=pctnorm, transform_first=True)
+        img3 = ax3.contourf(lons, lats, pct_cyclic, colors="w", norm=pctnorm)
         ax3.text(0.4, 0.4, empty_message, transform=ax3.transAxes, bbox=props)
     else:
-        img3 = ax3.contourf(lons, lats, pct_cyclic, transform=ccrs.PlateCarree(), cmap=cmappct, norm=pctnorm, levels=levelspctdiff, transform_first=True)
+        img3 = ax3.contourf(lons, lats, pct_cyclic, cmap=cmappct, norm=pctnorm, levels=levelspctdiff)
 
     if len(levs_diff) < 2:
-        img4 = ax4.contourf(lons, lats, dif_cyclic, transform=ccrs.PlateCarree(), colors="w", norm=dnorm)
+        img4 = ax4.contourf(lons, lats, dif_cyclic, colors="w", norm=dnorm)
         ax4.text(0.4, 0.4, empty_message, transform=ax4.transAxes, bbox=props)
     else:
-        img4 = ax4.contourf(lons, lats, dif_cyclic, transform=ccrs.PlateCarree(), cmap=cmapdiff, norm=dnorm, levels=levelsdiff)
+        img4 = ax4.contourf(lons, lats, dif_cyclic, cmap=cmapdiff, norm=dnorm, levels=levelsdiff)
         
     #Set Main title for subplots:
     st = fig.suptitle(wks.stem[:-5].replace("_"," - "), fontsize=18)
@@ -1904,7 +1944,7 @@ def prep_contour_plot(adata, bdata, diffdata, pctdata, **kwargs):
         # set a symmetric color bar for diff:
         absmaxdif = np.max(np.abs(diffdata))
         # set levels for difference plot:
-        levelsdiff = np.linspace(-1*absmaxdif, absmaxdif, 12)
+        levelsdiff = np.linspace(-1*absmaxdif.data, absmaxdif.data, 12)
         
     # Percent Difference options -- Check in kwargs for colormap and levels
     if "pct_diff_colormap" in kwargs:

--- a/scripts/plotting/aod_latlon.py
+++ b/scripts/plotting/aod_latlon.py
@@ -426,6 +426,7 @@ def aod_panel_latlon(adfobj, plot_titles, plot_params, data, season, obs_name, c
         extend_option = 'both' if symmetric else 'max'
         
         for ax, is_panel in [(axs[i], True), (ind_ax, False)]:
+            print(f"DEBUGGING: {type(ax) = }, {is_panel = } //  {type(lon_mesh) = }, {lon_mesh.shape = } // {type(lat_mesh) = }, {lat_mesh.shape = } // {field_values.shape = }")
             img = ax.contourf(lon_mesh, lat_mesh, field_values,
                             levels, cmap=cmap_option, extend=extend_option,
                             transform=ccrs.PlateCarree())

--- a/scripts/plotting/aod_latlon.py
+++ b/scripts/plotting/aod_latlon.py
@@ -132,6 +132,7 @@ def process_model_cases(adfobj, var, obs_data):
     # Process each case
     processed_data = []
     for case_name in cases:
+        print(f"[process_model_cases] {case_name = }")
         # Load and process model data
         case_data = process_model_data(adfobj, case_name, var, ref_obs)
         if case_data is not None:

--- a/scripts/plotting/aod_latlon.py
+++ b/scripts/plotting/aod_latlon.py
@@ -398,6 +398,7 @@ def aod_panel_latlon(adfobj, plot_titles, plot_params, data, season, obs_name, c
 
     # Generate each panel
     for i, field in enumerate(data):
+        print(f"DEBUGGING: {i = }, {field.shape = }")
         # Create individual plot
         ind_fig, ind_ax = plt.subplots(1, 1, figsize=((7*case_num)/2, 10/2),
                                       subplot_kw={'projection': ccrs.PlateCarree()})
@@ -408,7 +409,7 @@ def aod_panel_latlon(adfobj, plot_titles, plot_params, data, season, obs_name, c
         lat_values = field.lat.values
         field_values, lon_values = add_cyclic_point(field_values, coord=lon_values)
         lon_mesh, lat_mesh = np.meshgrid(lon_values, lat_values)
-        field_mean = np.nanmean(field_values)
+        field_mean = np.nanmean(field_values) ## THIS IS THE INCORRECT AVERAGE TO USE
 
         # Set plot parameters
         plot_param = plot_params[i]
@@ -416,6 +417,8 @@ def aod_panel_latlon(adfobj, plot_titles, plot_params, data, season, obs_name, c
                            plot_param['nlevel'], endpoint=True)
         if 'augment_levels' in plot_param:
             levels = sorted(np.append(levels, np.array(plot_param['augment_levels'])))
+
+        print(f"DEBUGGING: {levels = }")
 
         plot_config = plot_titles[i]
         title = f"{plot_config['title']} Mean {field_mean:.2g}"

--- a/scripts/plotting/aod_latlon.py
+++ b/scripts/plotting/aod_latlon.py
@@ -143,7 +143,10 @@ def process_model_cases(adfobj, var, obs_data):
 
 def process_model_data(adfobj, case_name, var, obs_shape):
     """Process model data and check grid compatibility."""
-    ds_case = adfobj.data.load_climo_da(case_name, var)
+    if case_name == adfobj.data.ref_case_label:
+        ds_case = adfobj.data.load_reference_climo_da(case_name, var)
+    else:
+        ds_case = adfobj.data.load_climo_da(case_name, var)
     if ds_case is None:
         print(f"\t WARNING: No climo file for {case_name} variable {var}")
         return None

--- a/scripts/plotting/aod_latlon.py
+++ b/scripts/plotting/aod_latlon.py
@@ -1,0 +1,483 @@
+"""Module for AOD-specific plotting functionality"""
+
+from pathlib import Path
+import numpy as np
+import xarray as xr
+import xesmf as xe
+
+
+import matplotlib as mpl
+import matplotlib.pyplot as plt
+from matplotlib import gridspec
+import cartopy.crs as ccrs
+from cartopy.mpl.ticker import LongitudeFormatter, LatitudeFormatter
+from cartopy.util import add_cyclic_point
+
+import plotting_functions as pf
+
+from dataclasses import dataclass
+
+@dataclass
+class AODPlotConfig:
+    """Configuration for AOD plots."""
+    seasons: list = ('DJF', 'MAM', 'JJA', 'SON')
+    season_names: dict = {'DJF': 'Dec-Jan-Feb', 'MAM': 'Mar-Apr-May', 'JJA': 'Jun-Jul-Aug', 'SON': 'Sep-Oct-Nov'}
+    obs_sources: list = ('TERRA MODIS', 'MERRA2')
+    var_name: str = 'AODVISdn'
+
+
+def aod_latlon(adfobj):
+    """Generate AOD comparison plots."""
+    config = AODPlotConfig()
+    
+    # Load observations
+    obs_data = load_observations(adfobj)
+    if not obs_data:
+        return
+        
+    # Process model data
+    model_data = process_model_cases(adfobj, config.var_name, obs_data)
+    if not model_data:
+        return
+        
+    # Generate plots
+    for obs_source, obs_dataset in obs_data.items():
+        for season in config.seasons:
+            create_aod_panel(adfobj, model_data, obs_dataset, 
+                           season, obs_source)
+            
+
+def load_observations(adfobj):
+    """Load MERRA2 and MODIS observation datasets.
+    
+    Parameters
+    ----------
+    adfobj : AdfDiag
+        The diagnostics object containing configuration
+        
+    Returns
+    -------
+    dict
+        Dictionary of observation datasets keyed by source name
+    """
+    obs_dir = adfobj.get_basic_info("obs_data_loc")
+    obs_files = {
+        'TERRA MODIS': 'MOD08_M3_192x288_AOD_2001-2020_climo.nc',
+        'MERRA2': 'MERRA2_192x288_AOD_2001-2020_climo.nc'
+    }
+    
+    obs_data = {}
+    for source, filename in obs_files.items():
+        ds = load_obs_data(obs_dir, filename)
+        if ds is None:
+            print(f"\t  WARNING: AOD Panel plots not made, missing {source} file")
+            return None
+            
+        # Extract correct variable based on source
+        if source == 'MERRA2':
+            ds = ds['TOTEXTTAU']
+        else:  # MODIS
+            ds = ds['AOD_550_Dark_Target_Deep_Blue_Combined_Mean_Mean']
+            
+        # Calculate seasonal means
+        ds_seasonal = monthly_to_seasonal(ds, obs=True)
+        obs_data[source] = ds_seasonal
+        
+    return obs_data
+
+
+def load_obs_data(obs_dir, file_name):
+    """Load and prepare observational dataset."""
+    file_path = Path(obs_dir) / file_name
+    if not file_path.is_file():
+        return None
+        
+    ds = xr.open_dataset(file_path)
+    # Round coordinates for consistency
+    ds['lon'] = ds['lon'].round(5)
+    ds['lat'] = ds['lat'].round(5)
+    return ds
+
+
+def process_model_cases(adfobj, var, obs_data):
+    """Process model cases and regrid if necessary.
+    
+    Parameters
+    ----------
+    adfobj : AdfDiag
+        The diagnostics object containing configuration
+    var : str
+        Variable name to process
+    obs_data : dict
+        Dictionary of observation datasets with their grids
+        
+    Returns
+    -------
+    list
+        List of processed model datasets, one per case
+    """
+    # Get case information
+    cases = adfobj.get_cam_info('cam_case_name', required=True)
+    if not adfobj.compare_obs:
+        cases = cases + [adfobj.data.ref_case_label] # ref case added to cases
+
+    # Get reference grid from first observation dataset
+    ref_obs = next(iter(obs_data.values()))
+    
+    # Process each case
+    processed_data = []
+    for case_name in cases:
+        # Load and process model data
+        case_data = process_model_data(adfobj, case_name, var, ref_obs)
+        if case_data is not None:
+            processed_data.append((case_data, case_name))
+            
+    return processed_data if processed_data else None
+
+
+def process_model_data(adfobj, case_name, var, obs_shape):
+    """Process model data and check grid compatibility."""
+    ds_case = adfobj.data.load_climo_da(case_name, var)
+    if ds_case is None:
+        print(f"\t WARNING: No climo file for {case_name} variable {var}")
+        return None
+        
+    ds_case['lon'] = ds_case['lon'].round(5)
+    ds_case['lat'] = ds_case['lat'].round(5)
+    
+    # Check grid compatibility
+    needs_regrid = check_grid_compatibility(ds_case, obs_shape)
+    if needs_regrid:
+        ds_case = regrid_to_obs(ds_case, obs_shape)
+        
+    return monthly_to_seasonal(ds_case)
+
+
+def check_grid_compatibility(model_arr, obs_arr):
+    """Check if model grid matches observation grid.
+    
+    Parameters
+    ----------
+    model_arr : xarray.DataArray
+        Model data array with lat/lon coordinates
+    obs_arr : xarray.DataArray
+        Observation data array with lat/lon coordinates
+        
+    Returns
+    -------
+    bool
+        True if grids don't match and regridding is needed
+    """
+    test_lons = model_arr.lon
+    test_lats = model_arr.lat
+    obs_lons = obs_arr.lon
+    obs_lats = obs_arr.lat
+
+    # Check if shapes match first
+    if obs_lons.shape != test_lons.shape:
+        return True
+        
+    # Check exact coordinate matches
+    try:
+        xr.testing.assert_equal(test_lons, obs_lons)
+        xr.testing.assert_equal(test_lats, obs_lats)
+        return False
+    except AssertionError:
+        return True
+    
+def create_aod_panel(adfobj, data_sets, obs_dataset, season, obs_name):
+    """Create AOD panel plot with differences and percent differences."""
+    plot_data = []
+    plot_titles = []
+    plot_params = []
+    case_names = []
+    types = []
+    
+    # Get plot parameters from configuration
+    plot_config = get_plot_params(adfobj)
+    
+    for case_data, case_name in data_sets:
+        # Calculate differences
+        diff = calculate_differences(case_data, obs_dataset, season)
+        plot_data.append(diff)
+        plot_titles.append(make_plot_config(diff, case_name, obs_name, season, "Diff"))
+        plot_params.append(plot_config['default'])
+        case_names.append(case_name)
+        types.append("Diff")
+        
+        # Calculate percent differences
+        pdiff = calculate_percent_diff(case_data, obs_dataset, season)
+        plot_data.append(pdiff)
+        plot_titles.append(make_plot_config(pdiff, case_name, obs_name, season, "Percent Diff"))
+        plot_params.append(plot_config['relerr'])
+        case_names.append(case_name)
+        types.append("Percent Diff")
+        
+    return aod_panel_latlon(adfobj, plot_titles, plot_params, plot_data, 
+                           season, obs_name, case_names, len(data_sets), 
+                           types, symmetric=True)
+
+
+def validate_obs_data(merra_data, modis_data):
+    """Validate observation datasets."""
+    if merra_data is None or modis_data is None:
+        raise ValueError("Missing observation data")
+    
+    if not np.array_equal(merra_data.lat, modis_data.lat):
+        raise ValueError("Observation grids do not match")
+
+
+def regrid_to_obs(model_arr, obs_arr):
+    """Regrid model data to match observation grid using bilinear interpolation.
+    
+    Parameters
+    ----------
+    model_arr : xarray.DataArray
+        Model data array to be regridded
+    obs_arr : xarray.DataArray
+        Observation data array with target grid
+        
+    Returns
+    -------
+    xarray.DataArray
+        Regridded model data, or None if grids already match
+    """
+    # Create target grid specification
+    ds_out = xr.Dataset({
+        "lat": (["lat"], obs_arr.lat.values, {"units": "degrees_north"}),
+        "lon": (["lon"], obs_arr.lon.values, {"units": "degrees_east"})
+    })
+    
+    # Perform regridding
+    regridder = xe.Regridder(model_arr, ds_out, "bilinear", periodic=True)
+    model_regrid = regridder(model_arr, keep_attrs=True)
+    
+    return model_regrid
+
+def calculate_differences(case_data, obs_data, season):
+    """Calculate differences between case and observation data for a given season.
+    
+    Parameters
+    ----------
+    case_data : xarray.DataArray
+        Model case data
+    obs_data : xarray.DataArray
+        Observation data
+    season : str
+        Season to calculate difference for
+        
+    Returns
+    -------
+    xarray.DataArray
+        Difference between case and observation data
+    """
+    return case_data.sel(season=season) - obs_data.sel(season=season)
+
+
+def calculate_percent_diff(case_data, obs_data, season):
+    """Calculate percent difference between case and observation data.
+    
+    Parameters
+    ----------
+    case_data : xarray.DataArray
+        Model case data
+    obs_data : xarray.DataArray
+        Observation data 
+    season : str
+        Season to calculate difference for
+        
+    Returns
+    -------
+    xarray.DataArray
+        Percent difference, clipped to [-100, 100]
+    """
+    diff = calculate_differences(case_data, obs_data, season)
+    pdiff = 100 * diff / obs_data.sel(season=season)
+    return np.clip(pdiff, -100, 100)
+
+
+def make_plot_config(data, case_name, obs_name, season, plot_type):
+    """Create plot configuration dictionary.
+    
+    Parameters
+    ----------
+    data : xarray.DataArray
+        Data to plot
+    case_name : str
+        Name of case being plotted
+    obs_name : str  
+        Name of observation dataset
+    season : str
+        Season being plotted
+    plot_type : str
+        Type of plot ('Diff' or 'Percent Diff')
+        
+    Returns
+    -------
+    dict
+        Plot configuration including data and metadata
+    """
+    config = AODPlotConfig()
+    return {
+        'data': data,
+        'title': f'{case_name} - {obs_name}\nAOD 550 nm - {config.season_names[season]}',
+        'case_name': case_name,
+        'plot_type': plot_type,
+        'season': season
+    }
+
+
+def get_plot_params(adfobj):
+    """Get AOD plot parameters from ADF configuration."""
+    res = adfobj.variable_defaults
+    res_aod_diags = res.get("aod_diags", {})
+    return {
+        'default': res_aod_diags.get("plot_params", {}),
+        'relerr': res_aod_diags.get("plot_params_relerr", {})
+    }
+
+### refactored aod_panel_latlon:
+def aod_panel_latlon(adfobj, plot_titles, plot_params, data, season, obs_name, case_names, case_num, types, symmetric=False):
+    """Create AOD panel plot with model vs observation differences.
+    
+    Parameters
+    ----------
+    adfobj : AdfDiag
+        The diagnostics object containing configuration
+    plot_titles : list
+        List of titles for each panel
+    plot_params : list
+        List of plotting parameters for each panel
+    data : list
+        List of xarray DataArrays to plot
+    season : str
+        Current season being plotted
+    obs_name : str
+        Name of observation dataset
+    case_names : list
+        List of case names
+    case_num : int
+        Number of cases
+    types : list
+        List of plot types ('Diff' or 'Percent Diff')
+    symmetric : bool, optional
+        Whether to use symmetric colormap, by default False
+    """
+    # Get plot configuration
+    file_type = adfobj.read_config_var("diag_basic_info").get('plot_type', 'png')
+    plot_dir = adfobj.plot_location[0]
+    plotfile = Path(plot_dir) / f'AOD_diff_{obs_name.replace(" ","_")}_{season}_LatLon_Mean.{file_type}'
+
+    # Check if plot should be regenerated
+    if plotfile.is_file() and not adfobj.get_basic_info('redo_plot'):
+        adfobj.add_website_data(plotfile, f'AOD_diff_{obs_name.replace(" ","_")}', None,
+                               season=season, multi_case=True, plot_type="LatLon", 
+                               category="4-Panel AOD Diags")
+        return
+
+    # Create figure and axes
+    fig = plt.figure(figsize=(7*case_num, 10))
+    gs = mpl.gridspec.GridSpec(2*case_num, int(3*case_num), wspace=0.5, hspace=0.0)
+    gs.tight_layout(fig)
+    
+    axs = []
+    for i in range(case_num):
+        start = i * 3
+        end = (i + 1) * 3
+        axs.append(plt.subplot(gs[0:case_num, start:end], projection=ccrs.PlateCarree()))
+        axs.append(plt.subplot(gs[case_num:, start:end], projection=ccrs.PlateCarree()))
+
+    # Generate each panel
+    for i, field in enumerate(data):
+        # Create individual plot
+        ind_fig, ind_ax = plt.subplots(1, 1, figsize=((7*case_num)/2, 10/2),
+                                      subplot_kw={'projection': ccrs.PlateCarree()})
+        
+        # Prepare data
+        field_values = field.values[:,:]
+        lon_values = field.lon.values
+        lat_values = field.lat.values
+        field_values, lon_values = add_cyclic_point(field_values, coord=lon_values)
+        lon_mesh, lat_mesh = np.meshgrid(lon_values, lat_values)
+        field_mean = np.nanmean(field_values)
+
+        # Set plot parameters
+        plot_param = plot_params[i]
+        levels = np.linspace(plot_param['range_min'], plot_param['range_max'],
+                           plot_param['nlevel'], endpoint=True)
+        if 'augment_levels' in plot_param:
+            levels = sorted(np.append(levels, np.array(plot_param['augment_levels'])))
+
+        plot_config = plot_titles[i]
+        title = f"{plot_config['title']} Mean {field_mean:.2g}"
+
+        # Create plots
+        cmap_option = (plot_param.get('colormap', plt.cm.bwr) if symmetric 
+                      else plot_param.get('colormap', plt.cm.turbo))
+        extend_option = 'both' if symmetric else 'max'
+        
+        for ax, is_panel in [(axs[i], True), (ind_ax, False)]:
+            img = ax.contourf(lon_mesh, lat_mesh, field_values,
+                            levels, cmap=cmap_option, extend=extend_option,
+                            transform=ccrs.PlateCarree())
+            ax.set_facecolor('gray')
+            ax.coastlines()
+            ax.set_title(title, fontsize=10)
+
+            cbar = plt.colorbar(img, orientation='horizontal', pad=0.05)
+            if 'ticks' in plot_param:
+                cbar.set_ticks(plot_param['ticks'])
+            if 'tick_labels' in plot_param:
+                cbar.ax.set_xticklabels(plot_param['tick_labels'])
+            cbar.ax.tick_params(labelsize=6)
+
+        # Save individual plot
+        pbase = f'AOD_{case_names[i]}_vs_{obs_name.replace(" ","_")}_{types[i].replace(" ","_")}'
+        ind_plotfile = Path(plot_dir) / f'{pbase}_{season}_LatLon_Mean.{file_type}'
+        ind_fig.savefig(ind_plotfile, bbox_inches='tight', dpi=300)
+        plt.close(ind_fig)
+
+    # Save panel plot
+    fig.savefig(plotfile, bbox_inches='tight', dpi=300)
+    adfobj.add_website_data(plotfile, f'AOD_diff_{obs_name.replace(" ","_")}', None,
+                           season=season, multi_case=True, plot_type="LatLon", 
+                           category="4-Panel AOD Diags")
+    plt.close(fig)
+
+
+def monthly_to_seasonal(ds, obs=False):
+    """Convert monthly data to seasonal means.
+    
+    Parameters
+    ----------
+    ds : xarray.Dataset or xarray.DataArray
+        Input data with monthly time dimension
+    obs : bool, optional
+        Whether input is observation data, by default False
+        
+    Returns
+    -------
+    xarray.DataArray
+        Data array with new season dimension
+    """
+    seasons = ['DJF', 'MAM', 'JJA', 'SON']
+    dataarrays = []
+    
+    if obs and isinstance(ds, xr.Dataset):
+        # Handle observation dataset with multiple variables
+        for varname in ds.data_vars:
+            if '_n' not in varname:  # Skip count variables
+                var_data = ds[varname]
+                for s in seasons:
+                    dataarrays.append(pf.seasonal_mean(var_data, season=s, is_climo=True))
+    else:
+        # Handle single DataArray
+        for s in seasons:
+            dataarrays.append(pf.seasonal_mean(ds, season=s, is_climo=True))
+
+    # Combine seasonal means
+    ds_seasonal = xr.concat(dataarrays, dim='season')
+    ds_seasonal['season'] = seasons
+    ds_seasonal = ds_seasonal.transpose('lat', 'lon', 'season')
+
+    return ds_seasonal

--- a/scripts/plotting/aod_latlon.py
+++ b/scripts/plotting/aod_latlon.py
@@ -15,13 +15,18 @@ from cartopy.util import add_cyclic_point
 
 import plotting_functions as pf
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 @dataclass
 class AODPlotConfig:
     """Configuration for AOD plots."""
     seasons: list = ('DJF', 'MAM', 'JJA', 'SON')
-    season_names: dict = {'DJF': 'Dec-Jan-Feb', 'MAM': 'Mar-Apr-May', 'JJA': 'Jun-Jul-Aug', 'SON': 'Sep-Oct-Nov'}
+    season_names: dict = field(default_factory=lambda: {
+        'DJF': 'Dec-Jan-Feb',
+        'MAM': 'Mar-Apr-May',
+        'JJA': 'Jun-Jul-Aug',
+        'SON': 'Sep-Oct-Nov'
+    })
     obs_sources: list = ('TERRA MODIS', 'MERRA2')
     var_name: str = 'AODVISdn'
 

--- a/scripts/plotting/global_latlon_map.py
+++ b/scripts/plotting/global_latlon_map.py
@@ -18,7 +18,7 @@ import warnings
 
 # Import local modules:
 import plotting_functions as pf
-from .aod_latlon import aod_latlon
+from aod_latlon import aod_latlon 
 
 # Format warning messages:
 def my_formatwarning(msg, *args, **kwargs):

--- a/scripts/plotting/global_latlon_map.py
+++ b/scripts/plotting/global_latlon_map.py
@@ -111,7 +111,8 @@ def process_variable(adfobj, var, seasons, pres_levs, plot_type, redo_plot):
         # Load reference data
         odata = load_reference_data(adfobj, var)
         if odata is None:
-            continue
+            print(f"[global_latlon_map][process_variable] finds no reference data.")
+            return
 
         #Loop over model cases:
         for case_idx, case_name in enumerate(adfobj.data.case_names):

--- a/scripts/plotting/global_latlon_map.py
+++ b/scripts/plotting/global_latlon_map.py
@@ -99,7 +99,7 @@ def global_latlon_map(adfobj):
     print("  ...lat/lon maps have been generated successfully.")
 
 
-def process_variable(adfobj, var, seasons, pres_levs, plot_type, redo_plot)
+def process_variable(adfobj, var, seasons, pres_levs, plot_type, redo_plot):
         vres = adfobj.variable_defaults.get(var, {})
         web_category = vres.get("category", None)
 

--- a/scripts/plotting/global_latlon_map.py
+++ b/scripts/plotting/global_latlon_map.py
@@ -129,7 +129,8 @@ def load_reference_data(adfobj, var):
         if var not in adfobj.data.ref_var_nam:
             dmsg = f"\t    WARNING: No obs data found for variable `{var}`, global lat/lon mean plotting skipped."
             adfobj.debug_log(dmsg)
-            print(dmsg)                return None
+            print(dmsg)
+            return None
         base_name = adfobj.data.ref_labels[var]
 
     odata = adfobj.data.load_reference_regrid_da(base_name, var)

--- a/scripts/plotting/global_latlon_map.py
+++ b/scripts/plotting/global_latlon_map.py
@@ -238,7 +238,7 @@ def global_latlon_map(adfobj):
                     for s in seasons:
                         plot_name = plot_loc / f"{var}_{pres}hpa_{s}_LatLon_Mean.{plot_type}"
                         doplot[plot_name] = plot_file_op(adfobj, plot_name, f"{var}_{pres}hpa", case_name, s, web_category, redo_plot, "LatLon")
-            if all(value is None for value in doplot.values()):
+            if not any(value is None for value in doplot.values()):
                 print(f"\t    INFO: All plots exist for {var}. Redo is {redo_plot}. Existing plots added to website data. Continue.")
                 continue
 

--- a/scripts/plotting/global_latlon_map.py
+++ b/scripts/plotting/global_latlon_map.py
@@ -100,25 +100,25 @@ def global_latlon_map(adfobj):
 
 
 def process_variable(adfobj, var, seasons, pres_levs, plot_type, redo_plot):
-        vres = adfobj.variable_defaults.get(var, {})
-        web_category = vres.get("category", None)
+    vres = adfobj.variable_defaults.get(var, {})
+    web_category = vres.get("category", None)
 
-        # For global maps, also set the central longitude:
-        # can be specified in adfobj basic info as 'central_longitude' or supplied as a number,
-        # otherwise defaults to 180
-        vres['central_longitude'] = pf.get_central_longitude(adfobj)
+    # For global maps, also set the central longitude:
+    # can be specified in adfobj basic info as 'central_longitude' or supplied as a number,
+    # otherwise defaults to 180
+    vres['central_longitude'] = pf.get_central_longitude(adfobj)
 
-        # Load reference data
-        odata = load_reference_data(adfobj, var)
-        if odata is None:
-            print(f"[global_latlon_map][process_variable] finds no reference data.")
-            return
+    # Load reference data
+    odata = load_reference_data(adfobj, var)
+    if odata is None:
+        print(f"[global_latlon_map][process_variable] finds no reference data.")
+        return
 
-        #Loop over model cases:
-        for case_idx, case_name in enumerate(adfobj.data.case_names):
-            process_case(adfobj, case_name, case_idx, var, odata, 
-                        seasons, pres_levs, plot_type, redo_plot,
-                        vres, web_category)
+    #Loop over model cases:
+    for case_idx, case_name in enumerate(adfobj.data.case_names):
+        process_case(adfobj, case_name, case_idx, var, odata, 
+                    seasons, pres_levs, plot_type, redo_plot,
+                    vres, web_category)
 
 
 
@@ -194,8 +194,8 @@ def process_seasonal_data(mdata, odata, season, weight_season=True):
         mseason = pf.seasonal_mean(mdata, season=season, is_climo=True)
         oseason = pf.seasonal_mean(odata, season=season, is_climo=True)
     else:
-        mseason = mdata.sel(time=seasons[s]).mean(dim='time')
-        oseason = odata.sel(time=seasons[s]).mean(dim='time')
+        mseason = mdata.sel(time=season).mean(dim='time')
+        oseason = odata.sel(time=season).mean(dim='time')
     
     # Calculate differences
     dseason = mseason - oseason
@@ -361,13 +361,14 @@ def check_existing_plots(adfobj, var, plot_loc, plot_type, case_name,
                                                redo_plot, "LatLon")
     return doplot
 
+
 def process_2d_plots(adfobj, mdata, odata, case_name, case_nickname,
                     var, seasons, plot_loc, plot_type, doplot,
                     mseasons, oseasons, dseasons, pseasons,
                     syear_case, eyear_case, syear_baseline, eyear_baseline,
                     web_category, vres):
     """Process and generate 2D plots."""
-    for s in seasons:
+    for s in seasons.keys():
         plot_name = plot_loc / f"{var}_{s}_LatLon_Mean.{plot_type}"
         if doplot[plot_name] is None:
             continue
@@ -402,7 +403,7 @@ def process_3d_plots(adfobj, mdata, odata, case_name, case_nickname,
                   f"ref: {pres in odata['lev']}], so skipping.")
             continue
 
-        for s in seasons:
+        for s in seasons.keys():
             plot_name = plot_loc / f"{var}_{pres}hpa_{s}_LatLon_Mean.{plot_type}"
             if doplot[plot_name] is None:
                 continue

--- a/scripts/plotting/global_latlon_map.py
+++ b/scripts/plotting/global_latlon_map.py
@@ -11,27 +11,16 @@ my_formatwarning(msg, *args, **kwargs)
 plot_file_op
     Check on status of output plot file.
 """
-#Import standard modules:
-import os
+# Import standard modules:
 from pathlib import Path
 import numpy as np
-import xarray as xr
-import xesmf as xe
-import warnings  # use to warn user about missing files.
+import warnings
 
-# Import plotting modules:
-import matplotlib as mpl
-import matplotlib.pyplot as plt
-
-import cartopy.crs as ccrs
-import cartopy.feature as cfeature
-from cartopy.util import add_cyclic_point
-from cartopy.mpl.ticker import LongitudeFormatter, LatitudeFormatter
+# Import local modules:
 import plotting_functions as pf
+from .aod_latlon import aod_latlon
 
-# Warnings
-import warnings  # use to warn user about missing files.
-#     - Format warning messages:
+# Format warning messages:
 def my_formatwarning(msg, *args, **kwargs):
     """Issue `msg` as warning."""
     return str(msg) + '\n'
@@ -92,251 +81,128 @@ def global_latlon_map(adfobj):
         Checks on pressure level dimension
     """
 
-    #Notify user that script has started:
     msg = "\n  Generating lat/lon maps..."
     print(f"{msg}\n  {'-' * (len(msg)-3)}")
 
-    #
-    # Use ADF api to get all necessary information
-    #
-    var_list = adfobj.diag_var_list
-    #Special ADF variable which contains the output paths for
-    #all generated plots and tables for each case:
-    plot_locations = adfobj.plot_location
+    # Get configuration
+    config = get_plot_config(adfobj)
+    
+    # Process regular variables
+    for var in adfobj.diag_var_list:
+        process_variable(adfobj, var, **config)
+        
+    # Handle AOD special case
+    if "AODVISdn" in adfobj.diag_var_list:
+        print("\tRunning AOD panel diagnostics against MERRA and MODIS...")
+        aod_latlon(adfobj)
+        
+    print("  ...lat/lon maps have been generated successfully.")
 
-    #Grab case years
-    syear_cases = adfobj.climo_yrs["syears"]
-    eyear_cases = adfobj.climo_yrs["eyears"]
 
-    #Grab baseline years (which may be empty strings if using Obs):
-    syear_baseline = adfobj.climo_yrs["syear_baseline"]
-    eyear_baseline = adfobj.climo_yrs["eyear_baseline"]
-
-    res = adfobj.variable_defaults # will be dict of variable-specific plot preferences
-    # or an empty dictionary if use_defaults was not specified in YAML.
-
-    #Set plot file type:
-    # -- this should be set in basic_info_dict, but is not required
-    # -- So check for it, and default to png
-    basic_info_dict = adfobj.read_config_var("diag_basic_info")
-    plot_type = basic_info_dict.get('plot_type', 'png')
-    print(f"\t NOTE: Plot type is set to {plot_type}")
-
-    # check if existing plots need to be redone
-    redo_plot = adfobj.get_basic_info('redo_plot')
-    print(f"\t NOTE: redo_plot is set to {redo_plot}")
-    #-----------------------------------------
-
-    #Determine if user wants to plot 3-D variables on
-    #pressure levels:
-    pres_levs = adfobj.get_basic_info("plot_press_levels")
-
-    weight_season = True  #always do seasonal weighting
-
-    #Set seasonal ranges:
-    seasons = {"ANN": np.arange(1,13,1),
-               "DJF": [12, 1, 2],
-               "JJA": [6, 7, 8],
-               "MAM": [3, 4, 5],
-               "SON": [9, 10, 11]
-               }
-
-    # probably want to do this one variable at a time:
-    for var in var_list:
-        #Notify user of variable being plotted:
-        print(f"\t - lat/lon maps for {var}")
-
-        # Check res for any variable specific options that need to be used BEFORE going to the plot:
-        if var in res:
-            vres = res[var]
-            #If found then notify user, assuming debug log is enabled:
-            adfobj.debug_log(f"global_latlon_map: Found variable defaults for {var}")
-
-            #Extract category (if available):
-            web_category = vres.get("category", None)
-
-        else:
-            vres = {}
-            web_category = None
-        #End if
+def process_variable(adfobj, var, seasons, pres_levs, plot_type, redo_plot)
+        vres = adfobj.variable_defaults.get(var, {})
+        web_category = vres.get("category", None)
 
         # For global maps, also set the central longitude:
         # can be specified in adfobj basic info as 'central_longitude' or supplied as a number,
         # otherwise defaults to 180
         vres['central_longitude'] = pf.get_central_longitude(adfobj)
 
-        # load reference data (observational or baseline)
-        if not adfobj.compare_obs:
-            base_name = adfobj.data.ref_case_label
-        else:
-            if var not in adfobj.data.ref_var_nam:
-                dmsg = f"\t    WARNING: No obs data found for variable `{var}`, global lat/lon mean plotting skipped."
-                adfobj.debug_log(dmsg)
-                print(dmsg)
-                continue
-            else:
-                base_name = adfobj.data.ref_labels[var]
-
-        # Gather reference variable data
-        odata = adfobj.data.load_reference_regrid_da(base_name, var)
-
+        # Load reference data
+        odata = load_reference_data(adfobj, var)
         if odata is None:
-            dmsg = f"\t    WARNING: No regridded test file for {base_name} for variable `{var}`, global lat/lon mean plotting skipped."
-            adfobj.debug_log(dmsg)
-            continue
-
-        o_has_dims = pf.validate_dims(odata, ["lat", "lon", "lev"]) # T iff dims are (lat,lon) -- can't plot unless we have both
-        if (not o_has_dims['has_lat']) or (not o_has_dims['has_lon']):
-            print(f"\t    WARNING: skipping global map for {var} as REFERENCE does not have both lat and lon")
             continue
 
         #Loop over model cases:
         for case_idx, case_name in enumerate(adfobj.data.case_names):
+            process_case(adfobj, case_name, case_idx, var, odata, 
+                        seasons, pres_levs, plot_type, redo_plot,
+                        vres, web_category)
 
-            #Set case nickname:
-            case_nickname = adfobj.data.test_nicknames[case_idx]
 
-            #Set output plot location:
-            plot_loc = Path(plot_locations[case_idx])
 
-            #Check if plot output directory exists, and if not, then create it:
-            if not plot_loc.is_dir():
-                print(f"    {plot_loc} not found, making new directory")
-                plot_loc.mkdir(parents=True)
+def load_reference_data(adfobj, var):
+    """Load and validate reference data."""
+    if not adfobj.compare_obs:
+        base_name = adfobj.data.ref_case_label
+    else:
+        if var not in adfobj.data.ref_var_nam:
+            dmsg = f"\t    WARNING: No obs data found for variable `{var}`, global lat/lon mean plotting skipped."
+            adfobj.debug_log(dmsg)
+            print(dmsg)                return None
+        base_name = adfobj.data.ref_labels[var]
 
-            #Load re-gridded model files:
-            mdata = adfobj.data.load_regrid_da(case_name, var)
+    odata = adfobj.data.load_reference_regrid_da(base_name, var)
+    if odata is None:
+        print(f"\t    WARNING: No reference data found for {var}")
+        return None
 
-            #Skip this variable/case if the regridded climo file doesn't exist:
-            if mdata is None:
-                dmsg = f"\t    WARNING: No regridded test file for {case_name} for variable `{var}`, global lat/lon mean plotting skipped."
-                adfobj.debug_log(dmsg)
-                continue
+    o_has_dims = pf.validate_dims(odata, ["lat", "lon", "lev"])
+    if (not o_has_dims['has_lat']) or (not o_has_dims['has_lon']):
+        print(f"\t    WARNING: Reference data missing lat/lon dimensions")
+        return None
+        
+    return odata
 
-            #Determine dimensions of variable:
-            has_dims = pf.validate_dims(mdata, ["lat", "lon", "lev"])
-            if (not has_dims['has_lat']) or (not has_dims['has_lon']):
-                print(f"\t    WARNING: skipping global map for {var} for case {case_name} as it does not have both lat and lon")
-                continue
-            else: # i.e., has lat&lon
-                if (has_dims['has_lev']) and (not pres_levs):
-                    print(f"\t    WARNING: skipping global map for {var} as it has more than lev dimension, but no pressure levels were provided")
-                    continue
 
-            # Check output file. If file does not exist, proceed.
-            # If file exists:
-            #   if redo_plot is true: delete it now and make plot
-            #   if redo_plot is false: add to website and move on
-            doplot = {}
+def process_case(adfobj, case_name, case_idx, var, odata, seasons, 
+                pres_levs, plot_type, redo_plot, vres, web_category):
+    """Process individual case data and generate plots."""
+    plot_loc = Path(adfobj.plot_location[case_idx])
+    plot_loc.mkdir(parents=True, exist_ok=True)
 
-            if not has_dims['has_lev']:
-                for s in seasons:
-                    plot_name = plot_loc / f"{var}_{s}_LatLon_Mean.{plot_type}"
-                    doplot[plot_name] = plot_file_op(adfobj, plot_name, var, case_name, s, web_category, redo_plot, "LatLon")
-            else:
-                for pres in pres_levs:
-                    for s in seasons:
-                        plot_name = plot_loc / f"{var}_{pres}hpa_{s}_LatLon_Mean.{plot_type}"
-                        doplot[plot_name] = plot_file_op(adfobj, plot_name, f"{var}_{pres}hpa", case_name, s, web_category, redo_plot, "LatLon")
-            if not any(value is None for value in doplot.values()):
-                print(f"\t    INFO: All plots exist for {var}. Redo is {redo_plot}. Existing plots added to website data. Continue.")
-                continue
+    mdata = adfobj.data.load_regrid_da(case_name, var)
+    if mdata is None:
+        return
 
-            #Create new dictionaries:
-            mseasons = {}
-            oseasons = {}
-            dseasons = {} # hold the differences
-            pseasons = {} # hold percent change
+    has_dims = pf.validate_dims(mdata, ["lat", "lon", "lev"])
+    if not pf.lat_lon_validate_dims(mdata):
+        print(f"\t    WARNING: Model data missing lat/lon dimensions")
+        return
 
-            if not has_dims['has_lev']:  # strictly 2-d data          
+    # Check pressure levels if 3D data
+    if has_dims['has_lev'] and not pres_levs:
+        print(f"\t    WARNING: 3D variable found but no pressure levels specified")
+        return
 
-                #Loop over season dictionary:
-                for s in seasons:
-                    plot_name = plot_loc / f"{var}_{s}_LatLon_Mean.{plot_type}"
-                    if doplot[plot_name] is None:
-                        continue
+    process_plots(adfobj, mdata, odata, case_name, case_idx,
+                 var, seasons, pres_levs, plot_loc, plot_type,
+                 redo_plot, vres, web_category, has_dims)
 
-                    if weight_season:
-                        mseasons[s] = pf.seasonal_mean(mdata, season=s, is_climo=True)
-                        oseasons[s] = pf.seasonal_mean(odata, season=s, is_climo=True)
-                    else:
-                        #Just average months as-is:
-                        mseasons[s] = mdata.sel(time=seasons[s]).mean(dim='time')
-                        oseasons[s] = odata.sel(time=seasons[s]).mean(dim='time')
-                    #End if
 
-                    # difference: each entry should be (lat, lon)
-                    dseasons[s] = mseasons[s] - oseasons[s]
-                    
-                    # percent change
-                    pseasons[s] = (mseasons[s] - oseasons[s]) / np.abs(oseasons[s]) * 100.0 #relative change
+def get_plot_config(adfobj):
+    """Get plotting configuration from ADF object."""
+    return {
+        'seasons': {
+            "ANN": np.arange(1,13,1),
+            "DJF": [12, 1, 2],
+            "JJA": [6, 7, 8],
+            "MAM": [3, 4, 5],
+            "SON": [9, 10, 11]
+        },
+        'plot_type': adfobj.read_config_var("diag_basic_info").get('plot_type', 'png'),
+        'redo_plot': adfobj.get_basic_info('redo_plot'),
+        'pres_levs': adfobj.get_basic_info("plot_press_levels")
+    }
 
-                    pf.plot_map_and_save(plot_name, case_nickname, adfobj.data.ref_nickname,
-                                            [syear_cases[case_idx],eyear_cases[case_idx]],
-                                            [syear_baseline,eyear_baseline],
-                                            mseasons[s], oseasons[s], dseasons[s], pseasons[s],
-                                            obs=adfobj.compare_obs, **vres)
 
-                    #Add plot to website (if enabled):
-                    adfobj.add_website_data(plot_name, var, case_name, category=web_category,
-                                            season=s, plot_type="LatLon")
-
-            else: # => pres_levs has values, & we already checked that lev is in mdata (has_lev)
-
-                for pres in pres_levs:
-
-                    #Check that the user-requested pressure level
-                    #exists in the model data, which should already
-                    #have been interpolated to the standard reference
-                    #pressure levels:
-                    if (not (pres in mdata['lev'])) or (not (pres in odata['lev'])):
-                        print(f"\t    WARNING: plot_press_levels value '{pres}' not present in {var} [test: {(pres in mdata['lev'])}, ref: {pres in odata['lev']}], so skipping.")
-                        continue
-
-                    #Loop over seasons:
-                    for s in seasons:
-                        plot_name = plot_loc / f"{var}_{pres}hpa_{s}_LatLon_Mean.{plot_type}"
-                        if doplot[plot_name] is None:
-                            continue
-
-                        if weight_season:
-                            mseasons[s] = pf.seasonal_mean(mdata, season=s, is_climo=True)
-                            oseasons[s] = pf.seasonal_mean(odata, season=s, is_climo=True)
-                        else:
-                            #Just average months as-is:
-                            mseasons[s] = mdata.sel(time=seasons[s]).mean(dim='time')
-                            oseasons[s] = odata.sel(time=seasons[s]).mean(dim='time')
-                        #End if
-
-                        # difference: each entry should be (lat, lon)
-                        dseasons[s] = mseasons[s] - oseasons[s]
-                        
-                        # percent change
-                        pseasons[s] = (mseasons[s] - oseasons[s]) / np.abs(oseasons[s]) * 100.0 #relative change
-
-                        pf.plot_map_and_save(plot_name, case_nickname, adfobj.data.ref_nickname,
-                                                [syear_cases[case_idx],eyear_cases[case_idx]],
-                                                [syear_baseline,eyear_baseline],
-                                                mseasons[s].sel(lev=pres), oseasons[s].sel(lev=pres), dseasons[s].sel(lev=pres),
-                                                pseasons[s].sel(lev=pres),
-                                                obs=adfobj.compare_obs, **vres)
-
-                        #Add plot to website (if enabled):
-                        adfobj.add_website_data(plot_name, f"{var}_{pres}hpa", case_name, category=web_category,
-                                                season=s, plot_type="LatLon")
-                    #End for (seasons)
-                #End for (pressure levels)
-            #End if (plotting pressure levels)
-        #End for (case loop)
-    #End for (variable loop)
-
-    # Check for AOD, and run the 4-panel diagnostics against MERRA and MODIS
-    if "AODVISdn" in var_list:
-        print("\tRunning AOD panel diagnostics against MERRA and MODIS...")
-        aod_latlon(adfobj)
-
-    #Notify user that script has ended:
-    print("  ...lat/lon maps have been generated successfully.")
+def process_seasonal_data(mdata, odata, season, weight_season=True):
+    """Helper function to calculate seasonal means and differences."""
+    if weight_season:
+        mseason = pf.seasonal_mean(mdata, season=season, is_climo=True)
+        oseason = pf.seasonal_mean(odata, season=season, is_climo=True)
+    else:
+        mseason = mdata.sel(time=seasons[s]).mean(dim='time')
+        oseason = odata.sel(time=seasons[s]).mean(dim='time')
+    
+    # Calculate differences
+    dseason = mseason - oseason
+    
+    # Calculate percent change
+    pseason = (mseason - oseason) / np.abs(oseason) * 100.0
+    pseason = pseason.where(np.isfinite(pseason), np.nan)
+    
+    return mseason, oseason, dseason, pseason
 
 
 def plot_file_op(adfobj, plot_name, var, case_name, season, web_category, redo_plot, plot_type):
@@ -392,533 +258,168 @@ def plot_file_op(adfobj, plot_name, var, case_name, season, web_category, redo_p
             return False  # False tells caller that file exists and not to overwrite
     else:
         return True
-########
 
 
-def aod_latlon(adfobj):
+def process_plots(adfobj, mdata, odata, case_name, case_idx, var, seasons, 
+                 pres_levs, plot_loc, plot_type, redo_plot, vres, web_category, has_dims):
+    """Process and generate plots for different seasons and pressure levels.
+    
+    Parameters
+    ----------
+    adfobj : AdfDiag
+        The diagnostics object containing configuration
+    mdata : xarray.DataArray  
+        Model data
+    odata : xarray.DataArray
+        Reference/observation data
+    case_name : str
+        Name of current case
+    case_idx : int
+        Index of current case
+    var : str
+        Variable name
+    seasons : dict
+        Dictionary of season definitions
+    pres_levs : list
+        Pressure levels to plot
+    plot_loc : Path
+        Output plot directory
+    plot_type : str
+        Plot file type (e.g. 'png')
+    redo_plot : bool
+        Whether to regenerate existing plots
+    vres : dict
+        Variable-specific plot settings
+    web_category : str
+        Category for website organization
+    has_dims : dict
+        Dictionary indicating which dimensions exist in data
+        
+    Returns
+    -------
+    None
     """
-    Function to gather data and plot parameters to plot a panel plot of model vs observation
-      difference and percent difference.
-
-    Calculate the seasonal means for DJF, MAM, JJA, SON for model and obs datasets
-
-    NOTE: The model lat/lons must be on the same grid as the observations. If they are not, they will be
-          regridded to match both the MERRA and MODIS observation dataset using helper function 'regrid_to_obs'
-
-          For details about spatial coordiantes of obs datasets, see /glade/campaign/cgd/amp/amwg/ADF_obs/:
-            - MERRA2_192x288_AOD_2001-2020_climo.nc
-            - MOD08_M3_192x288_AOD_2001-2020_climo.nc
-    """
-
-    var = "AODVISdn"
-    season_abbr = ['Dec-Jan-Feb', 'Mar-Apr-May', 'Jun-Jul-Aug', 'Sep-Oct-Nov']
-    # Define a list of season labels
-    seasons = ['DJF', 'MAM', 'JJA', 'SON']
-
-    test_case_names = adfobj.get_cam_info('cam_case_name', required=True)
-    # load reference data (observational or baseline)
-    if not adfobj.compare_obs:
-        base_name = adfobj.data.ref_case_label
-        case_names = test_case_names + [base_name]
-    else:
-        case_names = test_case_names
-
-    #Grab all case nickname(s)
-    test_nicknames = adfobj.case_nicknames["test_nicknames"]
-    base_nickname = adfobj.case_nicknames["base_nickname"]
-    case_nicknames = test_nicknames + [base_nickname]
-
-    res = adfobj.variable_defaults # will be dict of variable-specific plot preferences
-    # or an empty dictionary if use_defaults was not specified in YAML.
-    res_aod_diags = res["aod_diags"]
-    plot_params = res_aod_diags["plot_params"]
-    plot_params_relerr = res_aod_diags["plot_params_relerr"]
-
-    # Observational Datasets
-    #-----------------------
-    # Round lat/lons to 5 decimal places
-        # NOTE: this is neccessary due to small fluctuations in insignificant decimal places
-        #       in lats/lons between models and these obs data sets. The model cases will also 
-        #       be rounded in turn.
-    obs_dir = adfobj.get_basic_info("obs_data_loc")
-    file_merra2 = os.path.join(obs_dir, 'MERRA2_192x288_AOD_2001-2020_climo.nc')
-    file_mod08_m3 = os.path.join(obs_dir, 'MOD08_M3_192x288_AOD_2001-2020_climo.nc')
-
-    if (not Path(file_merra2).is_file()) or (not Path(file_mod08_m3).is_file()):
-        print("\t  WARNING: AOD Panel plots not made, missing MERRA2 and/or MODIS file")
+    # Get case nickname and years
+    case_nickname = adfobj.data.test_nicknames[case_idx]
+    syear_cases = adfobj.climo_yrs["syears"]
+    eyear_cases = adfobj.climo_yrs["eyears"]
+    syear_baseline = adfobj.climo_yrs["syear_baseline"]
+    eyear_baseline = adfobj.climo_yrs["eyear_baseline"]
+    
+    # Check if files exist and build doplot dict
+    doplot = check_existing_plots(adfobj, var, plot_loc, plot_type, 
+                                case_name, seasons, pres_levs, 
+                                has_dims, web_category, redo_plot)
+    
+    if not any(value is None for value in doplot.values()):
+        print(f"\t    INFO: All plots exist for {var}. Redo is {redo_plot}. Existing plots added to website data.")
         return
 
-    ds_merra2 = xr.open_dataset(file_merra2)
-    ds_merra2 = ds_merra2['TOTEXTTAU']
-    ds_merra2['lon'] = ds_merra2['lon'].round(5)
-    ds_merra2['lat'] = ds_merra2['lat'].round(5)
+    # Initialize seasonal data dictionaries
+    mseasons = {}
+    oseasons = {}
+    dseasons = {} 
+    pseasons = {}
 
-    ds_mod08_m3 = xr.open_dataset(file_mod08_m3)
-    ds_mod08_m3 = ds_mod08_m3['AOD_550_Dark_Target_Deep_Blue_Combined_Mean_Mean']
-    ds_mod08_m3['lon'] = ds_mod08_m3['lon'].round(5)
-    ds_mod08_m3['lat'] = ds_mod08_m3['lat'].round(5)
-
-    ds_merra2_season = monthly_to_seasonal(ds_merra2)
-    ds_merra2_season['lon'] = ds_merra2_season['lon'].round(5)
-    ds_merra2_season['lat'] = ds_merra2_season['lat'].round(5)
-
-    ds_mod08_m3_season = monthly_to_seasonal(ds_mod08_m3)
-    ds_mod08_m3_season['lon'] = ds_mod08_m3_season['lon'].round(5)
-    ds_mod08_m3_season['lat'] = ds_mod08_m3_season['lat'].round(5)
-
-    ds_obs = [ds_mod08_m3_season, ds_merra2_season]
-    obs_lat_shape = ds_obs[0]['lat'].shape[0]
-    obs_lon_shape = ds_obs[0]['lon'].shape[0]
-    obs_titles = ["TERRA MODIS", "MERRA2"]
-
-    # Model Case Datasets
-    #-----------------------
-    ds_cases = []
-
-    for case in test_case_names:
-        #Load re-gridded model files:
-        ds_case = adfobj.data.load_climo_da(case, var)
-
-        #Skip this variable/case if the climo file doesn't exist:
-        if ds_case is None:
-            dmsg = f"\t WARNING: No test climo file for {case} for variable `{var}`, global lat/lon plots skipped."
-            adfobj.debug_log(dmsg)
-            continue
-        else:
-            # Round lat/lons so they match obs
-            # NOTE: this is neccessary due to small fluctuations in insignificant decimal places
-            #       that raise an error due to non-exact difference calculations.
-            #       Rounding all datasets to 5 places ensures the proper difference calculation
-            ds_case['lon'] = ds_case['lon'].round(5)
-            ds_case['lat'] = ds_case['lat'].round(5)
-            case_lat_shape = ds_case['lat'].shape[0]
-            case_lon_shape = ds_case['lon'].shape[0]
-
-            # Check if the lats/lons are same as the first supplied observation set
-            if case_lat_shape == obs_lat_shape:
-                case_lat = True
-            else:
-                err_msg = "AOD 4-panel plot:\n"
-                err_msg += f"\t WARNING: The lat values don't match between obs and '{case}'\n"                    
-                err_msg += f"\t  - {case} lat shape: {case_lat_shape} and "
-                err_msg += f"obs lat shape: {obs_lat_shape}"
-                adfobj.debug_log(err_msg)
-                print(err_msg)
-                case_lat = False
-            # End if
-
-            if case_lon_shape == obs_lon_shape:
-                case_lon = True
-            else:
-                err_msg = "AOD 4-panel plot:\n"
-                err_msg += f"\t WARNING: The lon values don't match between obs and '{case}'\n"
-                err_msg += f"\t  - {case} lon shape: {case_lon_shape} and "
-                err_msg += f"obs lon shape: {obs_lon_shape}"
-                adfobj.debug_log(err_msg)
-                print(err_msg)
-                case_lon = False
-            # End if
-            
-            # Check to make sure spatial dimensions are compatible
-            if (case_lat) and (case_lon):
-                # Calculate seasonal means
-                ds_case_season = monthly_to_seasonal(ds_case)
-                ds_case_season['lon'] = ds_case_season['lon'].round(5)
-                ds_case_season['lat'] = ds_case_season['lat'].round(5)
-                ds_cases.append(ds_case_season)
-            else:
-                # Regrid the model data to obs
-                #NOTE: first argument is the model to be regridded, second is the obs
-                #      to be regridded to
-                ds_case_regrid = regrid_to_obs(adfobj, ds_case, ds_obs[0])
-
-                ds_case_season = monthly_to_seasonal(ds_case_regrid)
-                ds_case_season['lon'] = ds_case_season['lon'].round(5)
-                ds_case_season['lat'] = ds_case_season['lat'].round(5)
-                ds_cases.append(ds_case_season)
-            # End if
-        # End if
-
-    # load reference data (observational or baseline)
-    if not adfobj.compare_obs:
-
-        # Get baseline case name
-        base_name = adfobj.data.ref_case_label
-    
-        # Gather reference variable data
-        ds_base = adfobj.data.load_reference_climo_da(base_name, var)
-        if ds_base is None:
-            dmsg = f"\t WARNING: No baseline climo file for {base_name} for variable `{var}`, global lat/lon plots skipped."
-            adfobj.debug_log(dmsg)
-        else:
-            # Round lat/lons so they match obs
-            # NOTE: this is neccessary due to small fluctuations in insignificant decimal places
-            #       that raise an error due to non-exact difference calculations.
-            #       Rounding all datasets to 5 places ensures the proper difference calculation
-            ds_base['lon'] = ds_base['lon'].round(5)
-            ds_base['lat'] = ds_base['lat'].round(5)
-            base_lat_shape = ds_base['lat'].shape[0]
-            base_lon_shape = ds_base['lon'].shape[0]
-
-            # Check if the lats/lons are same as the first supplied observation set
-            if base_lat_shape == obs_lat_shape:
-                base_lat = True
-            else:
-                err_msg = "AOD 4-panel plot:\n"
-                err_msg += f"\t WARNING: The lat values don't match between obs and '{base_name}'\n"                    
-                err_msg += f"\t  - {base_name} lat shape: {base_lat_shape} and "
-                err_msg += f"obs lat shape: {obs_lat_shape}"
-                adfobj.debug_log(err_msg)
-                print(err_msg)
-                base_lat = False
-            # End if
-
-            if base_lon_shape == obs_lon_shape:
-                base_lon = True
-            else:
-                err_msg = "AOD 4-panel plot:\n"
-                err_msg += f"\t WARNING: The lon values don't match between obs and '{base_name}'\n"
-                err_msg += f"\t  - {base_name} lon shape: {base_lon_shape} and "
-                err_msg += f"obs lon shape: {obs_lon_shape}"
-                adfobj.debug_log(err_msg)
-                print(err_msg)
-                base_lon = False
-            # End if
-
-            # Check to make sure spatial dimensions are compatible
-            if (base_lat) and (base_lon):
-                # Calculate seasonal means
-                ds_base_season = monthly_to_seasonal(ds_base)
-                ds_base_season['lon'] = ds_base_season['lon'].round(5)
-                ds_base_season['lat'] = ds_base_season['lat'].round(5)
-                ds_cases.append(ds_base_season)
-            else:
-                # Regrid the model data to obs
-                #NOTE: first argument is the model to be regridded, second is the obs
-                #      to be regridded to
-                ds_base_regrid = regrid_to_obs(adfobj, ds_base, ds_obs[0])
-
-                ds_base_season = monthly_to_seasonal(ds_base_regrid)
-                ds_base_season['lon'] = ds_base_season['lon'].round(5)
-                ds_base_season['lat'] = ds_base_season['lat'].round(5)
-                ds_cases.append(ds_base_season)
-            # End if
-        # End if
-    # Number of relevant cases
-    case_num = len(ds_cases)
-    
-    # 4-Panel global lat/lon plots
-    #-----------------------------
-    # NOTE: This loops over all obs and available cases, so just
-    # make lists to keepo track of details for each case vs obs matchup
-    #   Plots:
-    #      - Difference of seasonal avg of case minus seasonal avg of observation
-    #      - Percent Difference of seasonal avg of case minus seasonal avg of observation
-
-    # Loop over each observation dataset first
-    for i_obs,ds_ob in enumerate(ds_obs):
-        for i_s,season in enumerate(seasons):
-            # Plot title list
-            plot_titles = []
-            # Calculated data list
-            data = []
-            # Plot parameter list
-            params = []
-            # Plot type list, ie difference or percent difference
-            types = []
-            # Model case name list
-            case_name_list = []
-
-            # Get observation short name
-            obs_name = obs_titles[i_obs]
-
-            # Get seasonal abbriviation
-            chem_season = season_abbr[i_s]
-
-            # Then loop over each available model case
-            for i_case,ds_case in enumerate(ds_cases):
-                case_nickname = case_nicknames[i_case]
-
-                # Difference with obs
-                case_field = ds_case.sel(season=season) - ds_ob.sel(season=season)
-                plot_titles.append(f'{case_nickname} - {obs_name}\nAOD 550 nm - ' + chem_season)
-                data.append(case_field)
-                params.append(plot_params)
-                types.append("Diff")
-                case_name_list.append(case_names[i_case])
-
-                # Percent difference with obs
-                field_relerr = 100 * case_field / ds_ob.sel(season=season)
-                field_relerr = np.clip(field_relerr, -100, 100)
-                plot_titles.append(f'Percent Diff {case_nickname} - {obs_name}\nAOD 550 nm - ' + chem_season)
-                data.append(field_relerr)
-                params.append(plot_params_relerr)
-                types.append("Percent Diff")
-                case_name_list.append(case_names[i_case])
-            # End for
-
-            # Create 4-panel plot for season
-            aod_panel_latlon(adfobj, plot_titles, params, data, season, obs_name, case_name_list, case_num, types, symmetric=True)
-        # End for
-    # End for
-
-
-########################################
-# Helper functions for AOD 4-panel plots
-########################################
-
-def monthly_to_seasonal(ds,obs=False):
-    ds_season = xr.Dataset(
-        coords={'lat': ds.coords['lat'], 'lon': ds.coords['lon'],
-                'season': np.arange(4)})
-    da_season = xr.DataArray(
-         coords=ds_season.coords, dims=['lat', 'lon', 'season'])
-    
-    # Create a list of DataArrays
-    dataarrays = []
-    # Define a list of season labels
-    seasons = ['DJF', 'MAM', 'JJA', 'SON']
-    
-    if obs:
-        for varname in ds:
-            if '_n' not in varname:
-                ds_season = xr.zeros_like(da_season)
-                for s in seasons:
-                    dataarrays.append(pf.seasonal_mean(ds, season=s, is_climo=True))
+    if not has_dims['has_lev']:
+        # Process 2D data
+        process_2d_plots(adfobj, mdata, odata, case_name, case_nickname,
+                        var, seasons, plot_loc, plot_type, doplot,
+                        mseasons, oseasons, dseasons, pseasons,
+                        syear_cases[case_idx], eyear_cases[case_idx],
+                        syear_baseline, eyear_baseline,
+                        web_category, vres)
     else:
+        # Process 3D data with pressure levels
+        process_3d_plots(adfobj, mdata, odata, case_name, case_nickname, 
+                        var, seasons, pres_levs, plot_loc, plot_type, doplot,
+                        mseasons, oseasons, dseasons, pseasons,
+                        syear_cases[case_idx], eyear_cases[case_idx],
+                        syear_baseline, eyear_baseline,
+                        web_category, vres)
+
+def check_existing_plots(adfobj, var, plot_loc, plot_type, case_name, 
+                        seasons, pres_levs, has_dims, web_category, redo_plot):
+    """Check which plots need to be generated."""
+    doplot = {}
+    
+    if not has_dims['has_lev']:
         for s in seasons:
-            dataarrays.append(pf.seasonal_mean(ds, season=s, is_climo=True))
-
-    # Use xr.concat to combine along a new 'season' dimension
-    ds_season = xr.concat(dataarrays, dim='season')
-
-    # Assign the 'season' labels to the new 'season' dimension
-    ds_season['season'] = seasons
-    ds_season = ds_season.transpose('lat', 'lon', 'season')
-
-    return ds_season
-#######
-
-
-def aod_panel_latlon(adfobj, plot_titles, plot_params, data, season, obs_name, case_name, case_num, types, symmetric=False):
-    """
-    Function to plot a panel plot of model vs observation difference and percent difference
-
-    This will be a 4-panel plot if model vs model run:
-        - Top left is test model minus obs
-        - Top right is baseline model minus obs
-        - Bottom left is test model minus obs percent difference
-        - Bottom right is baseline model minus obs percent difference
-    
-    This will be a 2-panel plot if model vs obs run:
-        - Top is test model minus obs
-        - Bottom is test model minus obs percent difference
-
-    NOTE: Individual plots of the panel plots will be created and saved to plotting location(s)
-          but will not be published to the webpage (if enabled)
-    """
-    #Set plot details:
-    # -- this should be set in basic_info_dict, but is not required
-    # -- So check for it, and default to png
-    basic_info_dict = adfobj.read_config_var("diag_basic_info")
-    file_type = basic_info_dict.get('plot_type', 'png')
-    plot_dir = adfobj.plot_location[0]
-
-    # check if existing plots need to be redone
-    redo_plot = adfobj.get_basic_info('redo_plot')
-
-    # Save the panel figure
-    plot_name = f'AOD_diff_{obs_name.replace(" ","_")}_{season}_LatLon_Mean.{file_type}'
-    plotfile = Path(plot_dir) / plot_name
-
-    # Check redo_plot. If set to True: remove old plot, if it already exists:
-    if (not redo_plot) and plotfile.is_file():
-        adfobj.debug_log(f"'{plotfile}' exists and clobber is false.")
-        #Add already-existing plot to website (if enabled):
-        adfobj.add_website_data(plotfile, f'AOD_diff_{obs_name.replace(" ","_")}', None,
-                            season=season, multi_case=True, plot_type="LatLon", category="4-Panel AOD Diags")
-
-        # Exit
-        return
+            plot_name = plot_loc / f"{var}_{s}_LatLon_Mean.{plot_type}"
+            doplot[plot_name] = plot_file_op(adfobj, plot_name, var, 
+                                           case_name, s, web_category, 
+                                           redo_plot, "LatLon")
     else:
-        if plotfile.is_file():
-            plotfile.unlink()
-        # End if
-    # End if
+        for pres in pres_levs:
+            for s in seasons:
+                plot_name = plot_loc / f"{var}_{pres}hpa_{s}_LatLon_Mean.{plot_type}"
+                doplot[plot_name] = plot_file_op(adfobj, plot_name, 
+                                               f"{var}_{pres}hpa",
+                                               case_name, s, web_category, 
+                                               redo_plot, "LatLon")
+    return doplot
 
-    # create figure:
-    fig = plt.figure(figsize=(7*case_num,10))
-    proj = ccrs.PlateCarree()
+def process_2d_plots(adfobj, mdata, odata, case_name, case_nickname,
+                    var, seasons, plot_loc, plot_type, doplot,
+                    mseasons, oseasons, dseasons, pseasons,
+                    syear_case, eyear_case, syear_baseline, eyear_baseline,
+                    web_category, vres):
+    """Process and generate 2D plots."""
+    for s in seasons:
+        plot_name = plot_loc / f"{var}_{s}_LatLon_Mean.{plot_type}"
+        if doplot[plot_name] is None:
+            continue
+            
+        # Calculate seasonal means and differences
+        mseasons[s], oseasons[s], dseasons[s], pseasons[s] = \
+            process_seasonal_data(mdata, odata, s)
 
-    # LAYOUT WITH GRIDSPEC
-    plot_len = int(3*case_num)
-    gs = mpl.gridspec.GridSpec(2*case_num, plot_len, wspace=0.5, hspace=0.0)
-    gs.tight_layout(fig)
+        # Generate plot
+        pf.plot_map_and_save(plot_name, case_nickname, adfobj.data.ref_nickname,
+                            [syear_case, eyear_case],
+                            [syear_baseline, eyear_baseline],
+                            mseasons[s], oseasons[s], dseasons[s], pseasons[s],
+                            obs=adfobj.compare_obs, **vres)
 
-    axs = []
-    for i in range(case_num):
-        start = i * 3
-        end = (i + 1) * 3
-        axs.append(plt.subplot(gs[0:case_num, start:end], projection=proj))
-        axs.append(plt.subplot(gs[case_num:, start:end], projection=proj))
-    # End for
+        # Add to website
+        adfobj.add_website_data(plot_name, var, case_name, 
+                               category=web_category,
+                               season=s, plot_type="LatLon")
 
-    # formatting for tick labels
-    lon_formatter = LongitudeFormatter(number_format='0.0f',
-                                        degree_symbol='',
-                                        dateline_direction_label=False)
-    lat_formatter = LatitudeFormatter(number_format='0.0f',
-                                        degree_symbol='')
+def process_3d_plots(adfobj, mdata, odata, case_name, case_nickname,
+                    var, seasons, pres_levs, plot_loc, plot_type, doplot,
+                    mseasons, oseasons, dseasons, pseasons, 
+                    syear_case, eyear_case, syear_baseline, eyear_baseline,
+                    web_category, vres):
+    """Process and generate 3D plots with pressure levels."""
+    for pres in pres_levs:
+        # Validate pressure level exists
+        if (not (pres in mdata['lev'])) or (not (pres in odata['lev'])):
+            print(f"\t    WARNING: plot_press_levels value '{pres}' not present " 
+                  f"in {var} [test: {(pres in mdata['lev'])}, "
+                  f"ref: {pres in odata['lev']}], so skipping.")
+            continue
 
-    # Loop over each data set
-    for i,field in enumerate(data):
-        # Set up sub plots for main panel plot
-        ind_fig, ind_ax = plt.subplots(1, 1, figsize=((7*case_num)/2,10/2),subplot_kw={'projection': proj})
+        for s in seasons:
+            plot_name = plot_loc / f"{var}_{pres}hpa_{s}_LatLon_Mean.{plot_type}"
+            if doplot[plot_name] is None:
+                continue
 
-        lon_values = field.lon.values
-        lat_values = field.lat.values
+            # Calculate seasonal means and differences
+            mseasons[s], oseasons[s], dseasons[s], pseasons[s] = \
+                process_seasonal_data(mdata, odata, s)
 
-        # Get field plot paramters
-        plot_param = plot_params[i]
+            # Generate plot
+            pf.plot_map_and_save(plot_name, case_nickname, adfobj.data.ref_nickname,
+                                [syear_case, eyear_case],
+                                [syear_baseline, eyear_baseline],
+                                mseasons[s].sel(lev=pres), 
+                                oseasons[s].sel(lev=pres),
+                                dseasons[s].sel(lev=pres),
+                                pseasons[s].sel(lev=pres),
+                                obs=adfobj.compare_obs, **vres)
 
-        # Define plot levels
-        levels = np.linspace(
-            plot_param['range_min'], plot_param['range_max'],
-            plot_param['nlevel'], endpoint=True)
-        if 'augment_levels' in plot_param:
-            levels = sorted(np.append(
-                levels, np.array(plot_param['augment_levels'])))
-        # End if
-
-        if field.ndim > 2:
-            print(f"Required 2d lat/lon coordinates, got {field.ndim}d")
-            emg = "AOD panel plot:\n"
-            emg += f"\t WARNING: Too many dimensions for {case_name}. Needs 2 (lat/lon) but got {field.ndim}"
-            adfobj.debug_log(emg)
-            print(f"{emg} ")
-            return
-        # End if
-
-        # Get data
-        field_values = field.values[:,:]
-        field_values, lon_values  = add_cyclic_point(field_values, coord=lon_values)
-        lon_mesh, lat_mesh = np.meshgrid(lon_values, lat_values)
-        field_mean = np.nanmean(field_values)
-
-        # Set plot details
-        extend_option = 'both' if symmetric else 'max'
-
-        if 'colormap' in plot_param:
-            cmap_option = plot_param['colormap'] if symmetric else plt.cm.turbo
-        else:
-            cmap_option = plt.cm.bwr if symmetric else plt.cm.turbo
-
-        img = axs[i].contourf(lon_mesh, lat_mesh, field_values,
-            levels, cmap=cmap_option, extend=extend_option,
-                              transform_first=True,
-            transform=ccrs.PlateCarree())
-        ind_img = ind_ax.contourf(lon_mesh, lat_mesh, field_values,
-            levels, cmap=cmap_option, extend=extend_option,
-                              transform_first=True,
-            transform=ccrs.PlateCarree())
-
-        axs[i].set_facecolor('gray')
-        ind_ax.set_facecolor('gray')
-        axs[i].coastlines()
-        ind_ax.coastlines()
-
-        # Set plot titles
-        axs[i].set_title(plot_titles[i] + ('  Mean %.2g' % field_mean),fontsize=10)
-        ind_ax.set_title(plot_titles[i] + ('  Mean %.2g' % field_mean),fontsize=10)
-
-        # Colorbar options
-        cbar = plt.colorbar(img, orientation='horizontal', pad=0.05)
-        ind_cbar = plt.colorbar(ind_img, orientation='horizontal', pad=0.05)
-
-        if 'ticks' in plot_param:
-            cbar.set_ticks(plot_param['ticks'])
-            ind_cbar.set_ticks(plot_param['ticks'])
-        if 'tick_labels' in plot_param:
-            cbar.ax.set_xticklabels(plot_param['tick_labels'])
-            ind_cbar.ax.set_xticklabels(plot_param['tick_labels'])
-        cbar.ax.tick_params(labelsize=6)
-
-        # Save the individual figure
-        pbase = f'AOD_{case_name[i]}_vs_{obs_name.replace(" ","_")}_{types[i].replace(" ","_")}'
-        ind_plotfile = f'{pbase}_{season}_LatLon_Mean.{file_type}'
-        ind_png_file = Path(plot_dir) / ind_plotfile
-        ind_fig.savefig(f'{ind_png_file}', bbox_inches='tight', dpi=300)
-        plt.close(ind_fig)
-    # End for
-
-    # Save the panel figure
-    plot_name = f'AOD_diff_{obs_name.replace(" ","_")}_{season}_LatLon_Mean.{file_type}'
-    plotfile = Path(plot_dir) / plot_name
-
-    # Save figure and add to website if applicable
-    fig.savefig(plotfile, bbox_inches='tight', dpi=300)
-    adfobj.add_website_data(plotfile, f'AOD_diff_{obs_name.replace(" ","_")}', None,
-                                season=season, multi_case=True, plot_type="LatLon", category="4-Panel AOD Diags")
-
-    # Close the figure
-    plt.close(fig)
-######
-
-
-def regrid_to_obs(adfobj, model_arr, obs_arr):
-    """
-    Check if the model grid needs to be interpolated to the obs grid. If so,
-    use xesmf to regrid and return new dataset
-    """
-    test_lons = model_arr.lon
-    test_lats = model_arr.lat
-
-    obs_lons = obs_arr.lon
-    obs_lats = obs_arr.lat
-
-    # Just set defaults for now
-    same_lats = True
-    same_lons = True
-    model_regrid_arr = None
-
-    if obs_lons.shape == test_lons.shape:
-        try:
-            xr.testing.assert_equal(test_lons, obs_lons)
-        except AssertionError as e:
-            same_lons = False
-            err_msg = "AOD 4-panel plot:\n"
-            err_msg += "\t The lons ARE NOT the same"
-            adfobj.debug_log(err_msg)
-        try:
-            xr.testing.assert_equal(test_lats, obs_lats)
-        except AssertionError as e:
-            same_lats = False
-            err_msg = "AOD 4-panel plot:\n"
-            err_msg += "\t The lats ARE NOT the same"
-            adfobj.debug_log(err_msg)
-    else:
-        same_lats = False
-        same_lons = False
-        print("\tThe model lat/lon grid does not match the " \
-             "obs grid.\n\t - Regridding to observation lats and lons")
-
-    # QUESTION: will there ever be a scenario where we need to regrid only lats or lons??
-    if (not same_lons) and (not same_lats):
-        # Make dummy array to be populated
-        ds_out = xr.Dataset(
-            {
-                "lat": (["lat"], obs_lats.values, {"units": "degrees_north"}),
-                "lon": (["lon"], obs_lons.values, {"units": "degrees_east"}),
-            }
-        )
-
-        # Regrid to the obs grid to make altered model grid
-        regridder = xe.Regridder(model_arr, ds_out, "bilinear", periodic=True)
-        model_regrid_arr = regridder(model_arr, keep_attrs=True)
-
-    # Return the new interpolated model array
-    return model_regrid_arr
-#######
-
-##############
-#END OF SCRIPT
+            # Add to website
+            adfobj.add_website_data(plot_name, f"{var}_{pres}hpa",
+                                   case_name, category=web_category,
+                                   season=s, plot_type="LatLon")

--- a/scripts/plotting/global_latlon_map.py
+++ b/scripts/plotting/global_latlon_map.py
@@ -238,9 +238,9 @@ def plot_file_op(adfobj, plot_name, var, case_name, season, web_category, redo_p
 
     Returns
     -------
-    int, None
-        Returns 1 if existing file is removed or no existing file.
-        Returns None if file exists and redo_plot is False
+    bool
+        Returns True if existing file is removed or no existing file, i.e. make the plot.
+        Returns False if file exists and redo_plot is False
 
     Notes
     -----
@@ -313,7 +313,7 @@ def process_plots(adfobj, mdata, odata, case_name, case_idx, var, seasons,
                                 case_name, seasons, pres_levs, 
                                 has_dims, web_category, redo_plot)
     
-    if not any(value is None for value in doplot.values()):
+    if not any(value for value in doplot.values()):
         print(f"\t    INFO: All plots exist for {var}. Redo is {redo_plot}. Existing plots added to website data.")
         return
 

--- a/scripts/plotting/polar_map.py
+++ b/scripts/plotting/polar_map.py
@@ -126,28 +126,28 @@ def polar_map(adfobj):
 
             for s in seasons:
                 for hemi_type in ["NHPolar", "SHPolar"]:
-                    if pres_levs:
-                        if has_lev:
-                            for pres in pres_levs:
-                                plot_name = plot_loc / f"{var}_{pres}hpa_{s}_{hemi_type}_Mean.{plot_type}"
-                                info = {
-                                    'path': plot_name,
-                                    'var': f"{var}_{pres}hpa",
-                                    'case': case_name,
-                                    'case_idx': case_idx,
-                                    'season': s,
-                                    'type': hemi_type,
-                                    'pressure': pres,
-                                    'exists': plot_name.is_file()
-                                }
-                                plot_info.append(info)
-                                if not (redo_plot or not info['exists']):
-                                    adfobj.add_website_data(info['path'], info['var'],
-                                                        info['case'], category=web_category,
-                                                        season=s, plot_type=hemi_type)
-                                else:
-                                    all_plots_exist = False
-                    else:
+                    if pres_levs and has_lev: # 3-D variable & pressure levels specified
+                        print(f"POLAR: {pres_levs = }")
+                        for pres in pres_levs:
+                            plot_name = plot_loc / f"{var}_{pres}hpa_{s}_{hemi_type}_Mean.{plot_type}"
+                            info = {
+                                'path': plot_name,
+                                'var': f"{var}_{pres}hpa",
+                                'case': case_name,
+                                'case_idx': case_idx,
+                                'season': s,
+                                'type': hemi_type,
+                                'pressure': pres,
+                                'exists': plot_name.is_file()
+                            }
+                            plot_info.append(info)
+                            if (redo_plot is False) and info['exists']:
+                                adfobj.add_website_data(info['path'], info['var'],
+                                                    info['case'], category=web_category,
+                                                    season=s, plot_type=hemi_type)
+                            else:
+                                all_plots_exist = False
+                    elif (not has_lev): # 2-D variable
                         plot_name = plot_loc / f"{var}_{s}_{hemi_type}_Mean.{plot_type}"
                         info = {
                             'path': plot_name,
@@ -159,7 +159,7 @@ def polar_map(adfobj):
                             'exists': plot_name.is_file()
                         }
                         plot_info.append(info)
-                        if not (redo_plot or not info['exists']):
+                        if (redo_plot is False) and info['exists']:
                             adfobj.add_website_data(info['path'], info['var'],
                                                   info['case'], category=web_category,
                                                   season=s, plot_type=hemi_type)

--- a/scripts/plotting/polar_map.py
+++ b/scripts/plotting/polar_map.py
@@ -217,13 +217,11 @@ def polar_map(adfobj):
                 has_lev = False
 
             if has_lev and pres_levs and plot.get('pressure'):
-                print("PRESSURE")
                 if not all(dim in mdata.dims for dim in ['lat', 'lev']):
                     continue
                 mdata = mdata.sel(lev=plot['pressure'])
                 odata_level = odata.sel(lev=plot['pressure'])
             else:
-                print(f"EXPECT 2D VARIABLE: {odata.shape}")
                 if not pf.lat_lon_validate_dims(mdata):
                     continue
 

--- a/scripts/plotting/polar_map.py
+++ b/scripts/plotting/polar_map.py
@@ -117,29 +117,36 @@ def polar_map(adfobj):
         
         for case_idx, case_name in enumerate(case_names):
             plot_loc = Path(plot_locations[case_idx])
-            
+
+            tmp_ds = adfobj.data.load_regrid_dataset(case_name, var)
+            if tmp_ds is None:
+                continue
+
+            has_lev = "lev" in tmp_ds.dims
+
             for s in seasons:
                 for hemi_type in ["NHPolar", "SHPolar"]:
                     if pres_levs:
-                        for pres in pres_levs:
-                            plot_name = plot_loc / f"{var}_{pres}hpa_{s}_{hemi_type}_Mean.{plot_type}"
-                            info = {
-                                'path': plot_name,
-                                'var': f"{var}_{pres}hpa",
-                                'case': case_name,
-                                'case_idx': case_idx,
-                                'season': s,
-                                'type': hemi_type,
-                                'pressure': pres,
-                                'exists': plot_name.is_file()
-                            }
-                            plot_info.append(info)
-                            if not (redo_plot or not info['exists']):
-                                adfobj.add_website_data(info['path'], info['var'],
-                                                      info['case'], category=web_category,
-                                                      season=s, plot_type=hemi_type)
-                            else:
-                                all_plots_exist = False
+                        if has_lev:
+                            for pres in pres_levs:
+                                plot_name = plot_loc / f"{var}_{pres}hpa_{s}_{hemi_type}_Mean.{plot_type}"
+                                info = {
+                                    'path': plot_name,
+                                    'var': f"{var}_{pres}hpa",
+                                    'case': case_name,
+                                    'case_idx': case_idx,
+                                    'season': s,
+                                    'type': hemi_type,
+                                    'pressure': pres,
+                                    'exists': plot_name.is_file()
+                                }
+                                plot_info.append(info)
+                                if not (redo_plot or not info['exists']):
+                                    adfobj.add_website_data(info['path'], info['var'],
+                                                        info['case'], category=web_category,
+                                                        season=s, plot_type=hemi_type)
+                                else:
+                                    all_plots_exist = False
                     else:
                         plot_name = plot_loc / f"{var}_{s}_{hemi_type}_Mean.{plot_type}"
                         info = {

--- a/scripts/plotting/polar_map.py
+++ b/scripts/plotting/polar_map.py
@@ -35,7 +35,6 @@ def polar_map(adfobj):
     print(f"{msg}\n  {'-' * (len(msg)-3)}")
 
     var_list = adfobj.diag_var_list
-    model_rgrid_loc = adfobj.get_basic_info("cam_regrid_loc", required=True)
 
     #Special ADF variable which contains the output paths for
     #all generated plots and tables for each case:

--- a/scripts/plotting/polar_map.py
+++ b/scripts/plotting/polar_map.py
@@ -7,15 +7,29 @@ import numpy as np
 # ADF library
 import plotting_functions as pf
 
+def get_hemisphere(hemi_type):
+    """Helper function to convert plot type to hemisphere code."""
+    return "NH" if hemi_type == "NHPolar" else "SH"
+
+def process_seasonal_data(mdata, odata, season, vres):
+    """Helper function to calculate seasonal means and differences."""
+    mseason = pf.seasonal_mean(mdata, season=season, is_climo=True)
+    oseason = pf.seasonal_mean(odata, season=season, is_climo=True)
+    
+    # Calculate differences
+    dseason = mseason - oseason
+    dseason.attrs['units'] = mseason.attrs['units']
+    
+    # Calculate percent change
+    pseason = (mseason - oseason) / np.abs(oseason) * 100.0
+    pseason.attrs['units'] = '%'
+    pseason = pseason.where(np.isfinite(pseason), np.nan)
+    pseason = pseason.fillna(0.0)
+    
+    return mseason, oseason, dseason, pseason
+
 def polar_map(adfobj):
-    """
-    This script/function generates polar maps of model fields with continental overlays.
-    Plots style follows old AMWG diagnostics:
-      - plots for ANN, DJF, MAM, JJA, SON
-      - separate files for each hemisphere, denoted `_nh` and `_sh` in file names.
-      - mean files shown on top row, difference on bottom row (centered)
-    [based on global_latlon_map.py]
-    """
+    """Generate polar maps of model fields with continental overlays."""
     #Notify user that script has started:
     msg = "\n  Generating polar maps..."
     print(f"{msg}\n  {'-' * (len(msg)-3)}")
@@ -104,7 +118,6 @@ def polar_map(adfobj):
 
     # probably want to do this one variable at a time:
     for var in var_list:
-        #Notify user of variable being plotted:
         print(f"\t - polar maps for {var}")
 
         if var not in adfobj.data.ref_var_nam:
@@ -113,310 +126,135 @@ def polar_map(adfobj):
             print(dmsg)
             continue
 
-        if adfobj.compare_obs:
-            #Check if obs exist for the variable:
-            if var in var_obs_dict:
-                #Note: In the future these may all be lists, but for
-                #now just convert the target_list.
-                #Extract target file:
-                dclimo_loc = var_obs_dict[var]["obs_file"]
-                #Extract target list (eventually will be a list, for now need to convert):
-                data_list = [var_obs_dict[var]["obs_name"]]
-                #Extract target variable name:
-                data_var = var_obs_dict[var]["obs_var"]
-            else:
-                dmsg = f"\t    WARNING: No obs found for variable `{var}`, polar map skipped."
-                adfobj.debug_log(dmsg)
-                continue
+        if not adfobj.compare_obs:
+            base_name = adfobj.data.ref_labels[var]
         else:
-            #Set "data_var" for consistent use below:
-            data_var = var
-        #End if
+            base_name = adfobj.data.ref_case_label
 
-        # Check res for any variable specific options that need to be used BEFORE going to the plot:
-        if var in res:
-            vres = res[var]
-            #If found then notify user, assuming debug log is enabled:
-            adfobj.debug_log(f"polar_map: Found variable defaults for {var}")
 
-            #Extract category (if available):
-            web_category = vres.get("category", None)
+        # Get variable-specific settings
+        vres = res.get(var, {})
+        web_category = vres.get("category", None)
 
-        else:
-            vres = {}
-            web_category = None
-        #End if
-
-        #loop over different data sets to plot model against:
-        for data_src in data_list:
-
-            # load data (observational) commparison files (we should explore intake as an alternative to having this kind of repeated code):
-            if adfobj.compare_obs:
-                #For now, only grab one file (but convert to list for use below)
-                oclim_fils = [dclimo_loc]
-                #Set data name:
-                data_name = data_src
-            else:
-                oclim_fils = sorted(dclimo_loc.glob(f"{data_src}_{var}_baseline.nc"))
-           
-            oclim_ds = pf.load_dataset(oclim_fils)
-            if oclim_ds is None:
-                print("\t    WARNING: Did not find any regridded reference climo files. Will try to skip.")
-                print(f"\t    INFO: Data Location, dclimo_loc is {dclimo_loc}")
-                print(f"\t      The glob is: {data_src}_{var}_*.nc")
-                continue
-
-            #Loop over model cases:
-            for case_idx, case_name in enumerate(case_names):
-
-                #Set case nickname:
-                case_nickname = test_nicknames[case_idx]
-
-                #Set output plot location:
-                plot_loc = Path(plot_locations[case_idx])
-
-                #Check if plot output directory exists, and if not, then create it:
-                if not plot_loc.is_dir():
-                    print(f"    {plot_loc} not found, making new directory")
-                    plot_loc.mkdir(parents=True)
-
-                # load re-gridded model files:
-                mclim_fils = sorted(mclimo_rg_loc.glob(f"{data_src}_{case_name}_{var}_*.nc"))
-
-                mclim_ds = pf.load_dataset(mclim_fils)
-                if mclim_ds is None:
-                    print("\t    WARNING: Did not find any regridded test climo files. Will try to skip.")
-                    print(f"\t    INFO: Data Location, mclimo_rg_loc, is {mclimo_rg_loc}")
-                    print(f"\t      The glob is: {data_src}_{case_name}_{var}_*.nc")
-                    continue
-                #End if
-
-                #Extract variable of interest
-                odata = oclim_ds[data_var].squeeze()  # squeeze in case of degenerate dimensions
-                mdata = mclim_ds[var].squeeze()
-
-                # APPLY UNITS TRANSFORMATION IF SPECIFIED:
-                # NOTE: looks like our climo files don't have all their metadata
-                mdata = mdata * vres.get("scale_factor",1) + vres.get("add_offset", 0)
-                # update units
-                mdata.attrs['units'] = vres.get("new_unit", mdata.attrs.get('units', 'none'))
-
-                # Do the same for the baseline case if need be:
-                if not adfobj.compare_obs:
-                    odata = odata * vres.get("scale_factor",1) + vres.get("add_offset", 0)
-                    # update units
-                    odata.attrs['units'] = vres.get("new_unit", odata.attrs.get('units', 'none'))
-                # or for observations.
-                else:
-                    odata = odata * vres.get("obs_scale_factor",1) + vres.get("obs_add_offset", 0)
-                    # Note: assume obs are set to have same untis as model.
-
-                #Determine dimensions of variable:
-                has_dims = pf.lat_lon_validate_dims(odata)
-                if has_dims:
-                    #If observations/baseline CAM have the correct
-                    #dimensions, does the input CAM run have correct
-                    #dimensions as well?
-                    has_dims_cam = pf.lat_lon_validate_dims(mdata)
-
-                    #If both fields have the required dimensions, then
-                    #proceed with plotting:
-                    if has_dims_cam:
-
-                        #
-                        # Seasonal Averages
-                        # Note: xarray can do seasonal averaging,
-                        # but depends on having time accessor,
-                        # which these prototype climo files do not have.
-                        #
-
-                        #Create new dictionaries:
-                        mseasons = {}
-                        oseasons = {}
-                        dseasons = {} # hold the differences
-                        pseasons = {} # hold percent change
-
-                        #Loop over season dictionary:
-                        for s in seasons:
-                            mseasons[s] = pf.seasonal_mean(mdata, season=s, is_climo=True)
-                            oseasons[s] = pf.seasonal_mean(odata, season=s, is_climo=True)
-                            # difference: each entry should be (lat, lon)
-                            dseasons[s] = mseasons[s] - oseasons[s]
-                            dseasons[s].attrs['units'] = mseasons[s].attrs['units']
-                            
-                            # percent change 
-                            pseasons[s] = (mseasons[s] - oseasons[s]) / np.abs(oseasons[s]) * 100.0 # relative change
-                            pseasons[s].attrs['units'] = '%'
-                            #check if pct has NaN's or Inf values and if so set them to 0 to prevent plotting errors
-                            pseasons[s] = pseasons[s].where(np.isfinite(pseasons[s]), np.nan)
-                            pseasons[s] = pseasons[s].fillna(0.0)
-
-                            # make plots: northern and southern hemisphere separately:
-                            for hemi_type in ["NHPolar", "SHPolar"]:
-
-                                #Create plot name and path:
-                                plot_name = plot_loc / f"{var}_{s}_{hemi_type}_Mean.{plot_type}"
-
-                                # If redo_plot set to True: remove old plot, if it already exists:
-                                if (not redo_plot) and plot_name.is_file():
-                                    #Add already-existing plot to website (if enabled):
-                                    adfobj.debug_log(f"'{plot_name}' exists and clobber is false.")
-                                    adfobj.add_website_data(plot_name, var, case_name, category=web_category,
-                                                            season=s, plot_type=hemi_type)
-
-                                    #Continue to next iteration:
-                                    continue
-                                else:
-                                    if plot_name.is_file():
-                                        plot_name.unlink()
-
-                                    #Create new plot:
-                                    # NOTE: send vres as kwarg dictionary.  --> ONLY vres, not the full res
-                                    # This relies on `plot_map_and_save` knowing how to deal with the options
-                                    # currently knows how to handle:
-                                    #   colormap, contour_levels, diff_colormap, diff_contour_levels, tiString, tiFontSize, mpl
-                                    #   *Any other entries will be ignored.
-                                    # NOTE: If we were doing all the plotting here, we could use whatever we want from the provided YAML file.
-
-                                    #Determine hemisphere to plot based on plot file name:
-                                    if hemi_type == "NHPolar":
-                                        hemi = "NH"
-                                    else:
-                                        hemi = "SH"
-                                    #End if
-
-                                    pf.make_polar_plot(plot_name, case_nickname, base_nickname,
-                                                     [syear_cases[case_idx],eyear_cases[case_idx]],
-                                                     [syear_baseline,eyear_baseline],
-                                                     mseasons[s], oseasons[s], dseasons[s], pseasons[s], hemisphere=hemi, obs=obs, **vres)
-
-                                    #Add plot to website (if enabled):
-                                    adfobj.add_website_data(plot_name, var, case_name, category=web_category,
-                                                            season=s, plot_type=hemi_type)
-
-                    else: #mdata dimensions check
-                        print(f"\t    WARNING: skipping polar map for {var} as it doesn't have only lat/lon dims.")
-                    #End if (dimensions check)
-
-                elif pres_levs: #Is the user wanting to interpolate to a specific pressure level?
-
-                    #Check that case inputs have the correct dimensions (including "lev"):
-                    has_lat, has_lev = pf.zm_validate_dims(mdata)  # assumes will work for both mdata & odata
-
-                    # check if there is a lat dimension:
-                    if not has_lat:
-                        print(
-                            f"\t    WARNING: Variable {var} is missing a lat dimension for '{case_name}', cannot continue to plot."
-                        )
-                        continue
-                    # End if
-
-                    #Check that case inputs have the correct dimensions (including "lev"):
-                    has_lat_ref, has_lev_ref = pf.zm_validate_dims(odata)
-
-                    # check if there is a lat dimension:
-                    if not has_lat_ref:
-                        print(
-                            f"\t    WARNING: Variable {var} is missing a lat dimension for '{data_name}', cannot continue to plot."
-                        )
-                        continue
-
-                    #Check if both cases have vertical levels to continue
-                    if (has_lev) and (has_lev_ref):
-
-                        #Loop over pressure levels:
+        # Get all plot info and check existence
+        plot_info = []
+        all_plots_exist = True
+        
+        for case_idx, case_name in enumerate(case_names):
+            plot_loc = Path(plot_locations[case_idx])
+            
+            for s in seasons:
+                for hemi_type in ["NHPolar", "SHPolar"]:
+                    if pres_levs:
                         for pres in pres_levs:
-
-                            #Check that the user-requested pressure level
-                            #exists in the model data, which should already
-                            #have been interpolated to the standard reference
-                            #pressure levels:
-                            if not (pres in mclim_ds['lev']):
-                                #Move on to the next pressure level:
-                                print(f"\t    WARNING: plot_press_levels value '{pres}' not a standard reference pressure, so skipping.")
-                                continue
-                            #End if
-
-                            #Create new dictionaries:
-                            mseasons = {}
-                            oseasons = {}
-                            dseasons = {} # hold the differences
-                            pseasons = {} # hold percent change
-
-                            #Loop over season dictionary:
-                            for s in seasons:
-                                mseasons[s] = (pf.seasonal_mean(mdata, season=s, is_climo=True)).sel(lev=pres)
-                                oseasons[s] = (pf.seasonal_mean(odata, season=s, is_climo=True)).sel(lev=pres)
-                                # difference: each entry should be (lat, lon)
-                                dseasons[s] = mseasons[s] - oseasons[s]
-                                dseasons[s].attrs['units'] = mseasons[s].attrs['units']
-                                
-                                # percent change
-                                pseasons[s] = (mseasons[s] - oseasons[s]) / abs(oseasons[s]) * 100.0 # relative change
-                                pseasons[s].attrs['units'] = '%'
-                                #check if pct has NaN's or Inf values and if so set them to 0 to prevent plotting errors
-                                pseasons[s] = pseasons[s].where(np.isfinite(pseasons[s]), np.nan)
-                                pseasons[s] = pseasons[s].fillna(0.0)
-
-                                # make plots: northern and southern hemisphere separately:
-                                for hemi_type in ["NHPolar", "SHPolar"]:
-
-                                    #Create plot name and path:
-                                    plot_name = plot_loc / f"{var}_{pres}hpa_{s}_{hemi_type}_Mean.{plot_type}"
-
-                                    # If redo_plot set to True: remove old plot, if it already exists:
-                                    if (not redo_plot) and plot_name.is_file():
-                                        #Add already-existing plot to website (if enabled):
-                                        adfobj.debug_log(f"'{plot_name}' exists and clobber is false.")
-                                        adfobj.add_website_data(plot_name, f"{var}_{pres}hpa",
-                                                                case_name, category=web_category,
-                                                                season=s, plot_type=hemi_type)
-
-                                        #Continue to next iteration:
-                                        continue
-                                    else:
-                                        if plot_name.is_file():
-                                            plot_name.unlink()
-
-                                        #Create new plot:
-                                        # NOTE: send vres as kwarg dictionary.  --> ONLY vres, not the full res
-                                        # This relies on `plot_map_and_save` knowing how to deal with the options
-                                        # currently knows how to handle:
-                                        #   colormap, contour_levels, diff_colormap, diff_contour_levels, tiString, tiFontSize, mpl
-                                        #   *Any other entries will be ignored.
-                                        # NOTE: If we were doing all the plotting here, we could use whatever we want from the provided YAML file.
-
-                                        #Determine hemisphere to plot based on plot file name:
-                                        if hemi_type == "NHPolar":
-                                            hemi = "NH"
-                                        else:
-                                            hemi = "SH"
-                                        #End if
-
-                                        pf.make_polar_plot(plot_name, case_nickname, base_nickname,
-                                                     [syear_cases[case_idx],eyear_cases[case_idx]],
-                                                     [syear_baseline,eyear_baseline],
-                                                     mseasons[s], oseasons[s], dseasons[s], pseasons[s], hemisphere=hemi, obs=obs, **vres)
-
-                                        #Add plot to website (if enabled):
-                                        adfobj.add_website_data(plot_name, f"{var}_{pres}hpa",
-                                                                case_name, category=web_category,
-                                                                season=s, plot_type=hemi_type)
-
-                            #End for (seasons)
-                        #End for (pressure level)
+                            plot_name = plot_loc / f"{var}_{pres}hpa_{s}_{hemi_type}_Mean.{plot_type}"
+                            info = {
+                                'path': plot_name,
+                                'var': f"{var}_{pres}hpa",
+                                'case': case_name,
+                                'case_idx': case_idx,
+                                'season': s,
+                                'type': hemi_type,
+                                'pressure': pres,
+                                'exists': plot_name.is_file()
+                            }
+                            plot_info.append(info)
+                            if not (redo_plot or not info['exists']):
+                                adfobj.add_website_data(info['path'], info['var'],
+                                                      info['case'], category=web_category,
+                                                      season=s, plot_type=hemi_type)
+                            else:
+                                all_plots_exist = False
                     else:
-                        print(f"\t    WARNING: variable '{var}' has no vertical dimension but is not just time/lat/lon, so skipping.")
-                    #End if (has_lev)
+                        plot_name = plot_loc / f"{var}_{s}_{hemi_type}_Mean.{plot_type}"
+                        info = {
+                            'path': plot_name,
+                            'var': var,
+                            'case': case_name,
+                            'case_idx': case_idx,
+                            'season': s,
+                            'type': hemi_type,
+                            'exists': plot_name.is_file()
+                        }
+                        plot_info.append(info)
+                        if not (redo_plot or not info['exists']):
+                            adfobj.add_website_data(info['path'], info['var'],
+                                                  info['case'], category=web_category,
+                                                  season=s, plot_type=hemi_type)
+                        else:
+                            all_plots_exist = False
 
-                else: #odata dimensions check
-                    print(f"\t    WARNING: skipping polar map for {var} as it has more than lat/lon dims, but no pressure levels were provided")
-                #End if (dimensions check and pressure levels)
-            #End for (case loop)
-        #End for (obs/baseline loop)
-    #End for (variable loop)
+        if all_plots_exist:
+            print(f"\t    Skipping {var} - all plots already exist")
+            continue
 
-    #Notify user that script has ended:
+        odata = adfobj.data.load_reference_regrid_da(base_name, var)
+        if odata is None:
+            print(f"\t    WARNING: No reference data found for {var}")
+            continue
+
+        # Process each case
+        for plot in plot_info:
+            if plot['exists'] and not redo_plot:
+                continue
+                
+            case_name = plot['case']
+            case_idx = plot['case_idx']
+            plot_loc = Path(plot_locations[case_idx])
+
+            # Ensure plot directory exists
+            plot_loc.mkdir(parents=True, exist_ok=True)
+
+            # Load and validate model data (units transformation included in load_regrid_da)
+            mdata = adfobj.data.load_regrid_da(case_name, var)
+            if mdata is None:
+                continue
+
+            # Process data based on dimensionality
+            if "lev" in mdata.dims:
+                has_lev = True
+            else:
+                has_lev = False
+
+            if has_lev and pres_levs and plot.get('pressure'):
+                print("PRESSURE")
+                if not all(dim in mdata.dims for dim in ['lat', 'lev']):
+                    continue
+                mdata = mdata.sel(lev=plot['pressure'])
+                odata_level = odata.sel(lev=plot['pressure'])
+            else:
+                print(f"EXPECT 2D VARIABLE: {odata.shape}")
+                if not pf.lat_lon_validate_dims(mdata):
+                    continue
+
+            # Calculate seasonal means and differences
+            use_odata = odata_level if has_lev else odata
+            mseason, oseason, dseason, pseason = process_seasonal_data(
+                mdata, 
+                use_odata,
+                plot['season'], vres
+            )
+
+            # Create plot
+            if plot['path'].exists():
+                plot['path'].unlink()
+
+            pf.make_polar_plot(
+                plot['path'], test_nicknames[case_idx], base_nickname,
+                [syear_cases[case_idx], eyear_cases[case_idx]],
+                [syear_baseline, eyear_baseline],
+                mseason, oseason, dseason, pseason,
+                hemisphere=get_hemisphere(plot['type']),
+                obs=adfobj.compare_obs, **vres
+            )
+
+            # Add to website
+            adfobj.add_website_data(
+                plot['path'], plot['var'], case_name,
+                category=web_category, season=plot['season'],
+                plot_type=plot['type']
+            )
+
     print("  ...polar maps have been generated successfully.")
 
 ##############

--- a/scripts/plotting/polar_map.py
+++ b/scripts/plotting/polar_map.py
@@ -1,6 +1,5 @@
-from pathlib import Path  # python standard library
-
-# data loading / analysis
+"""Module to make polar stereographic maps."""
+from pathlib import Path
 import xarray as xr
 import numpy as np
 
@@ -8,11 +7,39 @@ import numpy as np
 import plotting_functions as pf
 
 def get_hemisphere(hemi_type):
-    """Helper function to convert plot type to hemisphere code."""
+    """Helper function to convert plot type to hemisphere code.
+    
+    Parameters
+    ----------
+    hemi_type : str
+        if `NHPolar` set NH, otherwise SH
+        
+    Returns
+    -------
+    str
+        NH or SH
+    """
     return "NH" if hemi_type == "NHPolar" else "SH"
 
-def process_seasonal_data(mdata, odata, season, vres):
-    """Helper function to calculate seasonal means and differences."""
+def process_seasonal_data(mdata, odata, season):
+    """Helper function to calculate seasonal means and differences.
+    Parameters
+    ----------
+    mdata : xarray.DataArray
+        test case data
+    odata : xarray.DataArray
+        reference case data
+    season : str
+        season (JJA, DJF, MAM, SON)
+
+    Returns
+    -------
+    mseason : xarray.DataArray
+    oseason : xarray.DataArray
+    dseason : xarray.DataArray
+    pseason : xarray.DataArray
+        Seasonal means for test, reference, difference, and percent difference    
+    """
     mseason = pf.seasonal_mean(mdata, season=season, is_climo=True)
     oseason = pf.seasonal_mean(odata, season=season, is_climo=True)
     
@@ -212,7 +239,7 @@ def polar_map(adfobj):
             mseason, oseason, dseason, pseason = process_seasonal_data(
                 mdata, 
                 use_odata,
-                plot['season'], vres
+                plot['season']
             )
 
             # Create plot

--- a/scripts/plotting/polar_map.py
+++ b/scripts/plotting/polar_map.py
@@ -34,9 +34,6 @@ def polar_map(adfobj):
     msg = "\n  Generating polar maps..."
     print(f"{msg}\n  {'-' * (len(msg)-3)}")
 
-    #
-    # Use ADF api to get all necessary information
-    #
     var_list = adfobj.diag_var_list
     model_rgrid_loc = adfobj.get_basic_info("cam_regrid_loc", required=True)
 
@@ -51,28 +48,13 @@ def polar_map(adfobj):
     syear_cases = adfobj.climo_yrs["syears"]
     eyear_cases = adfobj.climo_yrs["eyears"]
 
-    # CAUTION:
-    # "data" here refers to either obs or a baseline simulation,
-    # Until those are both treated the same (via intake-esm or similar)
-    # we will do a simple check and switch options as needed:
+    # if doing comparison to obs, but no observations are found, quit
     if adfobj.get_basic_info("compare_obs"):
-        #Set obs call for observation details for plot titles
-        obs = True
-
-        #Extract variable-obs dictionary:
         var_obs_dict = adfobj.var_obs_dict
-
-        #If dictionary is empty, then  there are no observations to regrid to,
-        #so quit here:
         if not var_obs_dict:
             print("\t No observations found to plot against, so no polar maps will be generated.")
             return
-    else:
-        obs = False
-        data_name = adfobj.get_baseline_info("cam_case_name", required=True) # does not get used, is just here as a placemarker
-        data_list = [data_name] # gets used as just the name to search for climo files HAS TO BE LIST
-        data_loc  = model_rgrid_loc #Just use the re-gridded model data path
-    #End if
+
 
     #Grab baseline years (which may be empty strings if using Obs):
     syear_baseline = adfobj.climo_yrs["syear_baseline"]
@@ -97,12 +79,6 @@ def polar_map(adfobj):
     print(f"\t NOTE: redo_plot is set to {redo_plot}")
     #-----------------------------------------
 
-    #Set data path variables:
-    #-----------------------
-    mclimo_rg_loc = Path(model_rgrid_loc)
-    if not adfobj.compare_obs:
-        dclimo_loc  = Path(data_loc)
-    #-----------------------
 
     #Determine if user wants to plot 3-D variables on
     #pressure levels:


### PR DESCRIPTION
This PR contains a very tiny change in the global maps script. It is a bug fix to reverse the logic when checking whether all the plots for a given variable have been made. This will speed up ADF runs that don't need to re-make those plots.

It does the same for the polar plots, but with a much more substantial refactoring of the script. I think that it produces all the same plots, but the code is more efficient and easier to read. Essentially it has a more elaborate "pre-flight" part of the code, where it figures out all the plots that will be made and keeps all the information about them in a dictionary, and then iterates through a list of these dictionaries to do the calculations. This reduces the complexity of the code a lot because it removes nested loops for all the variations. It also updates the polar plots script to use the adf_dataset module, which also reduces code. 

If we confirm this works and we like the approach, I think we should open an issue to refactor the other standard plotting scripts to use this structure. 