### PR TITLE
Add ENSO analysis and plot scripts

### DIFF
--- a/config_cam_baseline_example_testENSO.yaml
+++ b/config_cam_baseline_example_testENSO.yaml
@@ -1,0 +1,537 @@
+#==============================
+#config_cam_baseline_example.yaml
+
+#This is the main CAM diagnostics config file
+#for doing comparisons of a CAM run against
+#another CAM run, or a CAM baseline simulation.
+
+#Currently, if one is on NCAR's Casper or
+#Cheyenne machine, then only the diagnostic output
+#paths are needed, at least to perform a quick test
+#run (these are indicated with "MUST EDIT" comments).
+#Running these diagnostics on a different machine,
+#or with a different, non-example simulation, will
+#require additional modifications.
+#
+#Config file Keywords:
+#--------------------
+#
+#1.  Using ${xxx} will substitute that text with the
+#    variable referenced by xxx. For example:
+#
+#    cam_case_name: cool_run
+#    cam_climo_loc: /some/where/${cam_case_name}
+#
+#    will set "cam_climo_loc" in the diagnostics package to:
+#    /some/where/cool_run
+#
+#    Please note that currently this will only work if the
+#    variable only exists in one location in the file.
+#
+#2.  Using ${<top_level_section>.xxx} will do the same as
+#    keyword 1 above, but specifies which sub-section the
+#    variable is coming from, which is necessary for variables
+#    that are repeated in different subsections.  For example:
+#
+#    diag_basic_info:
+#      cam_climo_loc:  /some/where/${diag_cam_climo.start_year}
+#
+#    diag_cam_climo:
+#      start_year: 1850
+#
+#    will set "cam_climo_loc" in the diagnostics package to:
+#    /some/where/1850
+#
+#Finally, please note that for both 1 and 2 the keywords must be lowercase.
+#This is because future developments will hopefully use other keywords
+#that are uppercase. Also please avoid using periods (".") in variable
+#names, as this will likely cause issues with the current file parsing
+#system.
+#--------------------
+#
+##==============================
+#
+# This file doesn't (yet) read environment variables, so the user must
+# set this themselves. It is also a good idea to search the doc for 'user'
+# to see what default paths are being set for output/working files.
+#
+# Note that the string 'USER-NAME-NOT-SET' is used in the jupyter script
+# to check for a failure to customize
+#
+user: 'mdfowler'
+
+
+#This first set of variables specify basic info used by all diagnostic runs:
+diag_basic_info:
+
+    #Is this a model vs observations comparison?
+    #If "false" or missing, then a model-model comparison is assumed:
+    compare_obs: false
+
+    #Generate HTML website (assumed false if missing):
+    #Note:  The website files themselves will be located in the path
+    #specified by "cam_diag_plot_loc", under the "<diag_run>/website" subdirectory,
+    #where "<diag_run>" is the subdirectory created for this particular diagnostics run
+    #(usually "case_vs_obs_XXX" or "case_vs_baseline_XXX").
+    create_html: true
+
+    #Location of observational datasets:
+    #Note: this only matters if "compare_obs" is true and the path
+    #isn't specified in the variable defaults file.
+    obs_data_loc: /glade/campaign/cgd/amp/amwg/ADF_obs
+
+    #Location where re-gridded and interpolated CAM climatology files are stored:
+    cam_regrid_loc: /glade/derecho/scratch/${user}/ADF/regrid
+
+    #Overwrite CAM re-gridded files?
+    #If false, or missing, then regridding will be skipped for regridded variables
+    #that already exist in "cam_regrid_loc":
+    cam_overwrite_regrid: false
+
+    #Location where diagnostic plots are stored:
+    cam_diag_plot_loc: /glade/derecho/scratch/${user}/ADF/plots
+
+    #Location of ADF variable plotting defaults YAML file:
+    #If left blank or missing, ADF/lib/adf_variable_defaults.yaml will be used
+    #Uncomment and change path for custom variable defaults file
+    #defaults_file: /some/path/to/defaults/file.yaml
+
+    #Vertical pressure levels (in hPa) on which to plot 3-D variables
+    #when using horizontal (e.g. lat/lon) map projections.
+    #If this config option is missing, then no 3-D variables will be plotted on
+    #horizontal maps.  Please note too that pressure levels must currently match
+    #what is available in the observations file in order to be plotted in a
+    #model vs obs run:
+    plot_press_levels: [200,850]
+
+    #Longitude line on which to center all lat/lon maps.
+    #If this config option is missing then the central
+    #longitude will default to 180 degrees E.
+    central_longitude: 180
+
+    #Number of processors on which to run the ADF.
+    #If this config variable isn't present then
+    #the ADF defaults to one processor.  Also, if
+    #you set it to "*" then it will default
+    #to all of the processors available on a
+    #single node/machine:
+    num_procs: 8
+
+    #If set to true, then redo all plots even if they already exist.
+    #If set to false, then if a plot is found it will be skipped:
+    redo_plot: true
+
+#This second set of variables provides info for the CAM simulation(s) being diagnosed:
+diag_cam_climo:
+
+    # History file list of strings to match
+    # eg. cam.h0 or ocn.pop.h.ecosys.nday1 or hist_str: [cam.h2,cam.h0]  
+    # Only affects timeseries as everything else uses the created timeseries 
+    # Default: 
+    hist_str: cam.h0a
+
+    #Calculate climatologies?
+    #If false, the climatology files will not be created:
+    calc_cam_climo: true
+
+    #Overwrite CAM climatology files?
+    #If false, or not prsent, then already existing climatology files will be skipped:
+    cam_overwrite_climo: false
+
+    #Name of CAM case (or CAM run name):
+    cam_case_name: b.e30_alpha06b.B1850C_LTso.ne30_t232_wgx3.132
+
+    #Case nickname
+    #NOTE: if nickname starts with '0' - nickname must be in quotes!
+    # ie '026a' as opposed to 026a
+    #If missing or left blank, will default to cam_case_name
+    case_nickname: '132'
+
+    #Location of CAM history (h0) files:
+    #Example test files
+    # cam_hist_loc: /glade/campaign/cgd/amp/amwg/ADF_test_cases/${diag_cam_climo.cam_case_name}
+    cam_hist_loc: /glade/derecho/scratch/hannay/archive//b.e30_alpha06b.B1850C_LTso.ne30_t232_wgx3.132/atm/hist
+
+    #Location of CAM climatologies (to be created and then used by this script)
+    cam_climo_loc: /glade/derecho/scratch/${user}/ADF/${diag_cam_climo.cam_case_name}/climo
+
+    #model year when time series files should start:
+    #Note:  Leaving this entry blank will make time series
+    #       start at earliest available year.
+    start_year: 2
+
+    #model year when time series files should end:
+    #Note:  Leaving this entry blank will make time series
+    #       end at latest available year.
+    end_year: 44
+
+    #Do time series files exist?
+    #If True, then diagnostics assumes that model files are already time series.
+    #If False, or if simply not present, then diagnostics will attempt to create
+    #time series files from history (time-slice) files:
+    cam_ts_done: false
+
+    #Save interim time series files?
+    #WARNING:  This can take up a significant amount of space,
+       #          but will save processing time the next time
+    cam_ts_save: true
+
+    #Overwrite time series files, if found?
+    #If set to false, then time series creation will be skipped if files are found:
+    cam_overwrite_ts: false
+
+    #Location where time series files are (or will be) stored:
+    cam_ts_loc: /glade/derecho/scratch/${user}/ADF/${diag_cam_climo.cam_case_name}/ts
+
+    #TEM diagnostics
+    #---------------
+    #TEM history file number
+    #If missing or blank, ADF will default to h4
+    tem_hist_str: cam.h4
+
+    #Location where TEM files are stored:
+    #NOTE: If path not specified or commented out, TEM calculation/plots will be skipped!
+    cam_tem_loc: /glade/derecho/scratch/${user}/${diag_cam_climo.cam_case_name}/tem/
+
+    #Overwrite TEM files, if found?
+    #If set to false, then TEM creation will be skipped if files are found:
+    overwrite_tem: false
+
+    #----------------------
+
+    #You can alternatively provide a list of cases, which will make the ADF
+    #apply the same diagnostics to each case separately in a single ADF session.
+    #All of the config variables below show how it is done, and are the only ones
+    #that need to be lists.  This also automatically enables the generation of
+    #a "main_website" in "cam_diag_plot_loc" that brings all of the different cases
+    #together under a single website.
+
+    #Also please note that config keywords cannot currently be used in list mode.
+
+    #cam_case_name:
+    #    - b.e23_alpha17f.BLT1850.ne30_t232.098
+    #    - b.e23_alpha17f.BLT1850.ne30_t232.095
+
+    #Case nickname
+    #NOTE: if nickname starts with '0' - nickname must be in quotes!
+    # ie '026a' as opposed to 026a
+    #If missing or left blank, will default to cam_case_name
+    #case_nickname:
+    #    - cool nickname
+    #    - cool nickname 2
+
+    #calc_cam_climo:
+    #    - true
+    #    - true
+
+    #cam_overwrite_climo:
+    #    - false
+    #    - false
+
+    #cam_hist_loc:
+    #    - /glade/campaign/cgd/amp/amwg/ADF_test_cases/b.e23_alpha17f.BLT1850.ne30_t232.098
+    #    - /glade/campaign/cgd/amp/amwg/ADF_test_cases/b.e23_alpha17f.BLT1850.ne30_t232.095
+
+    #cam_climo_loc:
+    #    - /some/where/you/want/to/have/climo_files/ #MUST EDIT!
+    #    - /the/same/or/some/other/climo/files/location
+
+    #start_year:
+    #    - 10
+    #    - 10
+
+    #end_year:
+    #    - 14
+    #    - 14
+
+    #cam_ts_done:
+    #    - false
+    #    - false
+
+    #cam_ts_save:
+    #    - true
+    #    - true
+
+    #cam_overwrite_ts:
+    #    - false
+    #    - false
+
+    #cam_ts_loc:
+    #    - /some/where/you/want/to/have/time_series_files
+    #    - /same/or/different/place/you/want/files
+
+    #TEM diagnostics
+    #---------------
+    #TEM history file number
+    #If missing or blank, ADF will default to h4
+    #tem_hist_str:
+    #    - cam.h4
+    #    - cam.h#
+
+    #Location where TEM files are stored:
+    #NOTE: If path not specified or commented out, TEM calculation/plots will be skipped!
+    #cam_tem_loc:
+    #    - /some/where/you/want/to/have/TEM_files/
+    #    - /same/or/different/place/you/want/TEM_files/
+
+    #Overwrite TEM files, if found?
+    #If set to false, then TEM creation will be skipped if files are found:
+    #overwrite_tem:
+    #    - false
+    #    - true
+
+    #----------------------
+
+
+#This third set of variables provide info for the CAM baseline climatologies.
+#This only matters if "compare_obs" is false:
+diag_cam_baseline_climo:
+
+    # History file list of strings to match
+    # eg. cam.h0 or ocn.pop.h.ecosys.nday1 or hist_str: [cam.h2,cam.h0]  
+    # Only affects timeseries as everything else uses the created timeseries 
+    # Default: 
+    hist_str: cam.h0a
+
+    #Calculate cam baseline climatologies?
+    #If false, the climatology files will not be created:
+    calc_cam_climo: true
+
+    #Overwrite CAM climatology files?
+    #If false, or not present, then already existing climatology files will be skipped:
+    cam_overwrite_climo: false
+
+    #Name of CAM baseline case:
+    cam_case_name: b.e23_alpha17f.BLT1850.ne30_t232.093
+
+    #Baseline case nickname
+    #NOTE: if nickname starts with '0' - nickname must be in quotes!
+    # ie '026a' as opposed to 026a
+    #If missing or left blank, will default to cam_case_name
+    case_nickname: #cool nickname
+
+    #Location of CAM baseline history (h0) files:
+    #Example test files
+    cam_hist_loc: /glade/campaign/cgd/amp/amwg/ADF_test_cases/${diag_cam_baseline_climo.cam_case_name}
+
+    #Location of baseline CAM climatologies:
+    cam_climo_loc: /glade/derecho/scratch/${user}/ADF/${diag_cam_baseline_climo.cam_case_name}/climo
+
+    #model year when time series files should start:
+    #Note:  Leaving this entry blank will make time series
+    #       start at earliest available year.
+    start_year: 10
+
+    #model year when time series files should end:
+    #Note:  Leaving this entry blank will make time series
+    #       end at latest available year.
+    end_year: 14
+
+    #Do time series files need to be generated?
+    #If True, then diagnostics assumes that model files are already time series.
+    #If False, or if simply not present, then diagnostics will attempt to create
+    #time series files from history (time-slice) files:
+    cam_ts_done: false
+
+    #Save interim time series files for baseline run?
+    #WARNING:  This can take up a significant amount of space:
+    cam_ts_save: true
+
+    #Overwrite baseline time series files, if found?
+    #If set to false, then time series creation will be skipped if files are found:
+    cam_overwrite_ts: false
+
+    #Location where time series files are (or will be) stored:
+    cam_ts_loc: /glade/derecho/scratch/${user}/ADF/${diag_cam_baseline_climo.cam_case_name}/ts
+
+    #TEM diagnostics
+    #---------------
+    #TEM history file number
+    #If missing or blank, ADF will default to h4
+    tem_hist_str: cam.h4
+
+    #Location where TEM files are stored:
+    #NOTE: If path not specified or commented out, TEM calculation/plots will be skipped!
+    cam_tem_loc: /glade/derecho/scratch/${user}/${diag_cam_baseline_climo.cam_case_name}/tem/
+
+    #Overwrite TEM files, if found?
+    #If set to false, then TEM creation will be skipped if files are found:
+    overwrite_tem: false
+
+
+#This fourth set of variables provides settings for calling the Climate Variability
+# Diagnostics Package (CVDP). If cvdp_run is set to true the CVDP will be set up and
+# run in background mode, likely completing after the ADF has completed.
+# If CVDP is to be run PSL, TREFHT, TS and PRECT (or PRECC and PRECL) should be listed
+# in the diag_var_list variable listing.
+# For more CVDP information: https://www.cesm.ucar.edu/working_groups/CVC/cvdp/
+diag_cvdp_info:
+
+    # Run the CVDP on the listed run(s)?
+    cvdp_run: false
+
+    # CVDP code path, sets the location of the CVDP codebase
+    #  CGD systems path = /home/asphilli/CESM-diagnostics/CVDP/Release/v5.2.0/
+    #  CISL systems path = /glade/u/home/asphilli/CESM-diagnostics/CVDP/Release/v5.2.0/
+    #  github location = https://github.com/NCAR/CVDP-ncl
+    cvdp_codebase_loc: /glade/u/home/asphilli/CESM-diagnostics/CVDP/Release/v5.2.0/
+
+    # Location where cvdp codebase will be copied to and diagnostic plots will be stored
+    cvdp_loc: /glade/derecho/scratch/${user}/ADF/cvdp/
+
+    # tar up CVDP results?
+    cvdp_tar: false
+
+# This set of variables provides settings for calling NOAA's
+# Model Diagnostic Task Force (MDTF) diagnostic package.
+# https://github.com/NOAA-GFDL/MDTF-diagnostics
+#
+# If mdtf_run: true, the MDTF will be set up and 
+# run in background mode, likely completing after the ADF has completed.
+#
+# WARNING: This currently only runs on CASPER (not derecho)
+#
+# The variables required depend on the diagnostics (PODs) selected. 
+# AMWG-developed PODS and their required variables:
+#   (Note that PRECT can be computed from PRECC & PRECL)
+#  - MJO_suite: daily PRECT, FLUT, U850, U200, V200  (all required)
+#  - Wheeler-Kiladis Wavenumber Frequency Spectra: daily PRECT, FLUT, U200, U850, OMEGA500
+#              (will use what is available)
+#  - Blocking (Rich Neale):  daily OMEGA500
+#  - Precip Diurnal Cycle (Rich Neale): 3-hrly PRECT
+#
+# Many other diagnostics are available; see 
+# https://mdtf-diagnostics.readthedocs.io/en/main/sphinx/start_overview.html
+
+#
+diag_mdtf_info:
+    # Run the MDTF on the model cases
+    mdtf_run: false
+
+    # The file that will be written by ADF to input to MDTF. Call this whatever you want.
+    mdtf_input_settings_filename : mdtf_input.json   
+
+    ## MDTF code path, sets the location of the MDTF codebase and pre-compiled conda envs
+    #  CHANGE if you have any: your own MDTF code, installed conda envs and/or obs_data
+
+    mdtf_codebase_path : /glade/campaign/cgd/amp/amwg/mdtf                                                                                                                                 
+    mdtf_codebase_loc  : ${mdtf_codebase_path}/MDTF-diagnostics.v3.1.20230817.ADF
+    conda_root         : /glade/u/apps/opt/conda
+    conda_env_root     : ${mdtf_codebase_path}/miniconda2/envs.MDTFv3.1.20230412/
+    OBS_DATA_ROOT      : ${mdtf_codebase_path}/obs_data
+
+    # SET this to a writable dir. The ADF will place ts files here for the MDTF to read (adds the casename)
+    MODEL_DATA_ROOT     : ${diag_cam_climo.cam_ts_loc}/mdtf/inputdata/model     
+
+    # Choose diagnostics (PODs). Full list of available PODs: https://github.com/NOAA-GFDL/MDTF-diagnostics
+    pod_list      :  [ "MJO_suite" ]
+
+    # Intermediate/output file settings
+    make_variab_tar: false     # tar up MDTF results
+    save_ps : false     # save postscript figures in addition to bitmaps
+    save_nc : false      # save netCDF files of processed data (recommend true when starting with new model data)
+    overwrite: true     # overwrite results in OUTPUT_DIR; otherwise results will be saved under a unique name
+
+    # Settings used in debugging:
+    verbose  : 3       # Log verbosity level.
+    test_mode: false   # Set to true for framework test. Data is fetched but PODs are not run.
+    dry_run  : false   # Framework test. No external commands are run and no remote data is copied. Implies test_mode.
+
+    # Settings that shouldn't change in ADF implementation for now
+    data_type           : single_run # single_run or multi_run (only works with single right now)
+    data_manager        : Local_File # Fetch data or it is local?
+    environment_manager : Conda      # Manage dependencies
+
+
+
+#+++++++++++++++++++++++++++++++++++++++++++++++++++
+#These variables below only matter if you are using
+#a non-standard method, or are adding your own
+#diagnostic scripts.
+#+++++++++++++++++++++++++++++++++++++++++++++++++++
+
+#Note:  If you want to pass arguments to a particular script, you can
+#do it like so (using the "averaging_example" script in this case):
+# - {create_climo_files: {kwargs: {clobber: true}}}
+
+#Name of time-averaging scripts being used to generate climatologies.
+#These scripts must be located in "scripts/averaging":
+time_averaging_scripts:
+    - create_climo_files
+    #- create_TEM_files #To generate TEM files, please un-comment
+
+#Name of regridding scripts being used.
+#These scripts must be located in "scripts/regridding":
+regridding_scripts:
+    - regrid_and_vert_interp
+
+#List of analysis scripts being used.
+#These scripts must be located in "scripts/analysis":
+analysis_scripts:
+    - amwg_table
+    - ENSO_acrossRuns
+    #- aerosol_gas_tables
+
+#List of plotting scripts being used.
+#These scripts must be located in "scripts/plotting":
+plotting_scripts:
+    - global_latlon_map
+    # - global_latlon_vect_map
+    # - zonal_mean
+    # - meridional_mean
+    # - polar_map
+    # - cam_taylor_diagram
+    # - qbo
+    # - ozone_diagnostics
+    - enso_comparison_plots
+    #- tape_recorder
+    #- tem
+    #- regional_map_multicase #To use this please un-comment and fill-out
+                              #the "region_multicase" section below
+
+#List of CAM variables that will be processesd:
+#If CVDP is to be run PSL, TREFHT, TS and PRECT (or PRECC and PRECL) should be listed
+diag_var_list:
+    - SWCF
+    - LWCF
+    - PRECC
+    - PRECL
+    - PSL
+    - Q
+    - U
+    - T
+    - RELHUM
+    - TREFHT
+    - TS
+    - TAUX
+    - TAUY
+    - FSNT
+    - FLNT
+    - LANDFRAC
+    - O3
+
+#<Add more variables here.>
+# MDTF recommended variables
+#    - FLUT
+#    - OMEGA500
+#    - PRECT
+#    - PS
+#    - PSL
+#    - U200
+#    - U850
+#    - V200
+#    - V850
+    
+# Options for multi-case regional contour plots (./plotting/regional_map_multicase.py)
+# region_multicase:
+#     region_spec: [slat, nlat, wlon, elon]
+#     region_time_option: <calendar | zeroanchor>  # If calendar, will look for specified years. If zeroanchor will use a nyears starting from year_offset from the beginning of timeseries
+#     region_start_year:
+#     region_end_year:
+#     region_nyear:
+#     region_year_offset:
+#     region_month: <NULL means look for season>
+#     region_season: <NULL means use annual mean>
+#     region_variables: <list of variables to try to use; allows for a subset of the total diag variables>
+
+#END OF FILE

