### PR TITLE
Update README software-environment instructions; add conda install guidance for machines without a conda module

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,27 +44,38 @@ for details (e.g. changing the environment location, using conda in batch jobs).
 ### If your machine has no conda module (e.g. CGD machines)
 
 Some machines don't provide a `conda` module, so you'll need your own. Install
-[Miniforge](https://github.com/conda-forge/miniforge) (uses conda-forge by default, matching
-`env/conda_environment.yaml`):
+[Miniforge](https://github.com/conda-forge/miniforge), which defaults to the conda-forge channel that supplies
+nearly all of `env/conda_environment.yaml`:
 ```
 curl -L -O "https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-$(uname)-$(uname -m).sh"
 bash Miniforge3-$(uname)-$(uname -m).sh
 ```
 [Miniconda](https://www.anaconda.com/docs/getting-started/miniconda/install) is an equivalent alternative. Once
-installed, create the environment with the same `conda env create` command above. Note that on NCAR HPC systems
-a personal conda install is shadowed by `module load conda` whenever that module is loaded.
+installed, create the environment with the same `conda env create` command above. The environment is created under
+your own conda installation's `envs/` directory — the `prefix:` line at the bottom of `env/conda_environment.yaml`
+names an NCAR HPC path, but `conda env create` uses `name:` and ignores `prefix:`, so it has no effect here. Note
+also that on NCAR HPC systems a personal conda install is shadowed by `module load conda` whenever that module is
+loaded.
 
-Also, along with these python requirements, the `ncrcat` NetCDF Operator (NCO) is also needed.  On the CISL machines this can be loaded by simply running:
+### Non-python requirements (all machines)
+
+Also, along with these python requirements, the `ncrcat` NetCDF Operator (NCO) is also needed.  On NCAR HPC
+(derecho/casper) this can be loaded by simply running:
 ```
 module load nco
-``` 
-or on the CGD machines by simply running:
-```
-module load tool/nco
 ```
 on the command line.
 
-Finally, if you also want to run the [Climate Variability Diagnostics Package](https://www.cesm.ucar.edu/working_groups/CVC/cvdp/) (CVDP) as part of the ADF then you'll also need NCL.  On the CISL machines this can be done using the command:
+On CGD machines the `tool/nco` modules are currently not usable: the unversioned `tool/nco` resolves to a
+modulefile for an install that isn't present and adds nothing to `PATH`, and `tool/nco/4.5.2` puts `ncrcat` on
+`PATH` but fails at runtime looking for `libexpat.so.0`, which current CGD systems no longer ship. Install NCO
+from conda-forge into your ADF environment instead:
+```
+conda activate adf_v1.0.0
+conda install -c conda-forge nco
+```
+
+Finally, if you also want to run the [Climate Variability Diagnostics Package](https://www.cesm.ucar.edu/working_groups/CVC/cvdp/) (CVDP) as part of the ADF then you'll also need NCL.  On NCAR HPC (derecho/casper) this can be done using the command:
 ```
 module load ncl
 ```

--- a/README.md
+++ b/README.md
@@ -51,16 +51,14 @@ curl -L -O "https://github.com/conda-forge/miniforge/releases/latest/download/Mi
 bash Miniforge3-$(uname)-$(uname -m).sh
 ```
 [Miniconda](https://www.anaconda.com/docs/getting-started/miniconda/install) is an equivalent alternative. Once
-installed, create the environment with the same `conda env create` command above. The environment is created under
-your own conda installation's `envs/` directory — the `prefix:` line at the bottom of `env/conda_environment.yaml`
-names an NCAR HPC path, but `conda env create` uses `name:` and ignores `prefix:`, so it has no effect here. Note
-also that on NCAR HPC systems a personal conda install is shadowed by `module load conda` whenever that module is
-loaded.
+installed, create the environment with the same `conda env create` command above; it lands under your own conda
+installation's `envs/` directory. Note that on NCAR HPC systems a personal conda install is shadowed by
+`module load conda` whenever that module is loaded.
 
 ### Non-python requirements (all machines)
 
-Also, along with these python requirements, the `ncrcat` NetCDF Operator (NCO) is also needed.  On NCAR HPC
-(derecho/casper) this can be loaded by simply running:
+The `ncrcat` NetCDF Operator (NCO) is also needed.  On NCAR HPC (derecho/casper) it can be loaded by simply
+running:
 ```
 module load nco
 ```

--- a/README.md
+++ b/README.md
@@ -17,31 +17,42 @@ Finally, if you are interested in general (but non-supported) tools used by AMP 
 
 ## Required software environment
 
-These diagnostics currently require Python version 3.6 or higher.  They also require the following non-standard python libraries/modules:
+These diagnostics require Python 3.9 or higher (CI runs the test suite on 3.9-3.13). The exact, version-pinned
+set of non-standard python libraries/modules (PyYAML, Xarray, Matplotlib, Cartopy, GeoCAT, uxarray, xESMF,
+xskillscore, Pint, netCDF4, Scipy, Pandas, ...) is kept in [`env/conda_environment.yaml`](env/conda_environment.yaml)
+rather than duplicated here, so it doesn't go stale.
 
-- PyYAML
-- Numpy
-- Xarray
-- Matplotlib
-- Cartopy
-- GeoCAT
-
-If one wants to generate the "AMWG" model variable statistics table as well, then these additional python libraries are also needed:
-
-- Scipy
-- Pandas
-
-On NCAR's CISL machines (cheyenne and casper), these can be loaded by running the following on the command line:
-```
-module load conda
-conda activate npl
-```
-If you are using conda on a non-CISL machine, then you can create and activate the appropriate python enviroment using the `env/conda_environment.yaml` file like so:
+Create and activate the environment from that file with:
 
 ```
 conda env create -f env/conda_environment.yaml
 conda activate adf_v1.0.0
 ```
+
+### On NCAR HPC (derecho/casper)
+
+Load the NCAR-provided conda module first, then create the environment as above:
+```
+module load conda
+conda env create -f env/conda_environment.yaml
+conda activate adf_v1.0.0
+```
+By default this places the environment under `/glade/work/$USER/conda-envs/`. See the
+[NCAR HPC conda documentation](https://ncar-hpc-docs.readthedocs.io/en/v24.08/environment-and-software/user-environment/conda/)
+for details (e.g. changing the environment location, using conda in batch jobs).
+
+### If your machine has no conda module (e.g. CGD machines)
+
+Some machines don't provide a `conda` module, so you'll need your own. Install
+[Miniforge](https://github.com/conda-forge/miniforge) (uses conda-forge by default, matching
+`env/conda_environment.yaml`):
+```
+curl -L -O "https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-$(uname)-$(uname -m).sh"
+bash Miniforge3-$(uname)-$(uname -m).sh
+```
+[Miniconda](https://www.anaconda.com/docs/getting-started/miniconda/install) is an equivalent alternative. Once
+installed, create the environment with the same `conda env create` command above. Note that on NCAR HPC systems
+a personal conda install is shadowed by `module load conda` whenever that module is loaded.
 
 Also, along with these python requirements, the `ncrcat` NetCDF Operator (NCO) is also needed.  On the CISL machines this can be loaded by simply running:
 ```
@@ -68,7 +79,7 @@ on the command line.
 Detailed instructions for users and developers are availabe on this repository's [wiki](https://github.com/NCAR/ADF/wiki).
 
 
-To run an example of the ADF diagnostics, simply download this repo, setup your computing environment as described in the [Required software environment](https://github.com/NCAR/CAM_diagnostics/blob/main/README.md#required-software-environment) section above, modify the `config_cam_baseline_example.yaml` file (or create one of your own) to point to the relevant diretories and run:
+To run an example of the ADF diagnostics, simply download this repo, setup your computing environment as described in the [Required software environment](#required-software-environment) section above, modify the `config_cam_baseline_example.yaml` file (or create one of your own) to point to the relevant directories and run:
 
 `./run_adf_diag config_cam_baseline_example.yaml`
 

--- a/env/conda_environment.yaml
+++ b/env/conda_environment.yaml
@@ -16,4 +16,3 @@ dependencies:
   - geocat-comp=2024.04.0
   - python=3.12
   - xesmf>=0.8.8
-prefix: /glade/work/$USER/conda-envs/adf_v1.0.0


### PR DESCRIPTION
Closes #95.

#95 asked for instructions on installing a personal conda, since CGD sysadmins
ask users to bring their own rather than use a system install. While adding
that, the "Required software environment" section turned out to be stale in
several other ways, so this refreshes the whole section.

### Changes

**Conda install instructions (for #95)**
- New subsection for machines with no `conda` module, with Miniforge install
  steps (machine-agnostic), plus Miniconda as an alternative.
- Notes that on NCAR HPC a personal conda install is shadowed by
  `module load conda`.

**Stale content removed**
- Dropped **cheyenne** reference.
- "Python 3.6 or higher" → 3.9+ (CI runs the suite on 3.9–3.13).
- The hand-maintained package list had drifted out of sync with
  `env/conda_environment.yaml` (missing netCDF4, uxarray, xESMF, xskillscore,
  Pint). Rather than re-syncing a list that will drift again, the README now
  points at the env file as the single source of truth.
- Dropped `conda activate npl` as the recommended route — NPL is not
  guaranteed to carry the ADF-specific dependencies (geocat-comp, uxarray,
  xesmf, xskillscore).
- Fixed a self-referential link that pointed at the old `NCAR/CAM_diagnostics`
  repo path, and a `diretories` typo.

**CGD NCO fix**
- Neither CGD `nco` module gives a working `ncrcat`: the unversioned
  `tool/nco` resolves to a modulefile whose install is absent and adds nothing
  to `PATH`, and `tool/nco/4.5.2` puts `ncrcat` on `PATH` but fails at runtime
  on a missing `libexpat.so.0`. The README now directs CGD users to
  conda-forge NCO instead.
- Added a "Non-python requirements (all machines)" heading
- The CGD NCL line is unchanged (verified on andre).

**`env/conda_environment.yaml`**
- Removed the trailing `prefix: /glade/work/$USER/conda-envs/adf_v1.0.0` line.
  It was inert and misleading: `conda env create` uses `name:` and ignores
  `prefix:`, conda never expands `$USER`, and the path is NCAR-specific in an
  otherwise machine-agnostic file.

### Verification

On **andre.cgd.ucar.edu** (AlmaLinux 8.10):
- conda-forge NCO 5.3.9 installs and `ncrcat` runs.
- `tool/ncl/6.6.2` works: sets `NCARG_ROOT=/usr/local/ncl-6.6.2`, reports
  6.6.2, completes a netCDF write→read roundtrip, and generates valid
  PostScript headless. Both things CVDP actually needs were exercised, not
  just the startup banner — `tool/nco/4.5.2` also gets `ncrcat` onto `PATH`
  and only fails on execution, so a banner check would have been too weak a
  bar. The difference between the two modules is structural: the NCL
  modulefile prepends a real install directory, while the NCO modulefile's
  `prepend-path PATH` is commented out and points at an install that isn't
  there.

Elsewhere:
- `mamba env create -f env/conda_environment.yaml --dry-run` solves cleanly
  (320 packages).
- Module availability confirmed on casper (`conda/latest`, `nco/5.3.4`,
  `ncl/6.6.2`); derecho not separately checked.
- All external links in the section return 200.

**Scope caveat:** CGD findings — NCO broken, NCL working — rest on andre only.

### Follow-up (not in this PR)

`env/conda_environment.yaml` lists `defaults` alongside `conda-forge`, which
routes some packages through `repo.anaconda.com` and triggers an Anaconda
commercial-ToS warning — which partly undercuts recommending Miniforge. I
tried to confirm whether the pins solve with conda-forge alone, but the test
was inconclusive: my own `~/.condarc` also lists `defaults`, so dropping it
from the yaml changed nothing locally. Worth a separate look on a clean
Miniforge install.