### PR TITLE
Separate time bounds for time series and climo generation

### DIFF
--- a/config_clm_native_grid_to_latlon.yaml
+++ b/config_clm_native_grid_to_latlon.yaml
@@ -168,6 +168,16 @@ diag_cam_climo:
     #       end at latest available year.
     end_year: 40
 
+    #model year when climatology should start:
+    #Note:  Leaving this entry blank will make time series
+    #       end at latest available year.
+    #climo_start_year: 35
+
+    #model year when climatology should end:
+    #Note:  Leaving this entry blank will make time series
+    #       end at latest available year.
+    #climo_end_year: 40
+
     #Do time series files exist?
     #If True, then diagnostics assumes that model files are already time series.
     #If False, or if simply not present, then diagnostics will attempt to create
@@ -240,6 +250,16 @@ diag_cam_baseline_climo:
     #Note:  Leaving this entry blank will make time series
     #       end at latest available year.
     end_year: 40
+
+    #model year when climatology should start:
+    #Note:  Leaving this entry blank will make time series
+    #       end at latest available year.
+    #climo_start_year: 35
+
+    #model year when time series files should end:
+    #Note:  Leaving this entry blank will make time series
+    #       end at latest available year.
+    #climo_end_year: 40
 
     #Do time series files need to be generated?
     #If True, then diagnostics assumes that model files are already time series.

--- a/config_clm_native_grid_to_latlon.yaml
+++ b/config_clm_native_grid_to_latlon.yaml
@@ -170,13 +170,13 @@ diag_cam_climo:
 
     #model year when climatology should start:
     #Note:  Leaving this entry blank will make time series
-    #       end at latest available year.
-    #climo_start_year: 35
+    #       start at the first available year
+    climo_start_year: 35
 
     #model year when climatology should end:
     #Note:  Leaving this entry blank will make time series
     #       end at latest available year.
-    #climo_end_year: 40
+    climo_end_year: 40
 
     #Do time series files exist?
     #If True, then diagnostics assumes that model files are already time series.
@@ -253,13 +253,13 @@ diag_cam_baseline_climo:
 
     #model year when climatology should start:
     #Note:  Leaving this entry blank will make time series
-    #       end at latest available year.
-    #climo_start_year: 35
+    #       start at first available year.
+    climo_start_year: 35
 
     #model year when time series files should end:
     #Note:  Leaving this entry blank will make time series
     #       end at latest available year.
-    #climo_end_year: 40
+    climo_end_year: 40
 
     #Do time series files need to be generated?
     #If True, then diagnostics assumes that model files are already time series.
@@ -313,16 +313,16 @@ plotting_scripts:
 #List of CAM variables that will be processesd:
 #If CVDP is to be run PSL, TREFHT, TS and PRECT (or PRECC and PRECL) should be listed
 diag_var_list:
-    #- TSA
-    - PREC
-    - ELAI
-    - GPP
+    - TSA
+    #- PREC
+    #- ELAI
+    #- GPP
     #- NPP
     #- FSDS
     #- ALTMAX
-    - ET
-    - TOTRUNOFF
-    - DSTFLXT
-    - MEG_isoprene 
+    #- ET
+    #- TOTRUNOFF
+    #- DSTFLXT
+    #- MEG_isoprene 
 
 #END OF FILE

--- a/scripts/averaging/create_climo_files.py
+++ b/scripts/averaging/create_climo_files.py
@@ -84,9 +84,13 @@ def create_climo_files(adf, clobber=False, search=None):
     start_year = adf.climo_yrs["syears"]
     end_year   = adf.climo_yrs["eyears"]
     if climo_start_year:
-        start_year = climo_start_year
+        if climo_start_year > end_year:
+            raise ValueError('Sorry, climo_start_year must be earlier than ts end year.')
+        start_year = max(climo_start_year, start_year)
     if climo_end_year:
-        end_year = climo_end_year
+        if climo_end_year < start_year:
+            raise ValueError('Sorry, climo_end_year must be later than ts start year.')
+        end_year = min(climo_end_year, end_year)
 
     comp = adf.model_component
     print("\ncomp",comp,"\n")
@@ -114,9 +118,13 @@ def create_climo_files(adf, clobber=False, search=None):
         bl_syr = adf.climo_yrs["syear_baseline"]
         bl_eyr = adf.climo_yrs["eyear_baseline"]
         if climo_baseline_start_year:
-            bl_syr = climo_baseline_start_year
+            if climo_baseline_start_year > bl_eyr:
+                raise ValueError('Sorry, climo_end_year must be later than ts start year.')
+            bl_syr = max(climo_baseline_start_year, bl_syr)
         if climo_baseline_end_year:
-            bl_eyr = climo_baseline_end_year
+            if climo_baseline_end_year < bl_syr:
+                raise ValueError('Sorry, climo_end_year must be later than ts start year.')
+            bl_eyr = min(climo_baseline_end_year, bl_eyr)
 
         #Append to case lists:
         case_names.append(baseline_name)

--- a/scripts/averaging/create_climo_files.py
+++ b/scripts/averaging/create_climo_files.py
@@ -76,10 +76,17 @@ def create_climo_files(adf, clobber=False, search=None):
     output_locs   = adf.get_cam_info("cam_climo_loc", required=True)
     calc_climos   = adf.get_cam_info("calc_cam_climo")
     overwrite     = adf.get_cam_info("cam_overwrite_climo")
+    # Get start and end year for climatology computation
+    climo_start_year = adf.get_cam_info("climo_start_year")
+    climo_end_year = adf.get_cam_info("climo_end_year")
 
     #Extract simulation years:
     start_year = adf.climo_yrs["syears"]
     end_year   = adf.climo_yrs["eyears"]
+    if climo_start_year:
+        start_year = climo_start_year
+    if climo_end_year:
+        end_year = climo_end_year
 
     comp = adf.model_component
     print("\ncomp",comp,"\n")
@@ -100,10 +107,16 @@ def create_climo_files(adf, clobber=False, search=None):
         output_bl_loc     = adf.get_baseline_info("cam_climo_loc", required=True)
         calc_bl_climos    = adf.get_baseline_info("calc_cam_climo")
         ovr_bl            = adf.get_baseline_info("cam_overwrite_climo")
+        climo_baseline_start_year = adf.get_baseline_info("climo_start_year")
+        climo_baseline_end_year = adf.get_baseline_info("climo_end_year")
 
         #Extract baseline years:
         bl_syr = adf.climo_yrs["syear_baseline"]
         bl_eyr = adf.climo_yrs["eyear_baseline"]
+        if climo_baseline_start_year:
+            bl_syr = climo_baseline_start_year
+        if climo_baseline_end_year:
+            bl_eyr = climo_baseline_end_year
 
         #Append to case lists:
         case_names.append(baseline_name)
@@ -246,7 +259,7 @@ def process_variable(adf, ts_files, syr, eyr, output_file, comp):
         if comp == "atm":
             dim = 'nbnd'
         # NOTE: force `load` here b/c if dask & time is cftime, throws a NotImplementedError:
-        time = xr.DataArray(cam_ts_data['time_bounds'].load().mean(dim=dim).values, 
+        time = xr.DataArray(cam_ts_data['time_bounds'].load().mean(dim=dim).values,
                             dims=time.dims, attrs=time.attrs)
         cam_ts_data['time'] = time
         cam_ts_data.assign_coords(time=time)


### PR DESCRIPTION
**Descriptions:**

This PR is to enable configuring start year and end year for climatology computation.

New yaml variables are added: `climo_start_year`  and `climo_end_year` 
 