### PR TITLE
Clean up Data handeling methods in `adf_dataset.py` and fix AMWG table formatting

### DIFF
--- a/lib/adf_dataset.py
+++ b/lib/adf_dataset.py
@@ -145,6 +145,12 @@ class AdfData:
         if not fils:
             warnings.warn(f"\t    WARNING: Did not find reference time series file(s), variable: {field}")
             return None
+        """
+        #Change the variable name from CAM standard to what is
+        # listed in variable defaults for this observation field
+        if self.adf.compare_obs:
+            field = self.ref_var_nam[field]
+        """
         return self.load_da(fils, field, case)
     #------------------
 
@@ -207,6 +213,10 @@ class AdfData:
         if not fils:
             warnings.warn(f"\t    WARNING: Did not find climo file(s) for case: {case}, variable: {field}")
             return None
+        #Change the variable name from CAM standard to what is
+        # listed in variable defaults for this observation field
+        if self.adf.compare_obs:
+            field = self.ref_var_nam[field]
         return self.load_da(fils, field, case)
 
     #------------------
@@ -310,14 +320,14 @@ class AdfData:
         return ds
 
     # Load DataArray
-    def load_da(self, fils, variablename, case, type=None):
+    def load_da(self, fils, variablename, case):
         """Return xarray DataArray from files(s) w/ optional scale factor, offset, and/or new units"""
         ds = self.load_dataset(fils)
         if ds is None:
             warnings.warn(f"\t    WARNING: Load failed for {variablename}")
             return None
         da = (ds[variablename]).squeeze()
-        units = da.attrs.get('units', 'none')
+        units = da.attrs.get('units', '--')
         add_offset, scale_factor = self.get_value_converters(case, variablename)
         da = da * scale_factor + add_offset
         da.attrs['scale_factor'] = scale_factor

--- a/lib/adf_dataset.py
+++ b/lib/adf_dataset.py
@@ -145,12 +145,10 @@ class AdfData:
         if not fils:
             warnings.warn(f"\t    WARNING: Did not find reference time series file(s), variable: {field}")
             return None
-        """
         #Change the variable name from CAM standard to what is
         # listed in variable defaults for this observation field
         if self.adf.compare_obs:
             field = self.ref_var_nam[field]
-        """
         return self.load_da(fils, field, case)
     #------------------
 

--- a/lib/adf_dataset.py
+++ b/lib/adf_dataset.py
@@ -195,7 +195,7 @@ class AdfData:
         if fils:
             return fils
         return None
-    
+
     def load_reference_climo_dataset(self, field):
         """Return Dataset for reference (aka baseline) climo of field"""
         case = self.ref_case_label

--- a/lib/adf_dataset.py
+++ b/lib/adf_dataset.py
@@ -157,7 +157,6 @@ class AdfData:
 
     # Climatology files
     #------------------
-
     # Test case(s)
     def get_climo_file(self, case, variablename):
         """Retrieve the climo file path(s) for variablename for a specific test case."""

--- a/lib/adf_dataset.py
+++ b/lib/adf_dataset.py
@@ -61,11 +61,13 @@ class AdfData:
     def set_reference(self):
         """Set attributes for reference (aka baseline) data location, names, and variables."""
         if self.adf.compare_obs:
-            self.ref_var_loc = {v: self.adf.var_obs_dict[v]['obs_file'] for v in self.adf.var_obs_dict}
-            self.ref_labels = {v: self.adf.var_obs_dict[v]['obs_name'] for v in self.adf.var_obs_dict}
-            self.ref_var_nam = {v: self.adf.var_obs_dict[v]['obs_var'] for v in self.adf.var_obs_dict}
-            self.ref_case_label = "Obs"
-            if not self.adf.var_obs_dict:
+            if "var_obs_dict" in dir(self.adf):
+                self.ref_var_loc = {v: self.adf.var_obs_dict[v]['obs_file'] for v in self.adf.var_obs_dict}
+                self.ref_labels = {v: self.adf.var_obs_dict[v]['obs_name'] for v in self.adf.var_obs_dict}
+                self.ref_var_nam = {v: self.adf.var_obs_dict[v]['obs_var'] for v in self.adf.var_obs_dict}
+                self.ref_case_label = "Obs"
+            else:
+            #if not self.adf.var_obs_dict:
                 warnings.warn("\t    WARNING: reference is observations, but no observations found to plot against.")
         else:
             self.ref_var_loc = {}
@@ -91,13 +93,29 @@ class AdfData:
     #------------------
     # Test case(s)
     def get_timeseries_file(self, case, field):
-        """Return list of test time series files"""
+        """Retrieve the time series file path(s) for variablename for a specific test case."""
         ts_locs = self.adf.get_cam_info("cam_ts_loc", required=True) # list of paths (could be multiple cases)
         caseindex = (self.case_names).index(case)
         ts_loc = Path(ts_locs[caseindex])
         ts_filenames = f'{case}.*.{field}.*nc'
         ts_files = sorted(ts_loc.glob(ts_filenames))
         return ts_files
+    
+    def load_timeseries_dataset(self, case, field):
+        """Return Dataset for test time series of field"""
+        fils = self.get_timeseries_file(case, field)
+        if not fils:
+            warnings.warn(f"\t    WARNING: Did not find time series file(s) for case: {case}, variable: {field}")
+            return None
+        return self.load_dataset(fils, type="tseries")
+    
+    def load_timeseries_da(self, case, variablename):
+        """Return DataArray from test time series file"""
+        fils = self.get_timeseries_file(case, variablename)
+        if not fils:
+            warnings.warn(f"\t    WARNING: Did not find case time series file(s), variable: {variablename}")
+            return None
+        return self.load_da(fils, variablename, case)
 
     # Reference case (baseline/obs)
     def get_ref_timeseries_file(self, field):
@@ -110,67 +128,24 @@ class AdfData:
             ts_filenames = f'{self.ref_case_label}.*.{field}.*nc'
             ts_files = sorted(ts_loc.glob(ts_filenames))
             return ts_files
-
-
-    def load_timeseries_dataset(self, fils):
-        """Return DataSet from time series file(s) and assign time to midpoint of interval"""
-        if (len(fils) == 0):
-            warnings.warn("\t    WARNING: Input file list is empty.")
-            return None
-        elif (len(fils) > 1):
-            ds = xr.open_mfdataset(fils, decode_times=False)
-        else:
-            sfil = str(fils[0])
-            if not Path(sfil).is_file():
-                warnings.warn(f"\t    WARNING: Expecting to find file: {sfil}")
-                return None
-            ds = xr.open_dataset(sfil, decode_times=False)
-        if ds is None:
-            warnings.warn(f"\t    WARNING: invalid data on load_dataset")
-        # assign time to midpoint of interval (even if it is already)
-        if 'time_bnds' in ds:
-            t = ds['time_bnds'].mean(dim='nbnd')
-            t.attrs = ds['time'].attrs
-            ds = ds.assign_coords({'time':t})
-        elif 'time_bounds' in ds:
-            t = ds['time_bounds'].mean(dim='nbnd')
-            t.attrs = ds['time'].attrs
-            ds = ds.assign_coords({'time':t})
-        else:
-            warnings.warn("\t    INFO: Timeseries file does not have time bounds info.")
-        return xr.decode_cf(ds)
-
-    def load_timeseries_da(self, case, variablename):
-        """Return DataArray from time series file(s).
-           Uses defaults file to convert units.
-        """
-        add_offset, scale_factor = self.get_value_converters(case, variablename)
-        fils = self.get_timeseries_file(case, variablename)
+        
+    def load_reference_timeseries_dataset(self, field):
+        """Return Dataset for reference (aka baseline) time series of field"""
+        case = self.ref_case_label
+        fils = self.get_ref_timeseries_file(field)
         if not fils:
-            warnings.warn(f"\t    WARNING: Did not find case time series file(s), variable: {variablename}")
+            warnings.warn(f"\t    WARNING: Did not find time series file(s) for case: {case}, variable: {field}")
             return None
-        return self.load_da(fils, variablename, add_offset=add_offset, scale_factor=scale_factor)
+        return self.load_dataset(fils, type="tseries")
     
     def load_reference_timeseries_da(self, field):
-        """Return a DataArray time series to be used as reference 
-          (aka baseline) for variable field.
-        """
+        """Return DataArray for reference (aka baseline) time series file"""
+        case = self.ref_case_label
         fils = self.get_ref_timeseries_file(field)
         if not fils:
             warnings.warn(f"\t    WARNING: Did not find reference time series file(s), variable: {field}")
             return None
-        #Change the variable name from CAM standard to what is
-        # listed in variable defaults for this observation field
-        if self.adf.compare_obs:
-            field = self.ref_var_nam[field]
-            add_offset = 0
-            scale_factor = 1
-        else:
-            add_offset, scale_factor = self.get_value_converters(self.ref_case_label, field)
-
-        return self.load_da(fils, field, add_offset=add_offset, scale_factor=scale_factor)
-
-
+        return self.load_da(fils, field, case)
     #------------------
 
 
@@ -178,55 +153,67 @@ class AdfData:
     #------------------
 
     # Test case(s)
