### PR TITLE
Update lat/lon dim check in global_latlon_map.py

### DIFF
--- a/scripts/plotting/aod_latlon.py
+++ b/scripts/plotting/aod_latlon.py
@@ -435,7 +435,8 @@ def aod_panel_latlon(adfobj, plot_titles, plot_params, data, season, obs_name, c
             ax.coastlines()
             ax.set_title(title, fontsize=10)
 
-            cbar = plt.colorbar(img, orientation='horizontal', pad=0.05)
+            fig_to_use = ind_fig if not is_panel else fig
+            cbar = fig_to_use.colorbar(img, ax=ax, orientation='horizontal', pad=0.05)
             if 'ticks' in plot_param:
                 cbar.set_ticks(plot_param['ticks'])
             if 'tick_labels' in plot_param:

--- a/scripts/plotting/global_latlon_map.py
+++ b/scripts/plotting/global_latlon_map.py
@@ -158,7 +158,7 @@ def process_case(adfobj, case_name, case_idx, var, odata, seasons,
         return
 
     has_dims = pf.validate_dims(mdata, ["lat", "lon", "lev"])
-    if not pf.lat_lon_validate_dims(mdata):
+    if (not has_dims['has_lat']) or (not has_dims['has_lon']):
         print(f"\t    WARNING: Model data missing lat/lon dimensions")
         return
 


### PR DESCRIPTION
Currently the code is checking incorrectly for lat/lon dims if the variable is 3d. This change will update the check to include both 2 and 3d variables.

This will also add a fix to the colorbar warning: `Adding colorbar to a different Figure` given during the AOD lat/lon plots