### PR TITLE
Use xr.DataArray.data as arguments to np functions

### DIFF
--- a/lib/plotting_functions.py
+++ b/lib/plotting_functions.py
@@ -1902,10 +1902,10 @@ def prep_contour_plot(adata, bdata, diffdata, pctdata, **kwargs):
         levelsdiff = np.arange(*kwargs['diff_contour_range'])
     else:
         # set a symmetric color bar for diff:
-        absmaxdif = np.max(np.abs(diffdata))
+        absmaxdif = np.max(np.abs(diffdata.data))
         # set levels for difference plot:
         levelsdiff = np.linspace(-1*absmaxdif, absmaxdif, 12)
-        
+
     # Percent Difference options -- Check in kwargs for colormap and levels
     if "pct_diff_colormap" in kwargs:
         cmappct = kwargs["pct_diff_colormap"]


### PR DESCRIPTION
Some combinations of recent versions of xarray and numpy throw a ValueError when the first two arguments to np.linspace are DataArray objects instead of numpy.array objects. This can be avoided by using the .data component as the argument.

I've verified that in older numpy versions where the xarray argument is allowed, the result from np.linspace is bit-for-bit identical whether the argument is the DataArray or DataArray.data. I also cleaned up some whitespace that was right next to the bit of code I'm actually interested in :)

This fix will help us address https://github.com/NCAR/CUPiD/issues/224 (see https://github.com/NCAR/CUPiD/issues/224#issuecomment-3005678735 for details)