-    def load_climo_da(self, case, variablename):
-        """Return DataArray from climo file"""
-        add_offset, scale_factor = self.get_value_converters(case, variablename)
-        fils = self.get_climo_file(case, variablename)
-        return self.load_da(fils, variablename, add_offset=add_offset, scale_factor=scale_factor)
-
-
-    def load_climo_file(self, case, variablename):
-        """Return Dataset for climo of variablename"""
-        fils = self.get_climo_file(case, variablename)
-        if not fils:
-            warnings.warn(f"\t    WARNING: Did not find climo file for variable: {variablename}. Will try to skip.")
-            return None
-        return self.load_dataset(fils)
-    
-
     def get_climo_file(self, case, variablename):
-        """Retrieve the climo file path(s) for variablename for a specific case."""
+        """Retrieve the climo file path(s) for variablename for a specific test case."""
         a = self.adf.get_cam_info("cam_climo_loc", required=True) # list of paths (could be multiple cases)
         caseindex = (self.case_names).index(case) # the entry for specified case
         model_cl_loc = Path(a[caseindex])
         return sorted(model_cl_loc.glob(f"{case}_{variablename}_climo.nc"))
-
+        
+    def load_climo_dataset(self, case, variablename):
+        """Return Dataset for test climo of field"""
+        fils = self.get_climo_file(case, variablename)
+        if not fils:
+            warnings.warn(f"\t    WARNING: Did not find climo file(s) for case: {case}, variable: {variablename}")
+            return None
+        return self.load_dataset(fils)
+    
+    def load_climo_da(self, case, variablename):
+        """Return DataArray from test climo file"""
+        fils = self.get_climo_file(case, variablename)
+        if not fils:
+            warnings.warn(f"\t    WARNING: Did not find climo file(s) for case: {case}, variable: {variablename}")
+            return None
+        return self.load_da(fils, variablename, case)
 
     # Reference case (baseline/obs)
-    def load_reference_climo_da(self, case, variablename):
-        """Return DataArray from reference (aka baseline) climo file"""
-        add_offset, scale_factor = self.get_value_converters(case, variablename)
-        fils = self.get_reference_climo_file(variablename)
-        return self.load_da(fils, variablename, add_offset=add_offset, scale_factor=scale_factor)
-
     def get_reference_climo_file(self, var):
         """Return a list of files to be used as reference (aka baseline) for variable var."""
         if self.adf.compare_obs:
             fils = self.ref_var_loc.get(var, None)
             return [fils] if fils is not None else None
         ref_loc = self.adf.get_baseline_info("cam_climo_loc")
+        if not ref_loc:
+            return None
         # NOTE: originally had this looking for *_baseline.nc
         fils = sorted(Path(ref_loc).glob(f"{self.ref_case_label}_{var}_climo.nc"))
         if fils:
             return fils
         return None
+    
+    def load_reference_climo_dataset(self, field):
+        """Return Dataset for reference (aka baseline) climo of field"""
+        case = self.ref_case_label
+        fils = self.get_reference_climo_file(field)
+        if not fils:
+            warnings.warn(f"\t    WARNING: Did not find climo file(s) for case: {case}, variable: {field}")
+            return None
+        return self.load_dataset(fils)
+
+    def load_reference_climo_da(self, field):
+        """Return DataArray for reference (aka baseline) climo file"""
+        case = self.ref_case_label
+        fils = self.get_reference_climo_file(field)
+        if not fils:
+            warnings.warn(f"\t    WARNING: Did not find climo file(s) for case: {case}, variable: {field}")
+            return None
+        return self.load_da(fils, field, case)
 
     #------------------
 
     
     # Regridded files
     #------------------
-
     # Test case(s)
     def get_regrid_file(self, case, field):
         """Return list of test regridded files"""
@@ -234,29 +221,26 @@ class AdfData:
         rlbl = self.ref_labels[field]  # rlbl = "reference label" = the name of the reference data that defines target grid
         return sorted(model_rg_loc.glob(f"{rlbl}_{case}_{field}_regridded.nc"))
 
-
     def load_regrid_dataset(self, case, field):
-        """Return a data set to be used as reference (aka baseline) for variable field."""
+        """Return a data set to be used as for test variable field."""
         fils = self.get_regrid_file(case, field)
         if not fils:
             warnings.warn(f"\t    WARNING: Did not find regrid file(s) for case: {case}, variable: {field}")
             return None
         return self.load_dataset(fils)
 
-    
     def load_regrid_da(self, case, field):
-        """Return a data array to be used as reference (aka baseline) for variable field."""
-        add_offset, scale_factor = self.get_value_converters(case, field)
+        """Return a data array to be used for test variable field."""
         fils = self.get_regrid_file(case, field)
         if not fils:
             warnings.warn(f"\t    WARNING: Did not find regrid file(s) for case: {case}, variable: {field}")
             return None
-        return self.load_da(fils, field, add_offset=add_offset, scale_factor=scale_factor)
-
+        return self.load_da(fils, field, case)
 
     # Reference case (baseline/obs)
-    def get_ref_regrid_file(self, case, field):
+    def get_ref_regrid_file(self, field):
         """Return list of reference regridded files"""
+        case = self.ref_case_label
         if self.adf.compare_obs:
             obs_loc = self.ref_var_loc.get(field, None)
             if obs_loc:
@@ -268,20 +252,19 @@ class AdfData:
             fils = sorted(model_rg_loc.glob(f"{case}_{field}_baseline.nc"))
         return fils
 
-
-    def load_reference_regrid_dataset(self, case, field):
+    def load_reference_regrid_dataset(self, field):
         """Return a data set to be used as reference (aka baseline) for variable field."""
-        fils = self.get_ref_regrid_file(case, field)
+        case = self.ref_case_label
+        fils = self.get_ref_regrid_file(field)
         if not fils:
             warnings.warn(f"\t    WARNING: Did not find regridded file(s) for case: {case}, variable: {field}")
             return None
         return self.load_dataset(fils)
 
-    
-    def load_reference_regrid_da(self, case, field):
+    def load_reference_regrid_da(self, field):
         """Return a data array to be used as reference (aka baseline) for variable field."""
-        add_offset, scale_factor = self.get_value_converters(case, field)
-        fils = self.get_ref_regrid_file(case, field)
+        case = self.ref_case_label
+        fils = self.get_ref_regrid_file(field)
         if not fils:
             warnings.warn(f"\t    WARNING: Did not find regridded file(s) for case: {case}, variable: {field}")
             return None
@@ -289,16 +272,15 @@ class AdfData:
         # listed in variable defaults for this observation field
         if self.adf.compare_obs:
             field = self.ref_var_nam[field]
-        return self.load_da(fils, field, add_offset=add_offset, scale_factor=scale_factor)
+        return self.load_da(fils, field, case)
 
     #------------------
 
 
     # DataSet and DataArray load
     #---------------------------
-
     # Load DataSet
-    def load_dataset(self, fils):
+    def load_dataset(self, fils, type=None):
         """Return xarray DataSet from file(s)"""
         if (len(fils) == 0):
             warnings.warn("\t    WARNING: Input file list is empty.")
@@ -313,24 +295,43 @@ class AdfData:
             ds = xr.open_dataset(sfil)
         if ds is None:
             warnings.warn(f"\t    WARNING: invalid data on load_dataset")
+        if type == "tseries":
+            # assign time to midpoint of interval (even if it is already)
+            if 'time_bnds' in ds:
+                t = ds['time_bnds'].mean(dim='nbnd')
+                t.attrs = ds['time'].attrs
+                ds = ds.assign_coords({'time':t})
+            elif 'time_bounds' in ds:
+                t = ds['time_bounds'].mean(dim='nbnd')
+                t.attrs = ds['time'].attrs
+                ds = ds.assign_coords({'time':t})
+            else:
+                warnings.warn("\t    INFO: dataset does not have time bounds info.")
         return ds
 
     # Load DataArray
-    def load_da(self, fils, variablename, **kwargs):
+    def load_da(self, fils, variablename, case, type=None):
         """Return xarray DataArray from files(s) w/ optional scale factor, offset, and/or new units"""
         ds = self.load_dataset(fils)
         if ds is None:
             warnings.warn(f"\t    WARNING: Load failed for {variablename}")
             return None
         da = (ds[variablename]).squeeze()
-        scale_factor = kwargs.get('scale_factor', 1)
-        add_offset = kwargs.get('add_offset', 0)
+        units = da.attrs.get('units', 'none')
+        add_offset, scale_factor = self.get_value_converters(case, variablename)
         da = da * scale_factor + add_offset
+        da.attrs['scale_factor'] = scale_factor
+        da.attrs['add_offset'] = add_offset
+        da = self.update_unit(variablename, da, units)
+        da.attrs['original_unit'] = units
+        return da
+
+    def update_unit(self, variablename, da, units):
         if variablename in self.adf.variable_defaults:
             vres = self.adf.variable_defaults[variablename]
-            da.attrs['units'] = vres.get("new_unit", da.attrs.get('units', 'none'))
+            da.attrs['units'] = vres.get("new_unit", units)
         else:
-            da.attrs['units'] = 'none'
+            da.attrs['units'] = '--'
         return da
 
     # Get variable conversion defaults, if applicable

--- a/lib/adf_variable_defaults.yaml
+++ b/lib/adf_variable_defaults.yaml
@@ -152,9 +152,6 @@ AODDUST:
   diff_contour_range: [-0.06, 0.06, 0.01]
   scale_factor: 1
   add_offset: 0