--- a/lib/adf_variable_defaults.yaml
+++ b/lib/adf_variable_defaults.yaml
@@ -69,7 +69,7 @@
 # Available ADF Default Plot Types
 #+++++++++++++
 default_ptypes: ["Tables","LatLon","LatLon_Vector","Zonal","Meridional",
-                  "NHPolar","SHPolar","TimeSeries","Special"]
+                  "NHPolar","SHPolar","TimeSeries","ENSO","Special",]
 
 #+++++++++++++
 # Constants

--- a/scripts/analysis/ENSO_acrossRuns.py
+++ b/scripts/analysis/ENSO_acrossRuns.py
@@ -1,0 +1,454 @@
+import os
+import glob
+import numpy as np 
+import xarray as xr
+import pandas as pd
+import datetime
+from datetime import date, timedelta
+import scipy.stats as stats
+import scipy.signal as signal
+import matplotlib
+import matplotlib.pyplot as plt
+import matplotlib.patches as patches
+import matplotlib.ticker as mticker
+import cartopy
+import cartopy.crs as ccrs
+
+# Import necessary ADF modules:
+from pathlib import Path
+from adf_base import AdfError
+
+## Functions ## 
+
+
+def ENSO_acrossRuns(adf, clobber=False, search=None):
+    """
+    This function computes ENSO statistics for new cases 
+
+    Description of needed inputs from ADF:
+
+    case_name    -> Name of CAM case provided by "cam_case_name"
+    input_ts_loc -> Location of CAM time series files provided by "cam_ts_loc"
+    output_loc   -> Location to write new dev file to, provided by "cam_climo_loc"
+    var_list     -> List of CAM output variables provided by "diag_var_list"
+
+    """
+    ## Define some basics 
+    lat_n = 10.0    
+    lat_s = -10.0
+
+    # Nino3.4
+    lat_n34 = 5
+    lat_s34 = -5
+    lon_e34 = 190 
+    lon_w34 = 240
+
+    # Nino3
+    lat_n3 = 5
+    lat_s3 = -5
+    lon_e3 = 210 
+    lon_w3 = 270
+
+    # Nino 4
+    lat_n4 = 5
+    lat_s4 = -5
+    lon_e4 = 160 
+    lon_w4 = 210
+
+    # Nino 1+2
+    lat_n12 = 0
+    lat_s12 = -10
+    lon_e12 = 270 
+    lon_w12 = 280
+
+    ## Read in ENSO characteristics from obs file 
+    obs_ds = xr.open_dataset('/glade/derecho/scratch/mdfowler/ENSOmetrics_Obs.nc')
+
+
+    ## Read in data for new case
+    # - - - - - - - - - - - - - - - - - - - - - - - 
+    case_names    = adf.get_cam_info("cam_case_name", required=True)
+    input_ts_locs = adf.get_cam_info("cam_ts_loc", required=True)
+    #Extract simulation years:
+    start_year = adf.climo_yrs["syears"]
+    end_year   = adf.climo_yrs["eyears"]
+
+
+    #Loop over CAM cases:
+    for case_idx, case_name in enumerate(case_names):
+        #Create "Path" objects:
+        input_location  = Path(input_ts_locs[case_idx])
+
+        case_shortName = adf.get_cam_info("case_nickname", required=True)[case_idx]
+        
+        #Check that time series input directory actually exists:
+        if not input_location.is_dir():
+            errmsg = f"Time series directory '{input_ts_locs}' not found.  Script is exiting."
+            raise AdfError(errmsg)
+        
+        #Check model year bounds:
+        syr, eyr = check_averaging_interval(start_year[case_idx], end_year[case_idx])
+
+        ts       = adf.data.load_timeseries_da(case_name, 'TS')
+        landfrac = adf.data.load_timeseries_da(case_name, 'LANDFRAC')
+
+        ts = ts.assign_coords({"case":  case_shortName})
+
+        #Extract data subset using provided year bounds:
+        tslice = get_time_slice_by_year(ts.time, int(syr), int(eyr))
+        ts       = ts.isel(time=tslice).sel(lat=slice(-10,10))
+        landfrac = landfrac.isel(time=tslice).sel(lat=slice(-10,10))
+
+    # - - - - - - - - - - - - - - - - - - - - - - - 
+    # Start computing ENSO-relevant pieces 
+    # - - - - - - - - - - - - - - - - - - - - - - - 
+
+        # Use ocean points only
+        ocnMask = landfrac.values
+        ocnMask[ocnMask>0.45] = np.nan
+        ocnMask[ocnMask<=0.45] = 1
+
+        # Detrend data 
+        TS = ts
+        ts_detrend = signal.detrend(TS, axis=0, type='linear')
+        # Get SST 
+        sst = ts_detrend * ocnMask
+        sst_raw_data = TS.values * ocnMask
+
+        sst = xr.DataArray(sst, 
+            coords={'time': ts.time.values,
+                    'lat':  ts.lat.values, 
+                    'lon':  ts.lon.values}, 
+            dims=["time", "lat", "lon"])
+        
+        # Remove annual cycle from monthly data 
+        sst_anom = rmMonAnnCyc(sst)
+
+        ## Compute nino 3.4 index
+        ## - - - - - - - - - - - - 
+        ilats = np.where((sst_anom.lat.values>=lat_s34)  & (sst_anom.lat.values<=lat_n34))[0]
+        ilons = np.where((sst_anom.lon.values>=lon_e34)  & (sst_anom.lon.values<=lon_w34))[0]
+
+        regionTS = sst_anom.isel(lat=ilats, lon=ilons)
+        coswgt   = np.cos(np.deg2rad(regionTS.lat))
+        nino34   = regionTS.weighted(coswgt).mean(('lon','lat'))
+        del ilats,ilons
+
+        ## Compute nino 3 index
+        ## - - - - - - - - - - - - 
+        ilats = np.where((sst_anom.lat.values>=lat_s3)  & (sst_anom.lat.values<=lat_n3))[0]
+        ilons = np.where((sst_anom.lon.values>=lon_e3)  & (sst_anom.lon.values<=lon_w3))[0]
+
+        regionTS = sst_anom.isel(lat=ilats, lon=ilons)
+        coswgt   = np.cos(np.deg2rad(regionTS.lat))
+        nino3    = regionTS.weighted(coswgt).mean(('lon','lat'))
+        del ilats,ilons
+
+        ## Compute nino 4 index
+        ## - - - - - - - - - - - - 
+        ilats = np.where((sst_anom.lat.values>=lat_s4)  & (sst_anom.lat.values<=lat_n4))[0]
+        ilons = np.where((sst_anom.lon.values>=lon_e4)  & (sst_anom.lon.values<=lon_w4))[0]
+
+        regionTS = sst_anom.isel(lat=ilats, lon=ilons)
+        coswgt   = np.cos(np.deg2rad(regionTS.lat))
+        nino4    = regionTS.weighted(coswgt).mean(('lon','lat'))
+        del ilats,ilons
+
+        ## Compute nino 1.2 index
+        ## - - - - - - - - - - - - 
+        ilats = np.where((sst_anom.lat.values>=lat_s12)  & (sst_anom.lat.values<=lat_n12))[0]
+        ilons = np.where((sst_anom.lon.values>=lon_e12)  & (sst_anom.lon.values<=lon_w12))[0]
+
+        regionTS = sst_anom.isel(lat=ilats, lon=ilons)
+        coswgt   = np.cos(np.deg2rad(regionTS.lat))
+        nino12   = regionTS.weighted(coswgt).mean(('lon','lat'))
+        del ilats,ilons
+
+        ## Western extent of SST correlation 
+        ## - - - - - - - - - - - - - - - - - -
+
+        cor_case       = getLagCorr(0, nino34, sst_anom)
+
+        ## Figure out western-most longitude of zero contour in pacific 
+        #     This works by creating a plot with a contour and identifying the western point, but I'm closing that plot
+        fig,axs = plt.subplots(1,1,figsize=(20,7),subplot_kw={"projection":ccrs.PlateCarree(central_longitude=210)})
+
+        lon0, lat0     = getWesternPoint(cor_case, 0)
+        lon0p5, lat0p5 = getWesternPoint(cor_case, 0.5)
+
+        plt.close()
+
+        ## Variance and Auto-correlation
+        ## - - - - - - - - - - - - - - - - 
+
+        nino34_var    = np.full([12], np.nan)
+        nino34_ac     = np.full([48], np.nan)
+        transit_month = np.nan
+
+        nino3_var      = np.full([12], np.nan)
+        nino3_ac       = np.full([48], np.nan)
+        transit_month3 = np.nan
+
+        nino4_var      = np.full([12], np.nan)
+        nino4_ac       = np.full([48], np.nan)
+        transit_month4 =  np.nan
+
+        nino12_var      = np.full([12], np.nan)
+        nino12_ac       = np.full([48], np.nan)
+        transit_month12 = np.nan
+
+
+        ## Reproduce the variance plot from Rich
+        #   NOTE: doesn't match exactly, likely because I use cos(lat) for weights instead of a gaussian like Rich 
+        nino34_var = nino34.groupby('time.month').var()
+        nino3_var  = nino3.groupby('time.month').var()
+        nino4_var  = nino4.groupby('time.month').var()
+        nino12_var = nino12.groupby('time.month').var()
+
+    
+        ## Reproduce the autocorrelation plot from Rich 
+        nino34_pd = pd.Series(nino34.values)
+        nino3_pd  = pd.Series(nino3.values)
+        nino4_pd  = pd.Series(nino4.values)
+        nino12_pd = pd.Series(nino12.values)
+
+        for iLag in range(48):
+            nino34_ac[iLag] = nino34_pd.autocorr(lag=iLag)
+            if ((nino34_ac[iLag-1]>0) & (nino34_ac[iLag]<0) & (np.isfinite(transit_month)==False)):
+                transit_month = iLag-1
+
+            nino3_ac[iLag] = nino3_pd.autocorr(lag=iLag)
+            if ((nino3_ac[iLag-1]>0) & (nino3_ac[iLag]<0) & (np.isfinite(transit_month3)==False)):
+                transit_month3 = iLag-1
+
+            nino4_ac[iLag] = nino4_pd.autocorr(lag=iLag)
+            if ((nino4_ac[iLag-1]>0) & (nino4_ac[iLag]<0) & (np.isfinite(transit_month4)==False)):
+                transit_month4 = iLag-1
+
+            nino12_ac[iLag] = nino12_pd.autocorr(lag=iLag)
+            if ((nino12_ac[iLag-1]>0) & (nino12_ac[iLag]<0) & (np.isfinite(transit_month12)==False)):
+                transit_month12 = iLag-1
+
+
+        ## SST biases 
+        ## - - - - - - - - - - - - - - - - 
+        sst_bias = np.full([ 4, len(ts.lat.values), len(ts.lon.values)], np.nan)
+        sst_raw  = np.full([ 4, len(ts.lat.values), len(ts.lon.values)], np.nan)
+        sst_anom = np.full([ 4, len(ts.lat.values), len(ts.lon.values)], np.nan)
+
+        sst_raw_data = xr.DataArray(sst_raw_data, 
+            coords={'time': ts.time.values,
+                    'lat':  ts.lat.values, 
+                    'lon':  ts.lon.values}, 
+            dims=["time", "lat", "lon"])
+
+        # Get seasonal means 
+        month_length = sst.time.dt.days_in_month
+        weights = ( month_length.groupby("time.season") / month_length.groupby("time.season").sum() )
+        # Calculate the weighted average
+        sst_case_weighted = (sst * weights).groupby("time.season").sum(dim="time")
+        sst_raw_case_weighted = (sst_raw_data * weights).groupby("time.season").sum(dim="time")
+        del month_length,weights
+
+        # Compute bias vs. observations (seasonally) 
+        sst_bias[:,:,:] = (sst_case_weighted - obs_ds.sst_obs_weighted) * ocnMask[0,:,:]
+        sst_raw[:,:,:]  = (sst_raw_case_weighted) * ocnMask[0,:,:]
+        sst_anom[:,:,:] = sst_case_weighted * ocnMask[0,:,:]
+
+        sst_bias = xr.DataArray(sst_bias, 
+            coords={
+                    'season': sst_case_weighted.season.values,
+                    'lat': sst_case_weighted.lat.values, 
+                    'lon':sst_case_weighted.lon.values}, 
+            dims=["season", "lat", "lon"])
+
+        sst_raw = xr.DataArray(sst_raw, 
+            coords={
+                    'season': sst_case_weighted.season.values,
+                    'lat': sst_case_weighted.lat.values, 
+                    'lon':sst_case_weighted.lon.values}, 
+            dims=["season", "lat", "lon"])
+
+        sst_anom = xr.DataArray(sst_anom, 
+            coords={
+                    'season': sst_case_weighted.season.values,
+                    'lat': sst_case_weighted.lat.values, 
+                    'lon':sst_case_weighted.lon.values}, 
+            dims=["season", "lat", "lon"])
+        
+        ## Get the longitude of the "cold tongue", approximated by the contour of the 299 K SST line
+        #     This works by creating a plot with a contour and identifying the western point, but I'm closing that plot
+        fig,axs = plt.subplots(1,1,figsize=(20,7),subplot_kw={"projection":ccrs.PlateCarree(central_longitude=210)})
+
+        lon299, lat299 = getWesternPoint(sst_raw.mean(dim='season'),299)
+
+        plt.close()
+
+        # Mean SST in nino3.4 region
+        ilats = np.where((sst_raw.lat.values>=lat_s34)  & (sst_raw.lat.values<=lat_n34))[0]
+        ilons = np.where((sst_raw.lon.values>=lon_e34)  & (sst_raw.lon.values<=lon_w34))[0]
+
+        # # Compute weights and get Nino3.4 
+        regionTS = sst_raw.isel(lat=ilats, lon=ilons)
+        coswgt   = np.cos(np.deg2rad(regionTS.lat))
+        sst_raw_nino34 = regionTS.weighted(coswgt).mean(('lon','lat'))
+
+
+        # - - - - - - - - - - - - - - - - - - - - - - - 
+        # Add ENSO stats for new case to existing DS
+        # - - - - - - - - - - - - - - - - - - - - - - - 
+        ## Combine all of above into a single DS, as in dev_ds 
+    
+        thisDev_DS = xr.Dataset(
+            data_vars = dict( 
+                startYear = (['case'], [ts['time.year'].values[0]]),
+                endYear   = (['case'], [ts['time.year'].values[-1]]),
+                nino34_zeroContour = (['case'], [lon0]),
+                nino34_0p5Contour  = (['case'], [lon0p5]),
+                nino34_variance    = (['case', 'nMonths_12'], [nino34_var]),
+                nino34_autocorr    = (['case', 'nMonths_48'], [nino34_ac]),
+                nino34_transMonth  = (['case'], [transit_month]),
+    
+                nino3_variance    = (['case', 'nMonths_12'], [nino3_var]),
+                nino3_autocorr    = (['case', 'nMonths_48'], [nino3_ac]),
+                nino3_transMonth  = (['case'], [transit_month3]),
+    
+                nino4_variance    = (['case', 'nMonths_12'], [nino4_var]),
+                nino4_autocorr    = (['case', 'nMonths_48'], [nino4_ac]),
+                nino4_transMonth  = (['case'], [transit_month4]),
+    
+                nino12_variance    = (['case', 'nMonths_12'], [nino12_var]),
+                nino12_autocorr    = (['case', 'nMonths_48'], [nino12_ac]),
+                nino12_transMonth  = (['case'], [transit_month12]),
+    
+                sst_raw         = (['case', 'season', 'lat', 'lon'], [sst_raw.values]),
+                sst_raw_nino34  = (['case', 'season'], [sst_raw_nino34.values]),   
+                sst_bias = (['case', 'season', 'lat', 'lon'], [sst_bias.values]),
+                sst_anom = (['case', 'season', 'lat', 'lon'], [sst_anom.values]),
+    
+                sst_lon299 = (['case'], [lon299]),
+                
+            ), 
+            
+            coords = dict(
+                case=([ts.case.values]), 
+                nMonths_48=np.arange(48),
+                nMonths_12=np.arange(12),
+                season=sst_bias.season.values,
+                lat=sst_bias.lat.values,
+                lon=sst_bias.lon.values,
+            )
+        )
+    
+        dev_ds   = xr.open_dataset("/glade/derecho/scratch/mdfowler/ENSOmetrics_CESM3dev.nc")
+        newDS    = xr.concat([dev_ds, thisDev_DS], dim="case")
+    
+        ## Save that new DS out to dev_ds and reload 
+        dev_ds.close()
+    
+        newDS.to_netcdf("/glade/derecho/scratch/mdfowler/ENSOmetrics_CESM3dev.nc", mode='w')
+
+
+
+def get_time_slice_by_year(time, startyear, endyear):
+    if not hasattr(time, 'dt'):
+        print("Warning: get_time_slice_by_year requires the `time` parameter to be an xarray time coordinate with a dt accessor. Returning generic slice (which will probably fail).")
+        return slice(startyear, endyear)
+    start_time_index = np.argwhere((time.dt.year >= startyear).values).flatten().min()
+    end_time_index = np.argwhere((time.dt.year <= endyear).values).flatten().max()
+    return slice(start_time_index, end_time_index+1)
+
+
+## Calculate nino anomalies 
+def rmMonAnnCyc(DS): 
+    
+    climatology = DS.groupby("time.month").mean("time")
+    anomalies   = DS.groupby("time.month") - climatology    
+
+    return anomalies
+
+def getLagCorr(lag, nino34, corDS):
+
+    if lag>0: 
+        A  = nino34[:-lag]
+        # B  = sst_anom.isel(case=iCase).shift(time=lag).isel(time=slice(lag,len(sst_anom.time.values)))
+        # B['time'] = sst_anom.time.values[:-lag]  # To get xr.corr to work, need to have the "same" time for computing corrs
+        B  = corDS.shift(time=-lag).isel(time=slice(0,len(corDS.time.values)-lag))
+        B['time'] = corDS.time.values[:-lag]  # To get xr.corr to work, need to have the "same" time for computing corrs
+    elif lag<0:
+        A  = nino34[-lag:]
+        A['time'] = nino34.time.values[:lag]
+        B  = corDS.isel(time=slice(0,len(corDS.time.values)+lag))
+    elif lag==0:
+        A = nino34
+        B = corDS
+            
+    cor = xr.corr(A, B, dim="time")
+
+    return cor
+
+def getWesternPoint(DS, contourLev):
+    corrs_sel = DS.sel(lon=slice(120,240), lat=slice(-10,10))
+    c2 = plt.contour(corrs_sel.lon.values,corrs_sel.lat.values ,  corrs_sel, [contourLev], transform=ccrs.PlateCarree())
+    
+    # Add contour marker
+    maybeLon = []
+    maybeLat = []
+    lenSeg = 0
+    for iSegs in range(len(c2.allsegs[0])): 
+        dat0 = c2.allsegs[0][iSegs]
+        western_most_lon = np.nanmin(dat0[:,0])
+        iMatchLat = np.where(dat0[:,0]==western_most_lon)[0]
+        maybeLon = np.append(maybeLon, western_most_lon)
+        maybeLat = np.append(maybeLat, dat0[int(iMatchLat[0]),1])
+        if len(dat0)>lenSeg:
+            lenSeg= len(dat0)
+            iselSeg = iSegs
+    
+    # axs.plot(maybeLon[iselSeg], maybeLat[iselSeg], 'o', color='limegreen', markersize=5, transform=ccrs.PlateCarree() )
+    
+    return maybeLon[iselSeg],maybeLat[iselSeg]
+
+def check_averaging_interval(syear_in, eyear_in):
+    #For now, make sure year inputs are integers or None,
+    #in order to allow for the zero additions done below:
+    if syear_in:
+        check_syr = int(syear_in)
+    else:
+        check_syr = None
+    #end if
+
+    if eyear_in:
+        check_eyr = int(eyear_in)
+    else:
+        check_eyr = None
+
+    #Need to add zeros if year values aren't long enough:
+    #------------------
+    #start year:
+    if check_syr:
+        assert check_syr >= 0, 'Sorry, values must be positive whole numbers.'
+        try:
+            syr = f"{check_syr:04d}"
+        except:
+            errmsg = " 'start_year' values must be positive whole numbers"
+            errmsg += f"not '{syear_in}'."
+            raise AdfError(errmsg)
+    else:
+        syr = None
+    #End if
+
+    #end year:
+    if check_eyr:
+        assert check_eyr >= 0, 'Sorry, end_year values must be positive whole numbers.'
+        try:
+            eyr = f"{check_eyr:04d}"
+        except:
+            errmsg = " 'end_year' values must be positive whole numbers"
+            errmsg += f"not '{eyear_in}'."
+            raise AdfError(errmsg)
+    else:
+        eyr = None
+    #End if
+    return syr, eyr
+

