### PR TITLE
Update conda environment for geocat-comp 2024.04.0

### DIFF
--- a/env/conda_environment.yaml
+++ b/env/conda_environment.yaml
@@ -1,18 +1,18 @@
-name: adf_v0.12
+name: adf_v0.13
 channels:
   - conda-forge
   - defaults
 dependencies:
-  - pyyaml=6.0
-  - scipy=1.10.0
-  - cartopy=0.21.1
-  - netcdf4=1.6.2
-  - xarray=2023.1.0
-  - matplotlib=3.6.3
-  - pandas=1.5.3
-  - pint=0.16   #GeoCAT doesn't work with newer versions
-  - xskillscore=0.0.5
-  - geocat-comp=2022.08.0
-  - python=3.11
-  - xesmf=0.8.7
-prefix: /glade/work/$USER/conda-envs/adf_v0.12
+  - pyyaml=6.0.2
+  - scipy=1.12.0
+  - cartopy=0.23.0
+  - netcdf4=1.6.5
+  - xarray=2024.1.1
+  - matplotlib=3.9.4
+  - pandas=2.2.0
+  - pint=0.23
+  - xskillscore=0.0.24
+  - geocat-comp=2024.04.0
+  - python=3.12
+  - xesmf>=0.8.8
+prefix: /glade/work/$USER/conda-envs/adf_v0.13


### PR DESCRIPTION
This is a suggestion for updating the conda environment to support `geocat-comp=2024.04.0` and Python 3.12.

Tested with the `main` branch for cam6_4_070 output from NorESM.