-  new_unit: ""
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
 
 AODVIS:
   category: "Aerosols"
@@ -164,9 +161,6 @@ AODVIS:
   diff_contour_range: [-0.1, 0.1, 0.01]
   scale_factor: 1
   add_offset: 0
-  new_unit: ""
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
 
 AODVISdn:
   category: "Aerosols"
@@ -176,21 +170,19 @@ AODVISdn:
   diff_contour_range: [-0.4, 0.401, 0.05]
   scale_factor: 1
   add_offset: 0
-  new_unit: ""
   obs_file: "MOD08_M3_192x288_AOD_2001-2020_climo.nc"
   obs_name: "MODIS"
   obs_var_name: "AOD_550_Dark_Target_Deep_Blue_Combined_Mean_Mean"
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
 
 BURDENBC:
   category: "Aerosols"
   colormap: "plasma_r"
   scale_factor: 1000000
   add_offset: 0
-  new_unit: 'g m$^{-2}$'
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
+  new_unit: 'g/m2'
+  mpl:
+    colorbar:
+      label : 'g m$^{-2}$'
   diff_colormap: "RdBu_r"
   obs_file: "BURDENBC_MERRA2_monthly_climo_1degree_200001-202506.nc"
   obs_var_name: "BURDENBC"
@@ -203,9 +195,10 @@ BURDENDUST:
   colormap: "plasma_r"
   scale_factor: 1000000
   add_offset: 0
-  new_unit: 'g m$^{-2}$'
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
+  new_unit: 'g/m2'
+  mpl:
+    colorbar:
+      label : 'g m$^{-2}$'
   diff_contour_range: [-1000, 1100, 100]
   diff_colormap: "RdBu_r"
   obs_file: "BURDENDUST_CAMS_monthly_climo_1degree_200301-202412.nc"
@@ -219,9 +212,10 @@ BURDENPOM:
   colormap: "plasma_r"
   scale_factor: 1000000
   add_offset: 0
-  new_unit: 'g m$^{-2}$'
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
+  new_unit: 'g/m2'
+  mpl:
+    colorbar:
+      label : 'g m$^{-2}$'
   diff_colormap: "RdBu_r"
 
 
@@ -230,11 +224,12 @@ BURDENSEASALT:
   colormap: "plasma_r"
   scale_factor: 1000000
   add_offset: 0
-  new_unit: 'g m$^{-2}$'
+  new_unit: 'g/m2'
+  mpl:
+    colorbar:
+      label : 'g m$^{-2}$'
   diff_contour_range: [-200, 200, 25]
   diff_colormap: "RdBu_r"
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
   obs_file: "BURDENSEASALT_CAMS_monthly_climo_1degree_200301-202412.nc"
   obs_var_name: "BURDENSEASALT"
   obs_name: "CAMS"
@@ -246,9 +241,10 @@ BURDENSO4:
   colormap: "plasma_r"
   scale_factor: 1000000
   add_offset: 0
-  new_unit: 'g m$^{-2}$'
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
+  new_unit: 'g/m2'
+  mpl:
+    colorbar:
+      label : 'g m$^{-2}$'
   diff_colormap: "RdBu_r"
   obs_file: "BURDENSO4_CAMS_monthly_climo_1degree_200301-202412.nc"
   obs_name: "CAMS"
@@ -261,17 +257,16 @@ BURDENSOA:
   colormap: "plasma_r"
   scale_factor: 1000000
   add_offset: 0
-  new_unit: 'g m$^{-2}$'
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
+  new_unit: 'g/m2'
+  mpl:
+    colorbar:
+      label : 'g m$^{-2}$'
   diff_colormap: "RdBu_r"
 
 DMS:
   category: "Aerosols"
   colormap: "jet"
   diff_colormap: "gist_ncar"
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
   scale_factor: 1000000000.0
   new_unit: "ppbv"
 
@@ -279,8 +274,6 @@ SO2:
   category: "Aerosols"
   colormap: "jet"
   diff_colormap: "gist_ncar"
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
   scale_factor: 1000000000.0
   new_unit: "ppbv"
 
@@ -288,8 +281,6 @@ SOAG:
   category: "Aerosols"
   colormap: "jet"
   diff_colormap: "gist_ncar"
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
   scale_factor: 1000000000.0
   new_unit: "ppbv"
 
@@ -298,58 +289,50 @@ BC:
   diff_colormap: "BrBG"
   scale_factor: 1000000000
   add_offset: 0
-  new_unit: '$\mu$g/m3'
+  new_unit: 'mu g/m3'
   mpl:
     colorbar:
       label : '$\mu$g/m3'
   category: "Aerosols"
   derivable_from: ["bc_a1", "bc_a4"]
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
 
 POM:
   colormap: "RdBu_r"
   diff_colormap: "BrBG"
   scale_factor: 1000000000
   add_offset: 0
-  new_unit: '$\mu$g/m3'
+  new_unit: 'mu g/m3'
   mpl:
     colorbar:
       label : '$\mu$g/m3'
   category: "Aerosols"
   derivable_from: ["pom_a1", "pom_a4"]
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
 
 SO4:
   colormap: "RdBu_r"
   diff_colormap: "BrBG"
   scale_factor: 1000000000
   add_offset: 0
-  new_unit: '$\mu$g/m3'
+  new_unit: 'mu g/m3'
   mpl:
     colorbar:
       label : '$\mu$g/m3'
   category: "Aerosols"
   derivable_from: ["so4_a1", "so4_a2", "so4_a3"]
   derivable_from_cam_chem: ["so4_a1", "so4_a2", "so4_a3", "so4_a5"]
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
 
 SOA:
   colormap: "RdBu_r"
   diff_colormap: "BrBG"
   scale_factor: 1000000000
   add_offset: 0
-  new_unit: '$\mu$g/m3'
+  new_unit: 'mu g/m3'
   mpl:
     colorbar:
       label : '$\mu$g/m3'
   category: "Aerosols"
   derivable_from: ["soa_a1", "soa_a2"]
   derivable_from_cam_chem: ["soa1_a1", "soa2_a1", "soa3_a1", "soa4_a1", "soa5_a1", "soa1_a2", "soa2_a2", "soa3_a2", "soa4_a2", "soa5_a2"]
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
 
 DUST:
   colormap: "RdBu_r"
@@ -358,14 +341,12 @@ DUST:
   diff_colormap: "BrBG"
   scale_factor: 1000000000
   add_offset: 0
-  new_unit: '$\mu$g/m3'
+  new_unit: 'mu g/m3'
   mpl:
     colorbar:
       label : '$\mu$g/m3'
   category: "Aerosols"
   derivable_from: ["dst_a1", "dst_a2", "dst_a3"]
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
 
 SeaSalt:
   colormap: "RdBu_r"
@@ -374,7 +355,7 @@ SeaSalt:
   diff_colormap: "BrBG"
   scale_factor: 1000000000
   add_offset: 0
-  new_unit: '$\mu$g/m3'
+  new_unit: 'mu g/m3'
   mpl:
     colorbar:
       label : '$\mu$g/m3'
@@ -384,8 +365,6 @@ SeaSalt:
       ticks: [-10,8,6,4,2,0,-2,-4,-6,-8,-10]
   category: "Aerosols"
   derivable_from: ["ncl_a1", "ncl_a2", "ncl_a3"]
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
   
 bc_a1:
   category: "Aerosols"