--- a/scripts/plotting/enso_comparison_plots.py
+++ b/scripts/plotting/enso_comparison_plots.py
@@ -1,0 +1,406 @@
+"""
+Generate plots that compare ENSO characteristics across various versions of CESM development
+"""
+
+import xarray as xr
+import numpy as np
+import matplotlib
+import matplotlib.pyplot as plt
+import matplotlib.patches as patches
+import matplotlib.ticker as mticker
+import cartopy
+import cartopy.crs as ccrs
+import warnings # use to warn user about missing files
+from pathlib import Path
+
+def enso_comparison_plots(adfobj):
+    """
+    This script/function is designed to generate ENSO-related plots across
+    various CESM simulations
+
+    Parameters
+    ----------
+    adfobj : AdfDiag
+        The diagnostics object that contains all the configuration information
+
+    Returns
+    -------
+    Does not return a value; produces plots and saves files.
+    """
+    
+    # Notify user that script has started:
+    msg = "\n  Generating ENSO plots to compare against all runs..."
+    print(f"{msg}\n  {'-' * (len(msg)-3)}")
+
+    plot_locations = adfobj.plot_location
+    plot_type = adfobj.get_basic_info('plot_type')
+    if not plot_type:
+        plot_type = 'png'
+
+    # check if existing plots need to be redone
+    redo_plot = adfobj.get_basic_info('redo_plot')
+    print(f"\t NOTE: redo_plot is set to {redo_plot}")
+
+    #Grab saved files
+    obs_ds   = xr.open_dataset('/glade/derecho/scratch/mdfowler/ENSOmetrics_Obs.nc')
+    cesm1_ds = xr.open_dataset("/glade/derecho/scratch/mdfowler/ENSOmetrics_CESM1.nc")
+    cesm2_ds = xr.open_dataset("/glade/derecho/scratch/mdfowler/ENSOmetrics_CESM2.nc")
+    dev_ds   = xr.open_dataset("/glade/derecho/scratch/mdfowler/ENSOmetrics_CESM3dev.nc")
+
+    # + + + + + + + + + + + + + + + + + + + +
+    #  Make Nino variance comparison plots
+    # + + + + + + + + + + + + + + + + + + + +
+#                          J   F   M    A  M   J   J   A    S   O    N  D
+    daysPerMonth = np.asarray([31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31])
+
+    ninoSelString =  ['Nino34', 'Nino12', 'Nino3', 'Nino4']
+
+    for iNino in range(len(ninoSelString)):
+        #Set path for variance figures:
+        plot_loc_ts  = Path(plot_locations[0]) / f'NinoVarianceComparison_{ninoSelString[iNino]}_ENSO_Mean.{plot_type}'
+        print('Creating plot for ', ninoSelString[iNino])
+
+        # Check redo_plot. If set to True: remove old plots, if they already exist:
+        if (not redo_plot) and plot_loc_ts.is_file():
+            #Add already-existing plot to website (if enabled):
+            adfobj.debug_log(f"'{plot_loc_ts}' exists and clobber is false.")
+            adfobj.add_website_data(plot_loc_ts, "NinoVarianceComparison", None, season=ninoSelString[iNino], multi_case=True, non_season=True, plot_type = "ENSO")
+
+            #Continue to next iteration:
+            return
+        elif (redo_plot):
+            if plot_loc_ts.is_file():
+                plot_loc_ts.unlink()
+        #End if
+
+        if ( (ninoSelString[iNino]=='Nino34') ):
+             pltVar = 'nino34_variance'
+        elif ( (ninoSelString[iNino]=='Nino12') ):
+             pltVar = 'nino12_variance'
+        elif ( (ninoSelString[iNino]=='Nino3') ):
+             pltVar = 'nino3_variance'
+        elif ( (ninoSelString[iNino]=='Nino4') ):
+             pltVar = 'nino4_variance'
+        else:
+            print('Invalid choice for ninoSelString supplied.\n Valid options: Nino34, Nino12, Nino3, Nino4')
+
+        fig,axs=plt.subplots(1,1,figsize=(15,5))
+
+        for iCase in range(len(dev_ds.case.values)):
+            case_max = np.nanmax(dev_ds[pltVar].values[iCase,:])
+            case_min = np.nanmin(dev_ds[pltVar].values[iCase,:])
+            # Weighted mean
+            weights = ( daysPerMonth / daysPerMonth.sum() )
+            weighted_mean = (dev_ds[pltVar].values[iCase,:] * weights).sum() / weights.sum()
+            
+            axs.plot(iCase+np.ones(2), [case_min, case_max], 'k-')
+            axs.plot(iCase+1, weighted_mean,'o', color='k')
+            axs.plot(iCase+1, case_min,'^',color='k')
+            axs.plot(iCase+1, case_max,'v',color='k')
+
+        cesm1_xCenter = len(dev_ds.case.values)+1.5
+        cesm2_xCenter = len(dev_ds.case.values)+3
+        obs_xCenter   = len(dev_ds.case.values)+4
+
+        offset = np.linspace(cesm1_xCenter-0.5, cesm1_xCenter+0.5, len(cesm1_ds.event.values))
+        for iEvent in range(len(cesm1_ds.event.values)):
+            case_max = np.nanmax(cesm1_ds[pltVar].values[iEvent,:])
+            case_min = np.nanmin(cesm1_ds[pltVar].values[iEvent,:])
+            # Weighted mean
+            weights = ( daysPerMonth / daysPerMonth.sum() )
+            weighted_mean = (cesm1_ds[pltVar].values[iEvent,:] * weights).sum() / weights.sum()
+            
+            axs.plot(offset[iEvent]*np.ones(2), [case_min, case_max],
+                    '-', color='mediumpurple', alpha=0.2)
+            axs.plot(offset[iEvent], weighted_mean,'o', color='mediumpurple',alpha=0.4)
+            axs.plot(offset[iEvent], case_min,'^',color='mediumpurple',alpha=0.4)
+            axs.plot(offset[iEvent],case_max,'v',color='mediumpurple',alpha=0.4)
+
+
+        offset = np.linspace(cesm2_xCenter-0.5, cesm2_xCenter+0.5, len(cesm2_ds.event.values))
+        for iEvent in range(len(cesm2_ds.event.values)):
+            case_max = np.nanmax(cesm2_ds[pltVar].values[iEvent,:])
+            case_min = np.nanmin(cesm2_ds[pltVar].values[iEvent,:])
+            # Weighted mean
+            weights = ( daysPerMonth / daysPerMonth.sum() )
+            weighted_mean = (cesm2_ds[pltVar].values[iEvent,:] * weights).sum() / weights.sum()
+            
+            axs.plot(offset[iEvent]*np.ones(2), [case_min, case_max],
+                    '-', color='orange', alpha=0.2)
+            axs.plot(offset[iEvent], weighted_mean,'o', color='orange',alpha=0.4)
+            axs.plot(offset[iEvent], case_min,'^',color='orange',alpha=0.4)
+            axs.plot(offset[iEvent],case_max,'v',color='orange',alpha=0.4)
+
+
+        # Get obs 
+        obs_max = np.nanmax(obs_ds[pltVar].values)
+        obs_min = np.nanmin(obs_ds[pltVar].values)
+        # Weighted mean
+        weights = ( daysPerMonth / daysPerMonth.sum() )
+        weighted_mean = (obs_ds[pltVar].values * weights).sum() / weights.sum()
+
+        axs.plot(obs_xCenter*np.ones(2), [obs_min, obs_max], '-', color='firebrick')
+        axs.plot(obs_xCenter, weighted_mean,'o', color='firebrick')
+        axs.plot(obs_xCenter, obs_min,'^',color='firebrick')
+        axs.plot(obs_xCenter, obs_max,'v',color='firebrick')
+
+        ## General plot settings 
+        ticks = np.append(1+np.arange(len(dev_ds.case.values)), cesm1_xCenter)
+        ticks = np.append(ticks, cesm2_xCenter)
+        ticks = np.append(ticks, obs_xCenter)
+
+        tickLabels = np.append(dev_ds.case.values, 'CESM1')
+        tickLabels = np.append(tickLabels, 'CESM2')
+        tickLabels = np.append(tickLabels, 'HadiSST')
+
+        axs.set_xticks(ticks)
+        axs.set_xticklabels(tickLabels)
+        plt.setp( axs.xaxis.get_majorticklabels(), rotation=45 )
+
+        axs.axhline(obs_min, color='firebrick',alpha=0.3)
+        axs.axhline(obs_max, color='firebrick',alpha=0.3)
+
+        axs.set_title('Monthly '+ninoSelString[iNino]+' variance')
+
+        #Save figure to file:
+        fig.savefig(plot_loc_ts, bbox_inches='tight', facecolor='white')
+
+        #Add plot to website (if enabled):
+        adfobj.add_website_data(plot_loc_ts, "NinoVarianceComparison", None, season=ninoSelString[iNino], multi_case=True, non_season=True, plot_type = "ENSO")
+
+    # + + + + + + + + + + + + + + + + + + + +
+    #  Make autocorrelation comparison plot
+    # + + + + + + + + + + + + + + + + + + + +
+
+    #Set path for variance figures:
+    plot_loc_autocorr  = Path(plot_locations[0]) / f'NinoAutocorrelation_Nino34_ENSO_Mean.{plot_type}'
+    print('Creating plot for Nino 3.4 autocorrelation transition')
+
+    # Check redo_plot. If set to True: remove old plots, if they already exist:
+    if (not redo_plot) and plot_loc_autocorr.is_file():
+        #Add already-existing plot to website (if enabled):
+        adfobj.debug_log(f"'{plot_loc_autocorr}' exists and clobber is false.")
+        adfobj.add_website_data(plot_loc_autocorr, "NinoAutocorrelation", None, season='Nino34', multi_case=True, non_season=True, plot_type = "ENSO")
+
+        #Continue to next iteration:
+        return
+    elif (redo_plot):
+        if plot_loc_autocorr.is_file():
+            plot_loc_autocorr.unlink()
+    #End if
+
+    fig,axs=plt.subplots(1,1,figsize=(15,5))
+
+    axs.scatter(dev_ds.case.values, dev_ds.nino34_transMonth, color='k')
+    axs.plot(np.full([len(cesm1_ds.event.values)], 'CESM1'), cesm1_ds.nino34_transMonth, 'o', color='mediumpurple', alpha=0.4)
+    axs.plot(np.full([len(cesm2_ds.event.values)], 'CESM2'), cesm2_ds.nino34_transMonth, 'o', color='orange', alpha=0.4)
+    axs.scatter('HadiSST', obs_ds.nino34_transMonth, color='k', marker='*', s=200)
+    axs.axhline(obs_ds.nino34_transMonth, color='grey',alpha=0.5)
+    axs.set_title('Month of transition in Autocorrelation for Nino3.4', fontsize=14)
+    axs.set_ylabel('Lag of nMonths',fontsize=12)
+
+    ticks = np.arange(len(dev_ds.case.values)+3)
+
+    tickLabels = np.append(dev_ds.case.values, 'CESM1')
+    tickLabels = np.append(tickLabels, 'CESM2')
+    tickLabels = np.append(tickLabels, 'HadiSST')
+
+    axs.set_xticks(ticks)
+    axs.set_xticklabels(tickLabels, fontsize=11)
+    axs.set_ylim([5,30])
+    plt.setp( axs.xaxis.get_majorticklabels(), rotation=40 )
+    
+    #Save figure to file:
+    fig.savefig(plot_loc_autocorr, bbox_inches='tight', facecolor='white')
+
+    #Add plot to website (if enabled):
+    adfobj.add_website_data(plot_loc_autocorr, "NinoAutocorrelation", None, season='Nino34', multi_case=True, non_season=True, plot_type = "ENSO")
+
+
+   # + + + + + + + + + + + + + + + + + + + +
+    #  Make western extent comparison plot
+    # + + + + + + + + + + + + + + + + + + + +
+
+    #Set path for variance figures:
+    plot_loc_westext  = Path(plot_locations[0]) / f'WesternExtent_Nino34_ENSO_Mean.{plot_type}'
+    print('Creating plot for Nino3.4 SST anomaly western extent')
+
+    # Check redo_plot. If set to True: remove old plots, if they already exist:
+    if (not redo_plot) and plot_loc_westext.is_file():
+        #Add already-existing plot to website (if enabled):
+        adfobj.debug_log(f"'{plot_loc_westext}' exists and clobber is false.")
+        adfobj.add_website_data(plot_loc_westext, "WesternExtent", None, season='Nino34', multi_case=True, non_season=True, plot_type = "ENSO")
+
+        #Continue to next iteration:
+        return
+    elif (redo_plot):
+        if plot_loc_westext.is_file():
+            plot_loc_westext.unlink()
+    #End if
+
+    fig,axs=plt.subplots(1,2,figsize=(10,9))
+    axs = axs.ravel()
+
+    axs[0].scatter(dev_ds.nino34_zeroContour, dev_ds.case.values, color='dodgerblue', alpha=1)
+    axs[0].set_title('Westernmost longitude of \n0 contour related to Nino 3.4 max')
+    axs[0].invert_yaxis()
+    axs[0].plot(cesm1_ds.nino34_zeroContour, np.full([len(cesm1_ds.event.values)], 'CESM1'), 'o', color='mediumpurple', alpha=0.4)
+    axs[0].plot(cesm2_ds.nino34_zeroContour, np.full([len(cesm2_ds.event.values)], 'CESM2'), 'o', color='orange', alpha=0.4)
+    axs[0].plot(obs_ds.nino34_zeroContour, 'HadiSST', '*', color='k',markersize=14)
+
+    axs[1].scatter(dev_ds.nino34_0p5Contour, dev_ds.case.values, marker = 's', color='dodgerblue', alpha=1)
+    axs[1].set_title('Westernmost longitude of \n0.5 contour related to Nino 3.4 max')
+    axs[1].invert_yaxis()
+    axs[1].plot(cesm1_ds.nino34_0p5Contour, np.full([len(cesm1_ds.event.values)], 'CESM1'), 's', color='mediumpurple', alpha=0.4)
+    axs[1].plot(cesm2_ds.nino34_0p5Contour, np.full([len(cesm2_ds.event.values)], 'CESM2'), 's', color='orange', alpha=0.4)
+    axs[1].plot(obs_ds.nino34_0p5Contour, 'HadiSST', '*', color='k',markersize=14)
+
+    axs[0].set_xlim(120,170)
+    axs[1].set_xlim(120,170)
+
+    fig.subplots_adjust(wspace=0.5)
+
+    #Save figure to file:
+    fig.savefig(plot_loc_westext, bbox_inches='tight', facecolor='white')
+
+    #Add plot to website (if enabled):
+    adfobj.add_website_data(plot_loc_westext, "WesternExtent", None, season='Nino34', multi_case=True, non_season=True, plot_type = "ENSO")
+
+    # + + + + + + + + + + + + + + + + + + + +
+    #  Make scatterplot comparison plots
+    # + + + + + + + + + + + + + + + + + + + +
+    case_shortName = adfobj.get_cam_info("case_nickname", required=True)[0]
+
+    #Set path for variance figures:
+    plot_loc_coldPoolScat  = Path(plot_locations[0]) / f'Scatter_ColdPoolExtent_ENSO_Mean.{plot_type}'
+    print('Creating plot for cold pool extent vs. western extent')
+
+    # Check redo_plot. If set to True: remove old plots, if they already exist:
+    if (not redo_plot) and plot_loc_coldPoolScat.is_file():
+        #Add already-existing plot to website (if enabled):
+        adfobj.debug_log(f"'{plot_loc_coldPoolScat}' exists and clobber is false.")
+        adfobj.add_website_data(plot_loc_coldPoolScat, "Scatter", None, season='ColdPoolExtent', multi_case=True, non_season=True, plot_type = "ENSO")
+
+        #Continue to next iteration:
+        return
+    elif (redo_plot):
+        if plot_loc_coldPoolScat.is_file():
+            plot_loc_coldPoolScat.unlink()
+    #End if
+
+    fig,axs = plt.subplots(1,1, figsize=(10,8))
+
+    xArr = np.append(dev_ds.sst_lon299, obs_ds.sst_lon299)
+    yArr = np.append(dev_ds.nino34_0p5Contour, obs_ds.nino34_0p5Contour)
+    cArr = np.append(dev_ds.sst_raw_nino34.mean(dim='season').values, (obs_ds.sst_raw_nino34.mean(dim='season').values + 273.15) )
+
+    caseLabels = np.append(dev_ds.case.values, 'HadiSST')
+    axs.tick_params(labelsize=12)  # Adjust 12 to your desired tick font size
+    s = axs.scatter(xArr, yArr, c=cArr)
+    cb = fig.colorbar(s,ax=axs,orientation='vertical')
+    cb.set_label('Mean Nino3.4 SST', size=14)
+    cb.ax.tick_params(labelsize=12)  # Adjust 12 to your desired tick font size 
+
+    for iCase in range(len(xArr)): 
+        if caseLabels[iCase]=='HadiSST':
+            axs.text(xArr[iCase]*0.975, 
+                    yArr[iCase], 
+                    # corrs.case.values[iCase], color='k', alpha=0.5, fontsize=11)
+                    caseLabels[iCase], color='g', fontsize=11)
+        elif caseLabels[iCase]==case_shortName:
+            axs.text(xArr[iCase], 
+                     yArr[iCase], 
+                     # corrs.case.values[iCase], color='k', alpha=0.5, fontsize=11)
+                     caseLabels[iCase], color='r', alpha=1, fontsize=14)
+        else: 
+            axs.text(xArr[iCase], 
+                    yArr[iCase], 
+                    # corrs.case.values[iCase], color='k', alpha=0.5, fontsize=11)
+                    caseLabels[iCase], color='k', alpha=0.7, fontsize=12)
+
+
+    axs.set_title('Extent of cold tongue vs. Western extent of 0.5 contour for ENSO',fontsize=14)
+    axs.set_xlabel('Westernmost point of 299 K contour in SSTs',fontsize=12)
+    axs.set_ylabel('Westernmost point of 0.5 contour\n in SST anomaly correlations with nino3.4 index', fontsize=12)
+
+    #Save figure to file:
+    fig.savefig(plot_loc_coldPoolScat, bbox_inches='tight', facecolor='white')
+
+    #Add plot to website (if enabled):
+    adfobj.add_website_data(plot_loc_coldPoolScat, "Scatter", None, season='ColdPoolExtent', multi_case=True, non_season=True, plot_type = "ENSO")
+
+
+    # --- Next Scatter: Autocorrelation and mean SST ---- 
+    plot_loc_durationSST  = Path(plot_locations[0]) / f'Scatter_NinoDuration&meanSST_ENSO_Mean.{plot_type}'
+    print('Creating plot for Nino duration and mean SST')
+
+    # Check redo_plot. If set to True: remove old plots, if they already exist:
+    if (not redo_plot) and plot_loc_durationSST.is_file():
+        #Add already-existing plot to website (if enabled):
+        adfobj.debug_log(f"'{plot_loc_durationSST}' exists and clobber is false.")
+        adfobj.add_website_data(plot_loc_durationSST, "Scatter", None, season='NinoDuration&meanSST', multi_case=True, non_season=True, plot_type = "ENSO")
+
+        #Continue to next iteration:
+        return
+    elif (redo_plot):
+        if plot_loc_durationSST.is_file():
+            plot_loc_durationSST.unlink()
+    #End if
+
+    fig,axs = plt.subplots(1,1,figsize=(8,5))
+
+    selSeason = 'DJF'
+
+    sst_raw_season = dev_ds.sst_raw.sel(season=selSeason).copy(deep=True)
+    transit_month  = dev_ds.nino34_transMonth
+    # sst_cesm2_raw_season = sst_cesm2.sel(season=selSeason)
+
+    # Define bounding box
+    sst_sel      = sst_raw_season.sel(lat=slice(-5,5), lon=slice(120,280))
+    sst_sel_mean = sst_sel.mean(dim='lon').mean(dim='lat')
+    axs.set_title('Averages over '+selSeason+' & Full Pacific (-5S to 5N, 120 to 280)')
+
+    axs.scatter(sst_sel_mean.values, transit_month.values)
+
+    for iCase in range(len(sst_raw_season.case.values)): 
+        if caseLabels[iCase]==case_shortName: 
+            axs.plot(sst_sel_mean.values[iCase], 
+                    transit_month[iCase], 'ro')
+            axs.text(sst_sel_mean.values[iCase], 
+                    transit_month[iCase], 
+                    dev_ds.case.values[iCase], color='r', alpha=1, fontsize=14)
+        else:
+            if transit_month[iCase]<=25:
+                axs.text(sst_sel_mean.values[iCase], 
+                        transit_month[iCase], 
+                        dev_ds.case.values[iCase], color='k', alpha=0.4, fontsize=12)
+
+    axs.set_xlabel('Mean SST')
+    axs.set_ylabel('Autocorrelation Transition (nMonths)')
+    axs.set_ylim([7,25])
+
+    axs.plot(273.15+obs_ds.sst_obs_raw_seasonal.sel(season=selSeason,lat=slice(-5,5), lon=slice(120,280)).mean(dim='lon').mean(dim='lat').values, 
+                    obs_ds.nino34_transMonth.values, 'g*', markersize=12)
+    axs.text(273.15+obs_ds.sst_obs_raw_seasonal.sel(season=selSeason,lat=slice(-5,5), lon=slice(120,280)).mean(dim='lon').mean(dim='lat').values, 
+                obs_ds.nino34_transMonth.values*0.91, 
+                'HadSST', color='g', alpha=0.8, fontsize=12)
+    
+    ## Add CESM ensembles
+    axs.scatter(cesm2_ds.sst_raw.sel(season=selSeason,lat=slice(-5,5), lon=slice(120,280)).mean(dim='lon').mean(dim='lat').values, 
+                cesm2_ds.nino34_transMonth.values, marker='s', c='orange', alpha=0.8)
+    axs.text(np.nanmean(cesm2_ds.sst_raw.sel(season=selSeason,lat=slice(-5,5), lon=slice(120,280)).mean(dim='lon').mean(dim='lat').values)*1.001, 
+            np.nanmean(cesm2_ds.nino34_transMonth.values), 'CESM2', color='orange', alpha=0.8, fontsize=12)
+
+
+    axs.scatter(cesm1_ds.sst_raw.sel(season=selSeason,lat=slice(-5,5), lon=slice(120,280)).mean(dim='lon').mean(dim='lat').values, 
+                cesm1_ds.nino34_transMonth.values, marker='^', c='mediumorchid', alpha=0.8)
+    axs.text(np.nanmean(cesm1_ds.sst_raw.sel(season=selSeason,lat=slice(-5,5), lon=slice(120,280)).mean(dim='lon').mean(dim='lat').values)*0.998, 
+             np.nanmean(cesm1_ds.nino34_transMonth.values), 'CESM1', color='mediumorchid', alpha=0.8, fontsize=12)
+
+    #Save figure to file:
+    fig.savefig(plot_loc_durationSST, bbox_inches='tight', facecolor='white')
+
+    #Add plot to website (if enabled):
+    adfobj.add_website_data(plot_loc_durationSST, "Scatter", None, season='NinoDuration&meanSST', multi_case=True, non_season=True, plot_type = "ENSO")
+
+    return


### PR DESCRIPTION
Create an analysis script that computes a variety of ENSO metrics (western extent, duration, etc.) for a new case, adding that to a pre-created netCDF file containing the same variables across previous simulations. Those are then plotted and placed in a new "ENSO" folder on the ADF website. 