### PR TITLE
Remove un-used 'xskillscore' from provided conda environment.

### DIFF
--- a/env/conda_environment.yaml
+++ b/env/conda_environment.yaml
@@ -1,4 +1,4 @@
-name: adf_v1.0.0
+name: adf_v1.0.1
 channels:
   - conda-forge
   - defaults
@@ -12,7 +12,6 @@ dependencies:
   - matplotlib=3.9.4
   - pandas=2.2.0
   - pint=0.23
-  - xskillscore=0.0.24
   - geocat-comp=2024.04.0
   - python=3.12
   - xesmf>=0.8.8


### PR DESCRIPTION
This PR removes the `xskillscore` package, which doesn't appear to actually be used, and was causing an issue with its currently pinned version (see issue #462 ).  If we eventually decide that we do want the `xskillscore` package then we can always add it back with an updated version.

Also please note that a new tag will be needed once this PR has been merged (as the conda environment will be updated).