@@ -393,184 +372,138 @@ bc_a1:
   diff_colormap: "gist_ncar"
   scale_factor: 1.0e-9
   new_unit: "ug/kg"
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
 bc_a4:
   category: "Aerosols"
   colormap: "jet"
   diff_colormap: "gist_ncar"
   scale_factor: 1.0e-9
   new_unit: "ug/kg"
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
 dst_a1:
   category: "Aerosols"
   colormap: "jet"
   diff_colormap: "gist_ncar"
   scale_factor: 1.0e-9
   new_unit: "ug/kg"
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
 dst_a2:
   category: "Aerosols"
   colormap: "jet"
   diff_colormap: "gist_ncar"
   scale_factor: 1.0e-9
   new_unit: "ug/kg"
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
 dst_a3:
   category: "Aerosols"
   colormap: "jet"
   diff_colormap: "gist_ncar"
   scale_factor: 1.0e-9
   new_unit: "ug/kg"
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
 ncl_a1:
   category: "Aerosols"
   colormap: "jet"
   diff_colormap: "gist_ncar"
   scale_factor: 1.0e-9
   new_unit: "ug/kg"
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
 ncl_a2:
   category: "Aerosols"
   colormap: "jet"
   diff_colormap: "gist_ncar"
   scale_factor: 1.0e-9
   new_unit: "ug/kg"
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
 ncl_a3:
   category: "Aerosols"
   colormap: "jet"
   diff_colormap: "gist_ncar"
   scale_factor: 1.0e-9
   new_unit: "ug/kg"
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
 num_a1:
   category: "Aerosols"
   colormap: "jet"
   diff_colormap: "gist_ncar"
   scale_factor: 1.0e-9
   new_unit: "ug/kg"
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
 num_a2:
   category: "Aerosols"
   colormap: "jet"
   diff_colormap: "gist_ncar"
   scale_factor: 1.0e-9
   new_unit: "ug/kg"
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
 num_a3:
   category: "Aerosols"
   colormap: "jet"
   diff_colormap: "gist_ncar"
   scale_factor: 1.0e-9
   new_unit: "ug/kg"
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
 num_a4:
   category: "Aerosols"
   colormap: "jet"
   diff_colormap: "gist_ncar"
   scale_factor: 1.0e-9
   new_unit: "ug/kg"
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
 num_a5:
   category: "Aerosols"
   colormap: "jet"
   diff_colormap: "gist_ncar"
   scale_factor: 1.0e-9
   new_unit: "ug/kg"
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
 pom_a1:
   category: "Aerosols"
   colormap: "jet"
   diff_colormap: "gist_ncar"
   scale_factor: 1.0e-9
   new_unit: "ug/kg"
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
 pom_a4:
   category: "Aerosols"
   colormap: "jet"
   diff_colormap: "gist_ncar"
   scale_factor: 1.0e-9
   new_unit: "ug/kg"
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
 so4_a1:
   category: "Aerosols"
   colormap: "jet"
   diff_colormap: "gist_ncar"
   scale_factor: 1.0e-9
   new_unit: "ug/kg"
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
 so4_a2:
   category: "Aerosols"
   colormap: "jet"
   diff_colormap: "gist_ncar"
   scale_factor: 1.0e-9
   new_unit: "ug/kg"
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
 so4_a3:
   category: "Aerosols"
   colormap: "jet"
   diff_colormap: "gist_ncar"
   scale_factor: 1.0e-9
   new_unit: "ug/kg"
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
 soa_a1:
   category: "Aerosols"
   colormap: "jet"
   diff_colormap: "gist_ncar"
   scale_factor: 1.0e-9
   new_unit: "ug/kg"
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
 soa_a2:
   category: "Aerosols"
   colormap: "jet"
   diff_colormap: "gist_ncar"
   scale_factor: 1.0e-9
   new_unit: "ug/kg"
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
 SAD_TROP:
   category: "Aerosols"
   colormap: "jet"
   diff_colormap: "gist_ncar"
   scale_factor: 1.0
   new_unit: "cm2/cm3"
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
 SAD_AERO:
   category: "Aerosols"
   colormap: "jet"
   diff_colormap: "gist_ncar"
   scale_factor: 1.0
   new_unit: "cm2/cm3"
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
 SAD_SULFC:
   category: "Aerosols"
   colormap: "jet"
   diff_colormap: "gist_ncar"
   scale_factor: 1.0
   new_unit: "cm2/cm3"
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
 
 #+++++++++++++++++
 # Category: Budget
@@ -652,456 +585,342 @@ CO:
   category: "Composition"
   colormap: "jet"
   diff_colormap: "gist_ncar"
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
   scale_factor: 1000000000.0
   new_unit: "ppbv"
 CO01:
   category: "Composition"
   colormap: "jet"
   diff_colormap: "gist_ncar"
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
   scale_factor: 1000000000.0
   new_unit: "ppbv"
 CO02:
   category: "Composition"
   colormap: "jet"
   diff_colormap: "gist_ncar"
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
   scale_factor: 1000000000.0
   new_unit: "ppbv"
 CO03:
   category: "Composition"
   colormap: "jet"
   diff_colormap: "gist_ncar"
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
   scale_factor: 1000000000.0
   new_unit: "ppbv"
 CO04:
   category: "Composition"
   colormap: "jet"
   diff_colormap: "gist_ncar"
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
   scale_factor: 1000000000.0
   new_unit: "ppbv"
 CO05:
   category: "Composition"
   colormap: "jet"
   diff_colormap: "gist_ncar"
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
   scale_factor: 1000000000.0
   new_unit: "ppbv"
 CO06:
   category: "Composition"
   colormap: "jet"
   diff_colormap: "gist_ncar"
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
   scale_factor: 1000000000.0
   new_unit: "ppbv"
 CO07:
   category: "Composition"
   colormap: "jet"
   diff_colormap: "gist_ncar"
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
   scale_factor: 1000000000.0
   new_unit: "ppbv"
 CO08:
   category: "Composition"
   colormap: "jet"
   diff_colormap: "gist_ncar"
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
   scale_factor: 1000000000.0
   new_unit: "ppbv"
 CO09:
   category: "Composition"
   colormap: "jet"
   diff_colormap: "gist_ncar"
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
   scale_factor: 1000000000.0
   new_unit: "ppbv"
 CO10:
   category: "Composition"
   colormap: "jet"
   diff_colormap: "gist_ncar"
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
   scale_factor: 1000000000.0
   new_unit: "ppbv"
 CO11:
   category: "Composition"
   colormap: "jet"
   diff_colormap: "gist_ncar"
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
   scale_factor: 1000000000.0
   new_unit: "ppbv"
 CO12:
   category: "Composition"
   colormap: "jet"
   diff_colormap: "gist_ncar"
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
   scale_factor: 1000000000.0
   new_unit: "ppbv"
 CO13:
   category: "Composition"
   colormap: "jet"
   diff_colormap: "gist_ncar"
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
   scale_factor: 1000000000.0
   new_unit: "ppbv"
 O3:
   category: "Composition"
   colormap: "jet"
   diff_colormap: "gist_ncar"
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
   scale_factor: 1000000000.0
   new_unit: "ppbv"
 N2O:
   category: "Composition"
   colormap: "jet"
   diff_colormap: "gist_ncar"
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
   scale_factor: 1000000000.0
   new_unit: "ppbv"
 HNO3:
   category: "Composition"
   colormap: "jet"
   diff_colormap: "gist_ncar"
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
   scale_factor: 1000000000.0
   new_unit: "ppbv"
 NO:
   category: "Composition"
   colormap: "jet"
   diff_colormap: "gist_ncar"
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
   scale_factor: 1000000000000.0
   new_unit: "pptv"
 NO2:
   category: "Composition"
   colormap: "jet"
   diff_colormap: "gist_ncar"
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
   scale_factor: 1000000000000.0
   new_unit: "pptv"
 NOX:
   category: "Composition"
   colormap: "jet"
   diff_colormap: "gist_ncar"
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
   scale_factor: 1000000000000.0
   new_unit: "pptv"
 NOY:
   category: "Composition"
   colormap: "jet"
   diff_colormap: "gist_ncar"
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
   scale_factor: 1000000000000.0
   new_unit: "pptv"
 OH:
   category: "Composition"
   colormap: "jet"
   diff_colormap: "gist_ncar"
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
   scale_factor: 1000000000000.0
   new_unit: "pptv"
 BIGALK:
   category: "Composition"
   colormap: "jet"
   diff_colormap: "gist_ncar"
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
   scale_factor: 1000000000.0
   new_unit: "ppbv"
 C2H4:
   category: "Composition"
   colormap: "jet"
   diff_colormap: "gist_ncar"
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
   scale_factor: 1000000000.0
   new_unit: "ppbv"
 C2H5O2:
   category: "Composition"
   colormap: "jet"
   diff_colormap: "gist_ncar"
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
   scale_factor: 1000000000.0
   new_unit: "ppbv"
 C2H5OH:
   category: "Composition"
   colormap: "jet"
   diff_colormap: "gist_ncar"
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
   scale_factor: 1000000000.0
   new_unit: "ppbv"
 C2H5OOH:
   category: "Composition"
   colormap: "jet"
   diff_colormap: "gist_ncar"
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
   scale_factor: 1000000000.0
   new_unit: "ppbv"
 C2H6:
   category: "Composition"
   colormap: "jet"
   diff_colormap: "gist_ncar"
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
   scale_factor: 1000000000.0
   new_unit: "ppbv"
 C3H6:
   category: "Composition"
   colormap: "jet"
   diff_colormap: "gist_ncar"
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
   scale_factor: 1000000000.0
   new_unit: "ppbv"
 C3H7O2:
   category: "Composition"
   colormap: "jet"
   diff_colormap: "gist_ncar"
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
   scale_factor: 1000000000.0
   new_unit: "ppbv"
 C3H7OOH:
   category: "Composition"
   colormap: "jet"
   diff_colormap: "gist_ncar"
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
   scale_factor: 1000000000.0
   new_unit: "ppbv"
 C3H8:
   category: "Composition"
   colormap: "jet"
   diff_colormap: "gist_ncar"
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
   scale_factor: 1000000000.0
   new_unit: "ppbv"
 CCL4:
   category: "Composition"
   colormap: "jet"
   diff_colormap: "gist_ncar"
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
   scale_factor: 1000000000.0
   new_unit: "ppbv"
 CFC11:
   category: "Composition"
   colormap: "jet"
   diff_colormap: "gist_ncar"
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
   scale_factor: 1000000000.0
   new_unit: "ppbv"
 CFC113:
   category: "Composition"
   colormap: "jet"
   diff_colormap: "gist_ncar"
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
   scale_factor: 1000000000.0
   new_unit: "ppbv"
 CFC114:
   category: "Composition"
   colormap: "jet"
   diff_colormap: "gist_ncar"
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
   scale_factor: 1000000000.0
   new_unit: "ppbv"
 CFC115:
   category: "Composition"
   colormap: "jet"
   diff_colormap: "gist_ncar"
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
   scale_factor: 1000000000.0
   new_unit: "ppbv"
 CFC12:
   category: "Composition"
   colormap: "jet"
   diff_colormap: "gist_ncar"
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
   scale_factor: 1000000000.0
   new_unit: "ppbv"
 CH2O:
   category: "Composition"
   colormap: "jet"
   diff_colormap: "gist_ncar"
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
   scale_factor: 1000000000.0
   new_unit: "ppbv"
 CH3BR:
   category: "Composition"
   colormap: "jet"
   diff_colormap: "gist_ncar"
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
   scale_factor: 1000000000.0
   new_unit: "ppbv"
 CH3CCL3:
   category: "Composition"
   colormap: "jet"
   diff_colormap: "gist_ncar"
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
   scale_factor: 1000000000.0
   new_unit: "ppbv"
 CH3CHO:
   category: "Composition"
   colormap: "jet"
   diff_colormap: "gist_ncar"
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
   scale_factor: 1000000000.0
   new_unit: "ppbv"
 CH3CL:
   category: "Composition"
   colormap: "jet"
   diff_colormap: "gist_ncar"
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
   scale_factor: 1000000000.0
   new_unit: "ppbv"
 CH3CO3:
   category: "Composition"
   colormap: "jet"
   diff_colormap: "gist_ncar"
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
   scale_factor: 1000000000.0
   new_unit: "ppbv"
 CH3COCH3:
   category: "Composition"
   colormap: "jet"
   diff_colormap: "gist_ncar"
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
   scale_factor: 1000000000.0
   new_unit: "ppbv"
 CH3COCHO:
   category: "Composition"
   colormap: "jet"
   diff_colormap: "gist_ncar"
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
   scale_factor: 1000000000.0
   new_unit: "ppbv"
 CH3COOH:
   category: "Composition"
   colormap: "jet"
   diff_colormap: "gist_ncar"
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
   scale_factor: 1000000000.0
   new_unit: "ppbv"
 CH3COOOH:
   category: "Composition"
   colormap: "jet"
   diff_colormap: "gist_ncar"
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
   scale_factor: 1000000000.0
   new_unit: "ppbv"
 CH3O2:
   category: "Composition"
   colormap: "jet"
   diff_colormap: "gist_ncar"
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
   scale_factor: 1000000000.0
   new_unit: "ppbv"
 CH3OH:
   category: "Composition"
   colormap: "jet"
   diff_colormap: "gist_ncar"
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
   scale_factor: 1000000000.0
   new_unit: "ppbv"
 CH3OOH:
   category: "Composition"
   colormap: "jet"
   diff_colormap: "gist_ncar"
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
   scale_factor: 1000000000.0
   new_unit: "ppbv"
 CH4:
   category: "Composition"
   colormap: "jet"
   diff_colormap: "gist_ncar"
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
   scale_factor: 1000000000.0
   new_unit: "ppbv"
 CHBR3:
   category: "Composition"
   colormap: "jet"
   diff_colormap: "gist_ncar"
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
   scale_factor: 1000000000.0
   new_unit: "ppbv"
 CLO:
   category: "Composition"
   colormap: "jet"
   diff_colormap: "gist_ncar"
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
   scale_factor: 1000000000.0
   new_unit: "ppbv"
 CLONO2:
   category: "Composition"
   colormap: "jet"
   diff_colormap: "gist_ncar"
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
   scale_factor: 1000000000.0
   new_unit: "ppbv"
 CLOX:
   category: "Composition"
   colormap: "jet"
   diff_colormap: "gist_ncar"
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
   scale_factor: 1000000000.0
   new_unit: "ppbv"
 CLOY:
   category: "Composition"
   colormap: "jet"
   diff_colormap: "gist_ncar"
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
   scale_factor: 1000000000.0
   new_unit: "ppbv"
 CO2:
