### PR TITLE
Fix website generation for non-default plot types

### DIFF
--- a/env/conda_environment.yaml
+++ b/env/conda_environment.yaml
@@ -1,4 +1,4 @@
-name: adf_v1.0.1
+name: adf_v1.0.3
 channels:
   - conda-forge
   - defaults

--- a/lib/adf_web.py
+++ b/lib/adf_web.py
@@ -845,13 +845,15 @@ class AdfWeb(AdfObs):
             #End if
 
             #List of ADF default plot types
-            avail_plot_types = res["default_ptypes"]
+            #Note: this is a copy, as the list is appended to below and
+            #"res" is re-used on every pass through this loop:
+            avail_plot_types = list(res["default_ptypes"])
 
             #Check if current plot type is in ADF default.
             #If not, add it so the index.html file can include it
             for ptype in plot_types.keys():
                 if ptype not in avail_plot_types:
-                    avail_plot_types.append(plot_types)
+                    avail_plot_types.append(ptype)
 
 
             # External packages that can be run through ADF


### PR DESCRIPTION
Any plotting script using a plot_type outside "default_ptypes" crashed website generation with "TypeError: unhashable type: 'collections.OrderedDict'" from template_index.html.

The loop meant to register an unrecognized plot type appended the plot_types dict rather than the plot type itself, so index.html then tried to use that dict as a dictionary key.

Also copy the default list before appending. "res" is the shared variable-defaults dictionary and this loop runs once per web-data entry, so appending in place permanently modified the loaded defaults.

Verified with a plotting script registering plot_type "CloudRegimes": the tab now renders on index.html and the generated site has no broken internal links.