@@ -1109,344 +928,258 @@ CO2:
   #contour_levels_range: [300,450,10.0]
   colormap: "jet"
   diff_colormap: "gist_ncar"
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
   scale_factor: 1000000.0
   new_unit: "ppmv"
 E90:
   category: "Composition"
   colormap: "jet"
   diff_colormap: "gist_ncar"
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
   scale_factor: 1000000000.0
   new_unit: "ppbv"
 GLYALD:
   category: "Composition"
   colormap: "jet"
   diff_colormap: "gist_ncar"
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
   scale_factor: 1000000000.0
   new_unit: "ppbv"
 GLYOXAL:
   category: "Composition"
   colormap: "jet"
   diff_colormap: "gist_ncar"
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
   scale_factor: 1000000000.0
   new_unit: "ppbv"
 H2402:
   category: "Composition"
   colormap: "jet"
   diff_colormap: "gist_ncar"
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
   scale_factor: 1000000000.0
   new_unit: "ppbv"
 H2O2:
   category: "Composition"
   colormap: "jet"
   diff_colormap: "gist_ncar"
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
   scale_factor: 1000000000.0
   new_unit: "ppbv"
 H2SO4:
   category: "Composition"
   colormap: "jet"
   diff_colormap: "gist_ncar"
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
   scale_factor: 1000000000.0
   new_unit: "ppbv"
 HCFC141B:
   category: "Composition"
   colormap: "jet"
   diff_colormap: "gist_ncar"
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
   scale_factor: 1000000000.0
   new_unit: "ppbv"
 HCFC142B:
   category: "Composition"
   colormap: "jet"
   diff_colormap: "gist_ncar"
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
   scale_factor: 1000000000.0
   new_unit: "ppbv"
 HCFC22:
   category: "Composition"
   colormap: "jet"
   diff_colormap: "gist_ncar"
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
   scale_factor: 1000000000.0
   new_unit: "ppbv"
 HCL:
   category: "Composition"
   colormap: "jet"
   diff_colormap: "gist_ncar"
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
   scale_factor: 1000000000.0
   new_unit: "ppbv"
 HCL_GAS:
   category: "Composition"
   colormap: "jet"
   diff_colormap: "gist_ncar"
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
   scale_factor: 1000000000.0
   new_unit: "ppbv"
 HNO3_GAS:
   category: "Composition"
   colormap: "jet"
   diff_colormap: "gist_ncar"
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
   scale_factor: 1000000000.0
   new_unit: "ppbv"
 HO2:
   category: "Composition"
   colormap: "jet"
   diff_colormap: "gist_ncar"
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
   scale_factor: 1000000000.0
   new_unit: "ppbv"
 HO2NO2:
   category: "Composition"
   colormap: "jet"
   diff_colormap: "gist_ncar"
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
   scale_factor: 1000000000.0
   new_unit: "ppbv"
 HOBR:
   category: "Composition"
   colormap: "jet"
   diff_colormap: "gist_ncar"
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
   scale_factor: 1000000000.0
   new_unit: "ppbv"
 HYAC:
   category: "Composition"
   colormap: "jet"
   diff_colormap: "gist_ncar"
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
   scale_factor: 1000000000.0
   new_unit: "ppbv"
 HYDRALD:
   category: "Composition"
   colormap: "jet"
   diff_colormap: "gist_ncar"
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
   scale_factor: 1000000000.0
   new_unit: "ppbv"
 ISOP:
   category: "Composition"
   colormap: "jet"
   diff_colormap: "gist_ncar"
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
   scale_factor: 1000000000.0
   new_unit: "ppbv"
 ISOPNO3:
   category: "Composition"
   colormap: "jet"
   diff_colormap: "gist_ncar"
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
   scale_factor: 1000000000.0
   new_unit: "ppbv"
 ISOPO2:
   category: "Composition"
   colormap: "jet"
   diff_colormap: "gist_ncar"
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
   scale_factor: 1000000000.0
   new_unit: "ppbv"
 ISOPOOH:
   category: "Composition"
   colormap: "jet"
   diff_colormap: "gist_ncar"
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
   scale_factor: 1000000000.0
   new_unit: "ppbv"
 MACR:
   category: "Composition"
   colormap: "jet"
   diff_colormap: "gist_ncar"
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
   scale_factor: 1000000000.0
   new_unit: "ppbv"
 MACRO2:
   category: "Composition"
   colormap: "jet"
   diff_colormap: "gist_ncar"
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
   scale_factor: 1000000000.0
   new_unit: "ppbv"
 MACROOH:
   category: "Composition"
   colormap: "jet"
   diff_colormap: "gist_ncar"
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
   scale_factor: 1000000000.0
   new_unit: "ppbv"
 MVK:
   category: "Composition"
   colormap: "jet"
   diff_colormap: "gist_ncar"
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
   scale_factor: 1000000000.0
   new_unit: "ppbv"
 N2O5:
   category: "Composition"
   colormap: "jet"
   diff_colormap: "gist_ncar"
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
   scale_factor: 1000000000.0
   new_unit: "ppbv"
 NH3:
   category: "Composition"
   colormap: "jet"
   diff_colormap: "gist_ncar"
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
   scale_factor: 1000000000.0
   new_unit: "ppbv"
 NH4:
   category: "Composition"
   colormap: "jet"
   diff_colormap: "gist_ncar"
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
   scale_factor: 1000000000.0
   new_unit: "ppbv"
 NO3:
   category: "Composition"
   colormap: "jet"
   diff_colormap: "gist_ncar"
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
   scale_factor: 1000000000.0
   new_unit: "ppbv"
 O3S:
   category: "Composition"
   colormap: "jet"
   diff_colormap: "gist_ncar"
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
   scale_factor: 1000000000.0
   new_unit: "ppbv"
 OCLO:
   category: "Composition"
   colormap: "jet"
   diff_colormap: "gist_ncar"
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
   scale_factor: 1000000000.0
   new_unit: "ppbv"
 OCS:
   category: "Composition"
   colormap: "jet"
   diff_colormap: "gist_ncar"
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
   scale_factor: 1000000000.0
   new_unit: "ppbv"
 ONITR:
   category: "Composition"
   colormap: "jet"
   diff_colormap: "gist_ncar"
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
   scale_factor: 1000000000.0
   new_unit: "ppbv"
 PAN:
   category: "Composition"
   colormap: "jet"
   diff_colormap: "gist_ncar"
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
   scale_factor: 1000000000.0
   new_unit: "ppbv"
 POOH:
   category: "Composition"
   colormap: "jet"
   diff_colormap: "gist_ncar"
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
   scale_factor: 1000000000.0
   new_unit: "ppbv"
 RO2:
   category: "Composition"
   colormap: "jet"
   diff_colormap: "gist_ncar"
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
   scale_factor: 1000000000.0
   new_unit: "ppbv"
 ROOH:
   category: "Composition"
   colormap: "jet"
   diff_colormap: "gist_ncar"
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
   scale_factor: 1000000000.0
   new_unit: "ppbv"
 SO3:
   category: "Composition"
   colormap: "jet"
   diff_colormap: "gist_ncar"
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
   scale_factor: 1000000000.0
   new_unit: "ppbv"
 SOAE:
   category: "Composition"
   colormap: "jet"
   diff_colormap: "gist_ncar"
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
   scale_factor: 1000000000.0
   new_unit: "ppbv"
 TERP:
   category: "Composition"
   colormap: "jet"
   diff_colormap: "gist_ncar"
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
   scale_factor: 1000000000.0
   new_unit: "ppbv"
 XO2:
   category: "Composition"
   colormap: "jet"
   diff_colormap: "gist_ncar"
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
   scale_factor: 1000000000.0
   new_unit: "ppbv"
 XOOH:
   category: "Composition"
   colormap: "jet"
   diff_colormap: "gist_ncar"
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
   scale_factor: 1000000000.0
   new_unit: "ppbv"
 
@@ -1460,16 +1193,12 @@ CLDICE:
   obs_file: "CLDICE_ERA5_monthly_climo_197901-202112.nc"
   obs_name: "ERA5"
   obs_var_name: "CLDICE"
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
 
 CLDLIQ:
   category: "Clouds"
   obs_file: "CLDLIQ_ERA5_monthly_climo_197901-202112.nc"
   obs_name: "ERA5"
   obs_var_name: "CLDLIQ"
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
 
 CLDTOT:
   colormap: "Oranges"
@@ -1483,8 +1212,6 @@ CLDTOT:
   obs_name: "ERAI"
   obs_var_name: "CLDTOT"
   category: "Clouds"
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
 
 CLDLOW:
   colormap: "Oranges"
@@ -1498,8 +1225,6 @@ CLDLOW:
   obs_name: "ERAI"
   obs_var_name: "CLDLOW"
   category: "Clouds"
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
 
 CLDHGH:
   colormap: "Oranges"
@@ -1513,8 +1238,6 @@ CLDHGH:
   obs_name: "ERAI"
   obs_var_name: "CLDHGH"
   category: "Clouds"
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
 
 CLDMED:
   colormap: "Oranges"
@@ -1528,8 +1251,6 @@ CLDMED:
   obs_name: "ERAI"
   obs_var_name: "CLDMED"
   category: "Clouds"
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
 
 CLOUD:
   colormap: "Blues"
@@ -1543,8 +1264,6 @@ CLOUD:
     colorbar:
       label : "Percent"
   category: "Clouds"
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
 
 CONCLD:
   category: "Clouds"
@@ -1556,7 +1275,7 @@ TGCLDLWP:
   diff_contour_range: [-100, 100, 10]
   scale_factor: 1000
   add_offset: 0
-  new_unit: "g m$^{-2}$"
+  new_unit: 'g/m2'
   mpl:
     colorbar:
       label : "g m$^{-2}$"
@@ -1566,8 +1285,6 @@ TGCLDLWP:
   obs_var_name: "TGCLDLWP"
   obs_scale_factor: 1000
   obs_add_offset: 0
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
 
 TGCLDIWP:
   colormap: "Blues"
@@ -1576,7 +1293,7 @@ TGCLDIWP:
   diff_contour_range: [-50, 50, 5]
   scale_factor: 1000
   add_offset: 0
-  new_unit: "g m$^{-2}$"
+  new_unit: 'g/m2'
   mpl:
     colorbar:
       label : "g m$^{-2}$"
@@ -1586,8 +1303,6 @@ TGCLDIWP:
   obs_var_name: "TGCLDIWP"
   obs_scale_factor: 1000
   obs_add_offset: 0
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
 
 CCN3:
   category: "Clouds"
@@ -1619,13 +1334,11 @@ PRECC:
   diff_contour_range: [-10, 10, 0.5]
   scale_factor: 86400000
   add_offset: 0
-  new_unit: "mm d$^{-1}$"
+  new_unit: "mm/d"
   mpl:
     colorbar:
       label : "mm/d"
   category: "Hydrologic cycle"
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
 
 PRECL:
   colormap: "Greens"
@@ -1634,13 +1347,11 @@ PRECL:
   diff_contour_range: [-10, 10, 0.5]
   scale_factor: 86400000
   add_offset: 0
-  new_unit: "mm d$^{-1}$"
+  new_unit: "mm/d"
   mpl:
     colorbar:
       label : "mm d$^{-1}$"
   category: "Hydrologic cycle"
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
 
 PRECSC:
   colormap: "Greens"
@@ -1649,13 +1360,11 @@ PRECSC:
   diff_contour_range: [-10, 10, 0.5]
   scale_factor: 86400000
   add_offset: 0
-  new_unit: "mm d$^{-1}$"
+  new_unit: "mm/d"
   mpl:
     colorbar:
       label : "mm d$^{-1}$"
   category: "Hydrologic cycle"
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
 
 PRECSL:
   colormap: "Greens"
@@ -1664,13 +1373,11 @@ PRECSL:
   diff_contour_range: [-10, 10, 0.5]
   scale_factor: 86400000
   add_offset: 0
-  new_unit: "mm d$^{-1}$"
+  new_unit: "mm/d"
   mpl:
     colorbar:
       label : "mm d$^{-1}$"
   category: "Hydrologic cycle"
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
 
 PRECT:
   colormap: "Blues"
@@ -1679,7 +1386,7 @@ PRECT:
   diff_contour_range: [-10, 10, 0.5]
   scale_factor: 86400000
   add_offset: 0
-  new_unit: "mm d$^{-1}$"
+  new_unit: "mm/d"
   mpl:
     colorbar:
       label : "mm d$^{-1}$"
@@ -1688,8 +1395,6 @@ PRECT:
   obs_var_name: "PRECT"
   category: "Hydrologic cycle"
   derivable_from: ['PRECL','PRECC']
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
 
 QFLX:
   category: "Hydrologic cycle"
@@ -1719,8 +1424,6 @@ PSL:
   obs_file: "PSL_ERA5_monthly_climo_197901-202112.nc"
   obs_name: "ERA5"
   obs_var_name: "PSL"
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
 
 PS:
   colormap: "Oranges"
@@ -1737,8 +1440,6 @@ PS:
   obs_file: "PS_ERA5_monthly_climo_197901-202112.nc"
   obs_name: "ERA5"
   obs_var_name: "PS"
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
 
 TREFHT:
   category: "Surface variables"
@@ -1761,8 +1462,6 @@ TS:
   obs_name: "ERAI"
   obs_var_name: "TS"
   category: "Surface variables"
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
 
 SST:
   colormap: "Blues"
@@ -1780,18 +1479,12 @@ SST:
   obs_var_name: "TS"
   category: "Surface variables"
   mask: "ocean"
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
 
 U10:
   category: "Surface variables"
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
 
 Surface_Wind_Stress:
   category: "Surface variables"
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
 
 TAUX:
   vector_pair: "TAUY"
@@ -1799,8 +1492,6 @@ TAUX:
   category: "Surface variables"
   scale_factor: -1
   add_offset: 0
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
 
 TAUY:
   vector_pair: "TAUX"
@@ -1808,23 +1499,15 @@ TAUY:
   category: "Surface variables"
   scale_factor: -1
   add_offset: 0
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
 
 ICEFRAC:
   category: "Surface variables"
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
 
 OCNFRAC:
   category: "Surface variables"
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
 
 LANDFRAC:
   category: "Surface variables"
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
 
 #+++++++++++++++++
 # Category: State
@@ -1837,13 +1520,14 @@ TMQ:
   diff_contour_range: [-10, 10, 0.5]
   scale_factor: 1.
   add_offset: 0
-  new_unit: "kg m$^{-2}$"
+  new_unit: "kg/m2"
+  mpl:
+    colorbar:
+      label : "kg m$^{-2}$"
   obs_file: "ERAI_all_climo.nc"
   obs_name: "ERAI"
   obs_var_name: "PREH2O"
   category: "State"
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
 
 RELHUM:
   colormap: "Blues"
@@ -1860,8 +1544,6 @@ RELHUM:
   obs_name: "ERAI"
   obs_var_name: "RELHUM"
   category: "State"
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
 
 U:
   colormap: "Blues"
@@ -1870,7 +1552,7 @@ U:
   diff_contour_range: [-15, 15, 2]
   scale_factor: 1
   add_offset: 0
-  new_unit: "ms$^{-1}$"
+  new_unit: "m/s"
   mpl:
     colorbar:
       label : "ms$^{-1}$"
@@ -1880,8 +1562,6 @@ U:
   vector_pair: "V"
   vector_name: "Wind"
   category: "State"
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
 
 V:
   colormap: "Blues"
@@ -1890,7 +1570,7 @@ V:
   diff_contour_range: [-15, 15, 2]
   scale_factor: 1
   add_offset: 0
-  new_unit: "ms$^{-1}$"
+  new_unit: "m/s"
   mpl:
     colorbar:
       label : "ms$^{-1}$"
@@ -1900,61 +1580,46 @@ V:
   vector_pair: "U"
   vector_name: "Wind"
   category: "State"
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
 
 Q:
   category: "State"
   obs_file: "Q_ERA5_monthly_climo_197901-202112.nc"
   obs_name: "ERA5"
   obs_var_name: "Q"
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
 
 T:
   category: "State"
   obs_file: "T_ERA5_monthly_climo_197901-202112.nc"
   obs_name: "ERA5"
   obs_var_name: "T"
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
 
 OMEGA:
   category: "State"
   obs_file: "OMEGA_ERA5_monthly_climo_197901-202112.nc"
   obs_name: "ERA5"
   obs_var_name: "OMEGA"
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
 
 OMEGA500:
   category: "State"
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
   scale_factor: 864
   add_offset: 0
-  new_unit: "hPa d$^{-1}$"
+  new_unit: "hPa/d"
+  mpl:
+    colorbar:
+      label : "hPa d$^{-1}$"
   hist_bins: [-105, -100,  -95,  -90,  -85,  -80,  -75,  -70,  -65,  -60,  -55, -50,  -45,  -40,  -35,  -30,  -25,  -20,  -15,  -10,   -5,    0, 5,   10,   15,   20,   25,   30,   35,   40,   45,   50,   55, 60,   65,   70,   75,   80,   85,   90,   95,  100]
 
 PINT:
   category: "State"
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
 
 PMID:
   category: "State"
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
 
 Z3:
   category: "State"
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
 
 Wind:
   category: "State"
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
 
 #+++++++++++++++++
 # Category: Radiation
@@ -1962,13 +1627,9 @@ Wind:
 
 QRL:
   category: "Radiation"
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
 
 QRS:
   category: "Radiation"
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
 
 #+++++++++++++++++
 # Category: TOA energy flux
@@ -1981,14 +1642,12 @@ RESTOM:
   diff_contour_range: [-10, 10, 0.5]
   scale_factor: 1
   add_offset: 0
-  new_unit: "W m$^{-2}$"
+  new_unit: "W/m2"
   mpl:
     colorbar:
       label : "W m$^{-2}$"
   category: "TOA energy flux"
   derivable_from: ['FLNT','FSNT']
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
 
 SWCF:
   colormap: "Blues"
@@ -1997,7 +1656,7 @@ SWCF:
   diff_contour_range: [-20, 20, 2]
   scale_factor: 1
   add_offset: 0
-  new_unit: "Wm$^{-2}$"
+  new_unit: "W/m2"
   mpl:
     colorbar:
       label : "Wm$^{-2}$"
@@ -2007,8 +1666,6 @@ SWCF:
   obs_scale_factor: 1
   obs_add_offset: 0
   category: "TOA energy flux"
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
 
 LWCF:
   colormap: "Oranges"
@@ -2017,7 +1674,7 @@ LWCF:
   diff_contour_range: [-15, 15, 1]
   scale_factor: 1
   add_offset: 0
-  new_unit: "Wm$^{-2}$"
+  new_unit: "W/m2"
   mpl:
     colorbar:
       label : "Wm$^{-2}$"
@@ -2025,8 +1682,6 @@ LWCF:
   obs_name: "CERES_EBAF_Ed4.1"
   obs_var_name: "toa_cre_lw_mon"
   category: "TOA energy flux"
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
 
 FSUTOA:
   colormap: "Blues"
@@ -2035,13 +1690,11 @@ FSUTOA:
   diff_contour_range: [-15, 15, 1]
   scale_factor: 1
   add_offset: 0
-  new_unit: "Wm$^{-2}$"
+  new_unit: "W/m2"
   mpl:
     colorbar:
       label : "Wm$^{-2}$"
   category: "TOA energy flux"
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
 
 FSNT:
   colormap: "Blues"
@@ -2050,7 +1703,7 @@ FSNT:
   diff_contour_range: [-20, 20, 2]
   scale_factor: 1
   add_offset: 0
-  new_unit: "Wm$^{-2}$"
+  new_unit: "W/m2"
   mpl:
     colorbar:
       label : "Wm$^{-2}$"
@@ -2058,23 +1711,15 @@ FSNT:
   obs_name: "CERES_EBAF_Ed4.1"
   obs_var_name: "fsnt"
   category: "TOA energy flux"
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
 
 FSNTC:
   category: "TOA energy flux"
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
 
 FSNTOA:
   category: "TOA energy flux"
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
 
 FLUT:
   category: "TOA energy flux"
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
 
 FLNT:
   colormap: "Oranges"
@@ -2083,7 +1728,7 @@ FLNT:
   diff_contour_range: [-20, 20, 2]
   scale_factor: 1
   add_offset: 0
-  new_unit: "Wm$^{-2}$"
+  new_unit: "W/m2"
   mpl:
     colorbar:
       label : "Wm$^{-2}$"
@@ -2091,8 +1736,6 @@ FLNT:
   obs_name: "CERES_EBAF_Ed4.1"
   obs_var_name: "toa_lw_all_mon"
   category: "TOA energy flux"
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
 
 FLNTC:
   colormap: "Oranges"
@@ -2101,7 +1744,7 @@ FLNTC:
   diff_contour_range: [-20, 20, 2]
   scale_factor: 1
   add_offset: 0
-  new_unit: "Wm$^{-2}$"
+  new_unit: "W/m2"
   mpl:
     colorbar:
       label : "Wm$^{-2}$"
@@ -2109,8 +1752,6 @@ FLNTC:
   obs_name: "CERES_EBAF_Ed4.1"
   obs_var_name: "toa_lw_clr_t_mon"
   category: "TOA energy flux"
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
 
 #+++++++++++++++++
 # Category: Surface energy flux
@@ -2118,13 +1759,9 @@ FLNTC:
 
 FSDS:
   category: "Sfc energy flux"
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
 
 FSDSC:
   category: "Sfc energy flux"
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
 
 FSNS:
   colormap: "Blues"
@@ -2133,7 +1770,7 @@ FSNS:
   diff_contour_range: [-24, 24, 2]
   scale_factor: 1
   add_offset: 0
-  new_unit: "Wm$^{-2}$"
+  new_unit: "W/m2"
   mpl:
     colorbar:
       label : "Wm$^{-2}$"
@@ -2141,8 +1778,6 @@ FSNS:
   obs_name: "CERES_EBAF_Ed4.1"
   obs_var_name: "sfc_net_sw_all_mon"
   category: "Sfc energy flux"
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
 
 FSNSC:
   colormap: "Blues"
@@ -2151,7 +1786,7 @@ FSNSC:
   diff_contour_range: [-24, 24, 2]
   scale_factor: 1
   add_offset: 0
-  new_unit: "Wm$^{-2}$"
+  new_unit: "W/m2"
   mpl:
     colorbar:
       label : "Wm$^{-2}$"
@@ -2159,8 +1794,6 @@ FSNSC:
   obs_name: "CERES_EBAF_Ed4.1"
   obs_var_name: "sfc_net_sw_clr_t_mon"
   category: "Sfc energy flux"
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
 
 FLDS:
   colormap: "Oranges"
@@ -2169,7 +1802,7 @@ FLDS:
   diff_contour_range: [-20, 20, 2]
   scale_factor: 1
   add_offset: 0
-  new_unit: "Wm$^{-2}$"
+  new_unit: "W/m2"
   mpl:
     colorbar:
       label : "Wm$^{-2}$"
@@ -2177,23 +1810,15 @@ FLDS:
   obs_name: "CERES_EBAF_Ed4.1"
   obs_var_name: "sfc_lw_down_all_mon"
   category: "Sfc energy flux"
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
 
 FLNS:
   category: "Sfc energy flux"
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
 
 FLNSC:
   category: "Sfc energy flux"
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
 
 SHFLX:
   category: "Sfc energy flux"
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
 
 LHFLX:
   colormap: "Blues"
@@ -2202,7 +1827,7 @@ LHFLX:
   diff_contour_range: [-45, 45, 5]
   scale_factor: 1
   add_offset: 0
-  new_unit: "Wm$^{-2}$"
+  new_unit: "W/m2"
   mpl:
     colorbar:
       label : "Wm$^{-2}$"
@@ -2210,8 +1835,6 @@ LHFLX:
   obs_name: "ERAI"
   obs_var_name: "LHFLX"
   category: "Sfc energy flux"
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
 
 #+++++++++++++++++
 # Category: COSP
@@ -2219,108 +1842,66 @@ LHFLX:
 
 CLDTOT_ISCCP:
   category: "COSP"
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
 
 CLIMODIS:
   category: "COSP"
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
 
 CLWMODIS:
   category: "COSP"
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
 
 FISCCP1_COSP:
   category: "COSP"
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
 
 ICE_ICLD_VISTAU:
   category: "COSP"
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
 
 IWPMODIS:
   category: "COSP"
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
 
 LIQ_ICLD_VISTAU:
   category: "COSP"
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
 
 LWPMODIS:
   category: "COSP"
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
 
 MEANCLDALB_ISCCP:
   category: "COSP"
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
 
 MEANPTOP_ISCCP:
   category: "COSP"
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
 
 MEANTAU_ISCCP:
   category: "COSP"
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
 
 MEANTB_ISCCP:
   category: "COSP"
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
 
 MEANTBCLR_ISCCP:
   category: "COSP"
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
 
 PCTMODIS:
   category: "COSP"
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
 
 REFFCLIMODIS:
   category: "COSP"
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
 
 REFFCLWMODIS:
   category: "COSP"
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
 
 SNOW_ICLD_VISTAU:
   category: "COSP"
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
 
 TAUTMODIS:
   category: "COSP"
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
 
 TAUWMODIS:
   category: "COSP"
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
 
 TOT_CLD_VISTAU:
   category: "COSP"
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
 
 TOT_ICLD_VISTAU:
   category: "COSP"
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
 
 CLDTOT_CAL:
   colormap: "cividis"
@@ -2397,20 +1978,16 @@ H2O:
   diff_colormap: "BrBG"
   scale_factor: 1
   add_offset: 0
-  new_unit: "mol mol$^{-1}$"
+  new_unit: "mol/mol"
   mpl:
     colorbar:
       label: "mol mol$^{-1}$"
   plot_log_pressure: True
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
 
 OMEGAT:
   colormap: "PuOr_r"
   diff_colormap: "coolwarm"
   plot_log_pressure: True
-  pct_diff_contour_levels: [-100,-75,-50,-40,-30,-20,-10,-8,-6,-4,-2,0,2,4,6,8,10,20,30,40,50,75,100]
-  pct_diff_colormap: "PuOr_r"
 
 #++++++++++++++
 # Category: TEM

--- a/scripts/analysis/amwg_table.py
+++ b/scripts/analysis/amwg_table.py
@@ -153,6 +153,7 @@ def amwg_table(adf):
         #Save the baseline to the first case's plots directory:
         output_locs.append(output_locs[0])
     else:
+        baseline_name = "Obs"
         print("\t WARNING: AMWG table doesn't currently work with obs, so obs table won't be created.")
     #End if
 
@@ -203,8 +204,10 @@ def amwg_table(adf):
             print(f"\t - Variable '{var}' being added to table")
 
             #Create list of time series files present for variable:
-            ts_filenames = f'{case_name}.*.{var}.*nc'
-            ts_files = sorted(input_location.glob(ts_filenames))
+            if case_name == baseline_name:
+                ts_files = adf.data.get_ref_timeseries_file(var)
+            else:
+                ts_files = adf.data.get_timeseries_file(case_name, var)
 
             # If no files exist, try to move to next variable. --> Means we can not proceed with this variable, and it'll be problematic later.
             if not ts_files:
@@ -221,9 +224,8 @@ def amwg_table(adf):
                 continue
             #End if
 
-            #Load model variable data from file:
-            ds = utils.load_dataset(ts_files)
-            data = ds[var]
+            #Load model variable data array:
+            data = adf.data.load_da(ts_files, var, case_name, type="tseries")
 
             #Extract units string, if available:
             if hasattr(data, 'units'):

--- a/scripts/plotting/adf_histogram.py
+++ b/scripts/plotting/adf_histogram.py
@@ -109,7 +109,7 @@ def adf_histogram(adfobj):
     # output: variable(season, region, bin)
     
     # "reference case" first:
-    ref_land = load_ref_func(*get_load_args(adfobj, adfobj.data.ref_case_label, "LANDFRAC"))
+    ref_land = load_ref_func(*get_load_args(adfobj, "LANDFRAC"))
     for var in var_list:
 
         ref_hist_file = plot_loc / f"{adfobj.data.ref_case_label}_{var}_{plot_name_string}.nc"
@@ -122,7 +122,7 @@ def adf_histogram(adfobj):
             vres = {}
 
         # probably have to make sure no "lev" dim (but gets confused about other dimensions)
-        da = load_ref_func(*get_load_args(adfobj, adfobj.data.ref_case_label, var))
+        da = load_ref_func(*get_load_args(adfobj, var))
         if da is None:
             print(f"failed to load {var} for {adfobj.data.ref_case_label}... skip")
             continue

--- a/scripts/plotting/aod_latlon.py
+++ b/scripts/plotting/aod_latlon.py
@@ -141,7 +141,7 @@ def process_model_cases(adfobj, var, obs_data):
 def process_model_data(adfobj, case_name, var, obs_shape):
     """Process model data and check grid compatibility."""
     if case_name == adfobj.data.ref_case_label:
-        ds_case = adfobj.data.load_reference_climo_da(case_name, var)
+        ds_case = adfobj.data.load_reference_climo_da(var)
     else:
         ds_case = adfobj.data.load_climo_da(case_name, var)
     if ds_case is None:

--- a/scripts/plotting/global_latlon_map.py
+++ b/scripts/plotting/global_latlon_map.py
@@ -134,7 +134,7 @@ def load_reference_data(adfobj, var):
             return None
         base_name = adfobj.data.ref_labels[var]
 
-    odata = adfobj.data.load_reference_regrid_da(base_name, var)
+    odata = adfobj.data.load_reference_regrid_da(var)
     if odata is None:
         print(f"\t    WARNING: No reference data found for {var}")
         return None

--- a/scripts/plotting/polar_map.py
+++ b/scripts/plotting/polar_map.py
@@ -196,7 +196,7 @@ def polar_map(adfobj):
             print(f"\t    Skipping {var} - all plots already exist")
             continue
 
-        odata = adfobj.data.load_reference_regrid_da(base_name, var)
+        odata = adfobj.data.load_reference_regrid_da(var)
         if odata is None:
             print(f"\t    WARNING: No reference data found for {var}")
             continue

--- a/scripts/plotting/zonal_mean.py
+++ b/scripts/plotting/zonal_mean.py
@@ -165,7 +165,7 @@ def zonal_mean(adfobj):
             base_name = adfobj.data.ref_labels[var]
 
         # Gather reference variable data
-        odata = adfobj.data.load_reference_regrid_da(base_name, var)
+        odata = adfobj.data.load_reference_regrid_da(var)
 
         #Check if regridded file exists, if not skip zonal plot for this var
         if odata is None:


### PR DESCRIPTION
This PR will clean up and organize the calls to read files, datasets, and data arrays depending on the file type, ie time series, climo, regridded climo. 

The main changes here are to:
1) Get all the file type functionality consistent. (probably be able to simplify all these down to a couple of functions still)
2) Remove baseline/ref name from any of these methods since there will always be only one case, just get it in the methods
3) Add function in `adf_dataset.py` to gather new unit info `update_unit` and call that in `load_da`. This could be useful as an external method, similarly to `get_value_converters`
4) Update `amwg_table.py` to implement these changes

Important changes:
1) The modifications for scale factor, offset, new units, and time bound adjustment (for time series) will always happen if the data is drawn using these methods in `adf_dataset.py`. That was the issue with the tables being improperly formatted, see #423 

Now you can load data sets and arrays generically any where in the ADF by calling `load_dataset(fils)` and/or `load_da(<list of files>, <variable name>, <case name>)`

or through the three file types:
&nbsp;&nbsp;`load_reference_timeseries_dataset`/`load_timeseries_dataset`
&nbsp;&nbsp;`load_reference_climo_dataset`/`load_climo_dataset`
&nbsp;&nbsp;`load_reference_regrid_dataset`/`load_regrid_dataset`

&nbsp;&nbsp;`load_<file type>_dataset` will inherently call `load_dataset` and
&nbsp;&nbsp;`load_<file type>_da` will inherently call `load_da`

calling `load_dataset` has a flag for time series files so that it can check the time bounds to ensure proper time alignment. This is only an issue for using older CAM/CESM files but this won't modify anything if the newer files are used.

This change will now force the ADF to figure out the modifications at the loading data array stage


Potential issues:
&nbsp;&nbsp;user must make sure of the scale/factor, units if using any premade file; using files that aren't created via ADF from the history files level. 
&nbsp;&nbsp;Remedy: The user just has to make sure there are no values for these arguments in the config yaml file if their datasets have been already modified, or use even more generic xarray load via `load_dataset` from `adf_utils`
&nbsp;&nbsp;Not likely but a definite issue for edge case scenarios.


Closes #423 and #424