### PR TITLE
Add GenTS as an option for making time series files

### DIFF
--- a/.github/scripts/pr_mod_file_tests.py
+++ b/.github/scripts/pr_mod_file_tests.py
@@ -144,6 +144,7 @@ def _main_prog():
     #argument, and include everything inside the "lib" directory -JN:
     testable_files = {"lib/adf_base.py",
                       "lib/adf_config.py",
+                      "lib/adf_file_utils.py",
                       "lib/adf_info.py",
                       "lib/adf_obs.py",
                       "lib/adf_web.py",

--- a/config_cam_baseline_example.yaml
+++ b/config_cam_baseline_example.yaml
@@ -122,13 +122,15 @@ diag_basic_info:
     #  gents - hand off to the GenTS package (https://github.com/AgentOxygen/GenTS),
     #          the tool the CESM project is standardizing on.
     #NOTE: GenTS is an optional dependency and is NOT part of the provided conda
-    #      environment, because it requires newer numpy/netCDF4 than the ADF env
-    #      pins.  Install it separately with "pip install gents".
-    #      Take care with numpy: GenTS needs numpy>=2.0, but numba (used by
-    #      xarray/flox during the climatology step) needs numpy<=2.2, so a
-    #      plain "pip install gents" on top of the ADF environment will pull
-    #      numpy 2.5 and make every climatology fail.  Pin the overlap, e.g.
-    #        pip install gents "numpy>=2.0,<2.3"
+    #      environment, because it may require newer numpy/netCDF4 than the ADF
+    #      env pins.  Install it separately with "pip install gents".
+    #      One thing to check afterwards: numba (used by xarray/flox during the
+    #      climatology step) caps the numpy version it accepts, and that cap
+    #      moves with the numba release -- numba 0.65 allows numpy<2.5, older
+    #      numba allowed much less.  If pip pulls a numpy your numba rejects,
+    #      every climatology fails while ADF still reports success, so check the
+    #      pair after installing rather than forcing a pin that may be wrong for
+    #      your environment.
     ts_tool: adf
 
     #Options for the GenTS back end (ignored unless "ts_tool" is "gents").

--- a/config_cam_baseline_example.yaml
+++ b/config_cam_baseline_example.yaml
@@ -132,25 +132,29 @@ diag_basic_info:
     ts_tool: adf
 
     #Options for the GenTS back end (ignored unless "ts_tool" is "gents").
-    #Every entry is optional; the defaults shown reproduce what the built-in
+    #Every entry is optional; leaving them out reproduces what the built-in
     #ADF back end produces.
-    #gents_options:
-        #Generate every variable in the history stream instead of just the
-        #variables listed in "diag_var_list":
-        #all_vars: false
+    #NOTE: these are flat entries rather than a nested "gents_options" block,
+    #      because the ADF config reader allows only one level of nesting.
 
-        #Write GenTS's native <component>/proc/tseries/<frequency>/ layout
-        #instead of writing flat into "cam_ts_loc":
-        #nested_layout: false
+    #Generate every variable in the history stream instead of just the
+    #variables listed in "diag_var_list":
+    #gents_all_vars: false
 
-        #Years per time series file.  If missing or blank, a single file
-        #spanning start_year through end_year is written for each variable,
-        #which is what the built-in ADF back end does:
-        #slice_years: 10
+    #Write GenTS's native <component>/proc/tseries/<frequency>/ layout instead
+    #of writing flat into "cam_ts_loc":
+    #gents_nested_layout: false
 
-        #netCDF compression.  If missing or blank, no compression is applied.
-        #The CESM3 convention is zlib level 2:
-        #compression: {alg: zlib, level: 2}
+    #Years per time series file.  If missing or blank, a single file spanning
+    #start_year through end_year is written for each variable, which is what
+    #the built-in ADF back end does:
+    #gents_slice_years: 10
+
+    #netCDF compression.  If missing or blank, no compression is applied.
+    #A level is required whenever an algorithm is given.
+    #The CESM3 convention is zlib at level 2:
+    #gents_compression: zlib
+    #gents_compression_level: 2
 
     #IMPORTANT: unlike ADF's built-in back end, GenTS writes "PS" to its own
     #time series file rather than copying it into every 3-D variable's file.

--- a/config_cam_baseline_example.yaml
+++ b/config_cam_baseline_example.yaml
@@ -117,6 +117,46 @@ diag_basic_info:
     #single node/machine:
     num_procs: 8
 
+    #Which tool generates the time series files:
+    #  adf   - (default) ADF's built-in "ncrcat" path
+    #  gents - hand off to the GenTS package (https://github.com/AgentOxygen/GenTS),
+    #          the tool the CESM project is standardizing on.
+    #NOTE: GenTS is an optional dependency and is NOT part of the provided conda
+    #      environment, because it requires newer numpy/netCDF4 than the ADF env
+    #      pins.  Install it separately with "pip install gents".
+    #      Take care with numpy: GenTS needs numpy>=2.0, but numba (used by
+    #      xarray/flox during the climatology step) needs numpy<=2.2, so a
+    #      plain "pip install gents" on top of the ADF environment will pull
+    #      numpy 2.5 and make every climatology fail.  Pin the overlap, e.g.
+    #        pip install gents "numpy>=2.0,<2.3"
+    ts_tool: adf
+
+    #Options for the GenTS back end (ignored unless "ts_tool" is "gents").
+    #Every entry is optional; the defaults shown reproduce what the built-in
+    #ADF back end produces.
+    #gents_options:
+        #Generate every variable in the history stream instead of just the
+        #variables listed in "diag_var_list":
+        #all_vars: false
+
+        #Write GenTS's native <component>/proc/tseries/<frequency>/ layout
+        #instead of writing flat into "cam_ts_loc":
+        #nested_layout: false
+
+        #Years per time series file.  If missing or blank, a single file
+        #spanning start_year through end_year is written for each variable,
+        #which is what the built-in ADF back end does:
+        #slice_years: 10
+
+        #netCDF compression.  If missing or blank, no compression is applied.
+        #The CESM3 convention is zlib level 2:
+        #compression: {alg: zlib, level: 2}
+
+    #IMPORTANT: unlike ADF's built-in back end, GenTS writes "PS" to its own
+    #time series file rather than copying it into every 3-D variable's file.
+    #ADF needs "PS" for vertical interpolation, so add "PS" to "diag_var_list"
+    #whenever "ts_tool" is "gents" and any 3-D variables are being diagnosed.
+
     #If set to true, then redo all plots even if they already exist.
     #If set to false, then if a plot is found it will be skipped:
     redo_plot: false

--- a/lib/adf_dataset.py
+++ b/lib/adf_dataset.py
@@ -135,8 +135,7 @@ class AdfData:
             ts_filenames = f'{case}.{hist_str}.{field}.*nc'
         else:
             ts_filenames = f'{case}.*.{field}.*nc'
-        ts_files = sorted(ts_loc.glob(ts_filenames))
-        return ts_files
+        return utils.find_ts_files(ts_loc, ts_filenames)
 
     # Reference case (baseline/obs)
     def get_ref_timeseries_file(self, field, hist_str=None):
@@ -153,8 +152,7 @@ class AdfData:
             ts_filenames = f'{self.ref_case_label}.{hist_str}.{field}.*nc'
         else:
             ts_filenames = f'{self.ref_case_label}.*.{field}.*nc'
-        ts_files = sorted(ts_loc.glob(ts_filenames))
-        return ts_files
+        return utils.find_ts_files(ts_loc, ts_filenames)
 
 
     def load_timeseries_dataset(self, fils):

--- a/lib/adf_derive.py
+++ b/lib/adf_derive.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+import numpy as np
 import xarray as xr
 
 import adf_utils as utils
@@ -151,21 +152,51 @@ def check_derive(self, res, var, case_name, diag_var_list, constit_dict, hist_fi
 
 ########
 
-def _find_constit(ts_dir, case_name, constit):
+def _find_constit(ts_dir, case_name, constit, hist_str=None):
     """
-    Locate a constituent's time series file(s), preferring this case's own.
+    Locate a constituent's time series file(s) for one case and stream.
 
-    find_ts_files falls back to a recursive search, so an unanchored pattern
-    can reach another case's files when several cases share a time series
-    tree.  Try the case-anchored name first and fall back to the looser
-    pattern ADF has always used.
+    Most specific first.  The history stream matters: derivation runs once per
+    configured stream, and a case with two of them holds two files per
+    constituent whose dates are identical, which cannot be combined.  The case
+    name matters because find_ts_files falls back to a recursive search, so an
+    unanchored pattern can reach another case's files when several cases share
+    a time series tree.  The looser patterns are kept as fallbacks so
+    directories that do not follow the naming still work.
+
+    Parameters
+    ----------
+    ts_dir : str or Path
+        directory holding the time series files
+    case_name : str
+        name of the case being processed
+    constit : str
+        variable name to search for
+    hist_str : str, optional
+        history stream being processed, e.g. "cam.h0a"
+
+    Returns
+    -------
+    list of Path
+        Matching files, sorted; empty if nothing matches.
     """
-    return (utils.find_ts_files(ts_dir, f"{case_name}.*.{constit}.*.nc")
-            or utils.find_ts_files(ts_dir, f"*.{constit}.*.nc"))
+    patterns = []
+    if hist_str:
+        patterns.append(f"{case_name}.{hist_str}.{constit}.*.nc")
+    #End if
+    patterns += [f"{case_name}.*.{constit}.*.nc", f"*.{constit}.*.nc"]
+
+    for pattern in patterns:
+        found = utils.find_ts_files(ts_dir, pattern)
+        if found:
+            return found
+        #End if
+    #End for
+    return []
 
 
 def derive_variable(self, case_name, var, res=None, ts_dir=None,
-                         constit_list=None, overwrite=None):
+                         constit_list=None, overwrite=None, hist_str=None):
     """
     Derive variables acccording to steps given here.  Since derivations will depend on the
     variable, each variable to derive will need its own set of steps below.
@@ -177,6 +208,11 @@ def derive_variable(self, case_name, var, res=None, ts_dir=None,
     is what the built-in back end produces.  Constituents whose files cover
     *overlapping* periods are refused, because the combined time axis would
     contain duplicates.
+
+    Derivation runs once per configured history stream, so `hist_str` has to
+    be passed for a case with more than one: without it the search matches
+    every stream's copy of a constituent, and those cover the same dates and
+    cannot be combined.
 
     If the file for the derived variable exists, the kwarg `overwrite` determines
     whether to overwrite the file (true) or exit with a warning message.
@@ -192,7 +228,7 @@ def derive_variable(self, case_name, var, res=None, ts_dir=None,
     constit_matches = {}
     for constit in constit_list:
         # Check if the constituent file(s) are present, if so add them to the dict
-        matches = _find_constit(ts_dir, case_name, constit)
+        matches = _find_constit(ts_dir, case_name, constit, hist_str)
         if not matches:
             continue
         if utils.ts_files_overlap(matches):
@@ -293,7 +329,7 @@ def derive_variable(self, case_name, var, res=None, ts_dir=None,
             # the whole list: taking [0] would multiply a full-span variable by
             # a single chunk, which time-axis alignment turns silently into NaN.
             # Check if PMID is in file:
-            ds_pmid = self.data.load_dataset(_find_constit(ts_dir, case_name, "PMID"))
+            ds_pmid = self.data.load_dataset(_find_constit(ts_dir, case_name, "PMID", hist_str))
             if not ds_pmid:
                 errmsg = "Missing necessary files for dry air density (rho) "
                 errmsg += "calculation.\nPlease make sure 'PMID' is in the CAM "
@@ -305,7 +341,7 @@ def derive_variable(self, case_name, var, res=None, ts_dir=None,
                 return
 
             # Check if T is in file:
-            ds_t = self.data.load_dataset(_find_constit(ts_dir, case_name, "T"))
+            ds_t = self.data.load_dataset(_find_constit(ts_dir, case_name, "T", hist_str))
             if not ds_t:
                 errmsg = "Missing necessary files for dry air density (rho) "
                 errmsg += "calculation.\nPlease make sure 'T' is in the CAM "
@@ -316,6 +352,30 @@ def derive_variable(self, case_name, var, res=None, ts_dir=None,
                 dmsg += f"\n\t missing 'T' in {ts_dir}, can't make time series for {var} "
                 self.debug_log(dmsg)
                 return
+
+            # PMID and T have to cover the same times as the constituents.
+            # xarray aligns on time with an outer join, so a mismatch does not
+            # raise -- it fills with NaN, and a wholly disjoint pair would write
+            # an all-NaN field that looks like a real one.  Check before
+            # multiplying rather than shipping that.
+            for aux_name, aux_ds in (("PMID", ds_pmid), ("T", ds_t)):
+                shared = np.intersect1d(ds[var]["time"].values,
+                                        aux_ds["time"].values)
+                if len(shared) == len(ds[var]["time"]):
+                    continue
+                #End if
+                errmsg = f"\t   ** '{aux_name}' covers {len(shared)} of the "
+                errmsg += f"{len(ds[var]['time'])} times needed for {var}, so the "
+                errmsg += "dry air density calculation would be incomplete. **\n"
+                errmsg += f"\t     Please check the '{aux_name}' time series files "
+                errmsg += f"in {ts_dir}.\n"
+                print(errmsg)
+                dmsg = f"derived time series for {case_name}:"
+                dmsg += f"\n\t '{aux_name}' time axis does not cover {var}; "
+                dmsg += "skipping derivation."
+                self.debug_log(dmsg)
+                return
+            #End for
 
             # Multiply aerosol by dry air density (rho): (P/Rd*T)
             ds[var] = ds[var]*(ds_pmid["PMID"]/(res["Rgas"]*ds_t["T"]))

--- a/lib/adf_derive.py
+++ b/lib/adf_derive.py
@@ -157,7 +157,13 @@ def derive_variable(self, case_name, var, res=None, ts_dir=None,
     Derive variables acccording to steps given here.  Since derivations will depend on the
     variable, each variable to derive will need its own set of steps below.
 
-    Caution: this method assumes that there will be one time series file per variable
+    A constituent may be split across several consecutive time series files
+    (GenTS does this when 'gents_slice_years' is set, and CMIP-style archives
+    are laid out that way).  All of a constituent's files are opened together
+    and the derived variable is written as a single file spanning them, which
+    is what the built-in back end produces.  Constituents whose files cover
+    *overlapping* periods are refused, because the combined time axis would
+    contain duplicates.
 
     If the file for the derived variable exists, the kwarg `overwrite` determines
     whether to overwrite the file (true) or exit with a warning message.
@@ -167,17 +173,33 @@ def derive_variable(self, case_name, var, res=None, ts_dir=None,
     # Loop through derived variables
     print(f"\t - deriving time series for {var}")
 
-    # Grab all required time series files for derived variable
-    constit_files = []
+    # Grab all required time series files for derived variable.  A constituent
+    # can contribute more than one file, so key them by constituent rather than
+    # counting files:
+    constit_matches = {}
     for constit in constit_list:
-        # Check if the constituent file is present, if so add it to list
-        constit_matches = utils.find_ts_files(ts_dir, f"*.{constit}.*.nc")
-        if constit_matches:
-            constit_files.append(str(constit_matches[0]))
+        # Check if the constituent file(s) are present, if so add them to the dict
+        matches = utils.find_ts_files(ts_dir, f"*.{constit}.*.nc")
+        if not matches:
+            continue
+        if utils.ts_files_overlap(matches):
+            wmsg = f"\t   ** Time series files for constituent '{constit}' cover "
+            wmsg += f"overlapping or unrecognized periods, so {var} cannot be "
+            wmsg += "calculated. **\n"
+            wmsg += "\t     Please leave only one set of time series files per "
+            wmsg += "variable in the directory.\n"
+            print(wmsg)
+            continue
+        # End if
+        constit_matches[constit] = [str(f) for f in matches]
     # End for
 
+    # Flattened, in constituent order, for opening as one dataset:
+    constit_files = [f for constit in constit_list
+                     for f in constit_matches.get(constit, [])]
+
     # Check if all the necessary constituent files were found
-    if len(constit_files) != len(constit_list):
+    if len(constit_matches) != len(constit_list):
         ermsg = f"\t   ** Not all constituent files present; {var} cannot be calculated. **\n"
         ermsg += f"\t     Please remove {var} from 'diag_var_list' or find the "
         ermsg += "relevant CAM files.\n"
@@ -209,8 +231,19 @@ def derive_variable(self, case_name, var, res=None, ts_dir=None,
         # Grab attributes from first constituent file to be used in derived variable
         attrs = ds[constit_list[0]].attrs
 
-        # create new file name for derived variable
-        derived_file = constit_files[0].replace(constit_list[0], var)
+        # create new file name for derived variable.  The derived file holds
+        # every constituent chunk that was just opened, so its name has to
+        # advertise that whole span, not the span of the first chunk alone.
+        # With one file per constituent the span is that file's own dates, so
+        # the name is unchanged from what ADF has always written.
+        first_files = constit_matches[constit_list[0]]
+        derived_file = Path(first_files[0]).name.replace(constit_list[0], var)
+        span = utils.ts_file_span(first_files)
+        if span:
+            old_span = Path(first_files[0]).stem.split(".")[-1]
+            derived_file = derived_file.replace(old_span, f"{span[0]}-{span[1]}")
+        # End if
+        derived_file = str(Path(first_files[0]).parent / derived_file)
 
         # Check if clobber is true for file
         if Path(derived_file).is_file():
@@ -243,8 +276,11 @@ def derive_variable(self, case_name, var, res=None, ts_dir=None,
         # User-defined defaults might not include aerosol zonal list
         azl = res.get("aerosol_zonal_list", [])
         if var in azl:
+            # PMID and T are chunked the same way the constituents are, so pass
+            # the whole list: taking [0] would multiply a full-span variable by
+            # a single chunk, which time-axis alignment turns silently into NaN.
             # Check if PMID is in file:
-            ds_pmid = self.data.load_dataset(utils.find_ts_files(ts_dir, "*.PMID.*")[0])
+            ds_pmid = self.data.load_dataset(utils.find_ts_files(ts_dir, "*.PMID.*"))
             if not ds_pmid:
                 errmsg = "Missing necessary files for dry air density (rho) "
                 errmsg += "calculation.\nPlease make sure 'PMID' is in the CAM "
@@ -253,9 +289,10 @@ def derive_variable(self, case_name, var, res=None, ts_dir=None,
                 dmsg = "derived time series:"
                 dmsg += f"\n\t missing 'PMID' in {ts_dir}, can't make time series for {var} "
                 self.debug_log(dmsg)
+                return
 
             # Check if T is in file:
-            ds_t = self.data.load_dataset(utils.find_ts_files(ts_dir, "*.T.*")[0])
+            ds_t = self.data.load_dataset(utils.find_ts_files(ts_dir, "*.T.*"))
             if not ds_t:
                 errmsg = "Missing necessary files for dry air density (rho) "
                 errmsg += "calculation.\nPlease make sure 'T' is in the CAM "
@@ -265,6 +302,7 @@ def derive_variable(self, case_name, var, res=None, ts_dir=None,
                 dmsg = "derived time series:"
                 dmsg += f"\n\t missing 'T' in {ts_dir}, can't make time series for {var} "
                 self.debug_log(dmsg)
+                return
 
             # Multiply aerosol by dry air density (rho): (P/Rd*T)
             ds[var] = ds[var]*(ds_pmid["PMID"]/(res["Rgas"]*ds_t["T"]))

--- a/lib/adf_derive.py
+++ b/lib/adf_derive.py
@@ -224,11 +224,13 @@ def derive_variable(self, case_name, var, res=None, ts_dir=None,
         #NOTE: this will need to be changed when derived equations are more complex! - JR
         if var == "RESTOM":
             der_val = ds["FSNT"]-ds["FLNT"]
+            der_long_name = "Net radiative flux at top of model (FSNT - FLNT)"
         else:
             # Loop through all constituents and sum
             der_val = 0
             for v in constit_list:
                 der_val += ds[v]
+            der_long_name = "Sum of " + ", ".join(constit_list)
 
         # Set derived variable name and add to dataset
         der_val.name = var
@@ -270,13 +272,28 @@ def derive_variable(self, case_name, var, res=None, ts_dir=None,
             # Sulfate conversion factor
             if var == "SO4":
                 ds[var] = ds[var]*(96./115.)
+
+            #Multiplying by density turned a mixing ratio into a concentration:
+            der_long_name += ", times dry air density"
+            attrs = {**attrs, "units": "kg/m3"}
         #----------------------------------------------------------------------------------
 
         # Drop all constituents from final saved dataset
         # These are not necessary because they have their own time series files
         ds_final = ds.drop_vars(constit_list)
-        # Copy attributes from constituent file to derived variable
-        ds_final[var].attrs = attrs
+        # Copy attributes from constituent file to derived variable, but not its
+        # name: the constituent's 'long_name' describes the constituent, not the
+        # variable just derived from it.
+        ds_final[var].attrs = {**attrs,
+                               "long_name": res.get(var, {}).get("long_name",
+                                                                 der_long_name)}
+        # open_mfdataset leaves time bounds as a *chunked* datetime array, and
+        # xarray refuses to encode one of those when the units it inherits from
+        # 'time' come without a dtype.  They are tiny, so just load them.
+        # ponytail: load, not re-encode; revisit if a bounds variable is ever large
+        for tvar in [v for v in ds_final.variables
+                     if ds_final[v].dtype.kind in "OM" and ds_final[v].chunks]:
+            ds_final[tvar] = ds_final[tvar].load()
         ds_final.to_netcdf(derived_file, unlimited_dims='time', mode='w')
     # End if (all the necessary constituent files exist)
 ########

--- a/lib/adf_derive.py
+++ b/lib/adf_derive.py
@@ -151,6 +151,19 @@ def check_derive(self, res, var, case_name, diag_var_list, constit_dict, hist_fi
 
 ########
 
+def _find_constit(ts_dir, case_name, constit):
+    """
+    Locate a constituent's time series file(s), preferring this case's own.
+
+    find_ts_files falls back to a recursive search, so an unanchored pattern
+    can reach another case's files when several cases share a time series
+    tree.  Try the case-anchored name first and fall back to the looser
+    pattern ADF has always used.
+    """
+    return (utils.find_ts_files(ts_dir, f"{case_name}.*.{constit}.*.nc")
+            or utils.find_ts_files(ts_dir, f"*.{constit}.*.nc"))
+
+
 def derive_variable(self, case_name, var, res=None, ts_dir=None,
                          constit_list=None, overwrite=None):
     """
@@ -179,7 +192,7 @@ def derive_variable(self, case_name, var, res=None, ts_dir=None,
     constit_matches = {}
     for constit in constit_list:
         # Check if the constituent file(s) are present, if so add them to the dict
-        matches = utils.find_ts_files(ts_dir, f"*.{constit}.*.nc")
+        matches = _find_constit(ts_dir, case_name, constit)
         if not matches:
             continue
         if utils.ts_files_overlap(matches):
@@ -280,7 +293,7 @@ def derive_variable(self, case_name, var, res=None, ts_dir=None,
             # the whole list: taking [0] would multiply a full-span variable by
             # a single chunk, which time-axis alignment turns silently into NaN.
             # Check if PMID is in file:
-            ds_pmid = self.data.load_dataset(utils.find_ts_files(ts_dir, "*.PMID.*"))
+            ds_pmid = self.data.load_dataset(_find_constit(ts_dir, case_name, "PMID"))
             if not ds_pmid:
                 errmsg = "Missing necessary files for dry air density (rho) "
                 errmsg += "calculation.\nPlease make sure 'PMID' is in the CAM "
@@ -292,7 +305,7 @@ def derive_variable(self, case_name, var, res=None, ts_dir=None,
                 return
 
             # Check if T is in file:
-            ds_t = self.data.load_dataset(utils.find_ts_files(ts_dir, "*.T.*"))
+            ds_t = self.data.load_dataset(_find_constit(ts_dir, case_name, "T"))
             if not ds_t:
                 errmsg = "Missing necessary files for dry air density (rho) "
                 errmsg += "calculation.\nPlease make sure 'T' is in the CAM "

--- a/lib/adf_derive.py
+++ b/lib/adf_derive.py
@@ -201,13 +201,17 @@ def derive_variable(self, case_name, var, res=None, ts_dir=None,
     Derive variables acccording to steps given here.  Since derivations will depend on the
     variable, each variable to derive will need its own set of steps below.
 
-    A constituent may be split across several consecutive time series files
-    (GenTS does this when 'gents_slice_years' is set, and CMIP-style archives
-    are laid out that way).  All of a constituent's files are opened together
-    and the derived variable is written as a single file spanning them, which
-    is what the built-in back end produces.  Constituents whose files cover
-    *overlapping* periods are refused, because the combined time axis would
-    contain duplicates.
+    A constituent may be split across several consecutive time series files,
+    which is what GenTS produces when 'gents_slice_years' is set.  All of a
+    constituent's files are opened together and the derived variable is
+    written as a single file spanning them, which is what the built-in back
+    end produces.  Constituents whose files cover *overlapping* periods are
+    refused, because the combined time axis would contain duplicates.
+
+    Only ADF/GenTS names, `{case}.{stream}.{variable}.{start}-{end}.nc`, are
+    understood.  A chunked archive named some other way (a CMIP `_`-separated
+    name, say) cannot have its dates read, and is refused rather than combined
+    on a guess.
 
     Derivation runs once per configured history stream, so `hist_str` has to
     be passed for a case with more than one: without it the search matches
@@ -286,13 +290,22 @@ def derive_variable(self, case_name, var, res=None, ts_dir=None,
         # With one file per constituent the span is that file's own dates, so
         # the name is unchanged from what ADF has always written.
         first_files = constit_matches[constit_list[0]]
-        derived_file = Path(first_files[0]).name.replace(constit_list[0], var)
+        # Substitute whole dot-separated tokens rather than doing a plain
+        # string replace: a case name that happens to contain the constituent
+        # name (say case 'bFSNTtest' with constituent 'FSNT') would otherwise
+        # be rewritten too, producing a file nothing downstream can find.
+        tokens = Path(first_files[0]).stem.split(".")
         span = utils.ts_file_span(first_files)
+        for idx, token in enumerate(tokens):
+            if token == constit_list[0]:
+                tokens[idx] = var
+                break
+            # End if
+        # End for
         if span:
-            old_span = Path(first_files[0]).stem.split(".")[-1]
-            derived_file = derived_file.replace(old_span, f"{span[0]}-{span[1]}")
+            tokens[-1] = f"{span[0]}-{span[1]}"
         # End if
-        derived_file = str(Path(first_files[0]).parent / derived_file)
+        derived_file = str(Path(first_files[0]).parent / (".".join(tokens) + ".nc"))
 
         # Check if clobber is true for file
         if Path(derived_file).is_file():

--- a/lib/adf_derive.py
+++ b/lib/adf_derive.py
@@ -1,7 +1,7 @@
-import glob
-import os
 from pathlib import Path
 import xarray as xr
+
+import adf_utils as utils
 
 
 def check_derive(self, res, var, case_name, diag_var_list, constit_dict, hist_file_ds, hist0):
@@ -171,8 +171,9 @@ def derive_variable(self, case_name, var, res=None, ts_dir=None,
     constit_files = []
     for constit in constit_list:
         # Check if the constituent file is present, if so add it to list
-        if glob.glob(os.path.join(ts_dir, f"*.{constit}.*.nc")):
-            constit_files.append(glob.glob(os.path.join(ts_dir, f"*.{constit}.*"))[0])
+        constit_matches = utils.find_ts_files(ts_dir, f"*.{constit}.*.nc")
+        if constit_matches:
+            constit_files.append(str(constit_matches[0]))
     # End for
 
     # Check if all the necessary constituent files were found
@@ -241,7 +242,7 @@ def derive_variable(self, case_name, var, res=None, ts_dir=None,
         azl = res.get("aerosol_zonal_list", [])
         if var in azl:
             # Check if PMID is in file:
-            ds_pmid = self.data.load_dataset(glob.glob(os.path.join(ts_dir, "*.PMID.*"))[0])
+            ds_pmid = self.data.load_dataset(utils.find_ts_files(ts_dir, "*.PMID.*")[0])
             if not ds_pmid:
                 errmsg = "Missing necessary files for dry air density (rho) "
                 errmsg += "calculation.\nPlease make sure 'PMID' is in the CAM "
@@ -252,7 +253,7 @@ def derive_variable(self, case_name, var, res=None, ts_dir=None,
                 self.debug_log(dmsg)
 
             # Check if T is in file:
-            ds_t = self.data.load_dataset(glob.glob(os.path.join(ts_dir, "*.T.*"))[0])
+            ds_t = self.data.load_dataset(utils.find_ts_files(ts_dir, "*.T.*")[0])
             if not ds_t:
                 errmsg = "Missing necessary files for dry air density (rho) "
                 errmsg += "calculation.\nPlease make sure 'T' is in the CAM "

--- a/lib/adf_diag.py
+++ b/lib/adf_diag.py
@@ -328,8 +328,22 @@ class AdfDiag(AdfWeb):
         Return the per-case configuration used by the time series step.
 
         Gathered in one place so that the built-in ("adf") and the GenTS back
-        ends cannot drift apart in how they read the config file.  Every value
-        is a list with one entry per case, baseline included.
+        ends cannot drift apart in how they read the config file.
+
+        Parameters
+        ----------
+        baseline : bool, optional
+            If ``True``, read the baseline case's settings; otherwise read the
+            test cases'.  Default is ``False``.
+
+        Returns
+        -------
+        dict
+            Keys ``case_names``, ``cam_ts_done``, ``cam_hist_locs``,
+            ``ts_dirs``, ``overwrite_ts``, ``start_years``, ``end_years`` and
+            ``hist_str_list``, each a list with one entry per case, plus
+            ``case_type_string``, a str used in messages ("case" or
+            "baseline").
         """
 
         # Check if baseline time-series files are being created:

--- a/lib/adf_diag.py
+++ b/lib/adf_diag.py
@@ -734,7 +734,7 @@ class AdfDiag(AdfWeb):
                 if constit_dict:
                     for der_var, constit_list in constit_dict.items():
                         derive_variable(self, case_name, der_var, res,
-                                        ts_dir, constit_list)
+                                        ts_dir, constit_list, hist_str=hist_str)
             # End for hist_str
         # End cases loop
 

--- a/lib/adf_diag.py
+++ b/lib/adf_diag.py
@@ -323,10 +323,66 @@ class AdfDiag(AdfWeb):
 
     #########
 
+    def get_ts_case_config(self, baseline=False):
+        """
+        Return the per-case configuration used by the time series step.
+
+        Gathered in one place so that the built-in ("adf") and the GenTS back
+        ends cannot drift apart in how they read the config file.  Every value
+        is a list with one entry per case, baseline included.
+        """
+
+        # Check if baseline time-series files are being created:
+        if baseline:
+            # Use baseline settings, while converting them all to lists:
+            return {
+                "case_names": [self.get_baseline_info("cam_case_name", required=True)],
+                "cam_ts_done": [self.get_baseline_info("cam_ts_done")],
+                "cam_hist_locs": [self.get_baseline_info("cam_hist_loc")],
+                "ts_dirs": [self.get_baseline_info("cam_ts_loc", required=True)],
+                "overwrite_ts": [self.get_baseline_info("cam_overwrite_ts")],
+                "start_years": [self.climo_yrs["syear_baseline"]],
+                "end_years": [self.climo_yrs["eyear_baseline"]],
+                "case_type_string": "baseline",
+                "hist_str_list": [self.hist_string["base_hist_str"]],
+            }
+        # End if
+
+        # Use test case settings, which are already lists:
+        return {
+            "case_names": self.get_cam_info("cam_case_name", required=True),
+            "cam_ts_done": self.get_cam_info("cam_ts_done"),
+            "cam_hist_locs": self.get_cam_info("cam_hist_loc"),
+            "ts_dirs": self.get_cam_info("cam_ts_loc", required=True),
+            "overwrite_ts": self.get_cam_info("cam_overwrite_ts"),
+            "start_years": self.climo_yrs["syears"],
+            "end_years": self.climo_yrs["eyears"],
+            "case_type_string": "case",
+            "hist_str_list": self.hist_string["test_hist_str"],
+        }
+
+    #########
+
     def create_time_series(self, baseline=False):
         """
         Generate time series versions of the CAM history file data.
+
+        The 'ts_tool' config variable selects which back end does the work:
+        'adf' (the default) uses the ncrcat path below, 'gents' hands off to
+        the GenTS package via lib/adf_gents.py.
         """
+
+        # Hand off to GenTS if that back end was requested:
+        ts_tool = self.get_basic_info("ts_tool") or "adf"
+        if str(ts_tool).lower() == "gents":
+            from adf_gents import create_time_series_gents
+            return create_time_series_gents(self, baseline=baseline)
+        # End if
+        if str(ts_tool).lower() != "adf":
+            emsg = f"Unknown 'ts_tool' value '{ts_tool}'."
+            emsg += " Please use either 'adf' or 'gents'."
+            self.end_diag_fail(emsg)
+        # End if
 
         #Notify user that script has started:
         msg = "\n  Calculating CAM time series..."
@@ -343,31 +399,17 @@ class AdfDiag(AdfWeb):
             return subprocess.run(cmd, shell=False)
         # End def
 
-        # Check if baseline time-series files are being created:
-        if baseline:
-            # Use baseline settings, while converting them all to lists:
-            case_names = [self.get_baseline_info("cam_case_name", required=True)]
-            cam_ts_done = [self.get_baseline_info("cam_ts_done")]
-            cam_hist_locs = [self.get_baseline_info("cam_hist_loc")]
-            ts_dirs = [self.get_baseline_info("cam_ts_loc", required=True)]
-            overwrite_ts = [self.get_baseline_info("cam_overwrite_ts")]
-            start_years = [self.climo_yrs["syear_baseline"]]
-            end_years = [self.climo_yrs["eyear_baseline"]]
-            case_type_string = "baseline"
-            hist_str_list = [self.hist_string["base_hist_str"]]
-
-        else:
-            # Use test case settings, which are already lists:
-            case_names = self.get_cam_info("cam_case_name", required=True)
-            cam_ts_done = self.get_cam_info("cam_ts_done")
-            cam_hist_locs = self.get_cam_info("cam_hist_loc")
-            ts_dirs = self.get_cam_info("cam_ts_loc", required=True)
-            overwrite_ts = self.get_cam_info("cam_overwrite_ts")
-            start_years = self.climo_yrs["syears"]
-            end_years = self.climo_yrs["eyears"]
-            case_type_string="case"
-            hist_str_list = self.hist_string["test_hist_str"]
-        # End if
+        # Gather the per-case configuration (shared with the GenTS back end):
+        cfg = self.get_ts_case_config(baseline=baseline)
+        case_names = cfg["case_names"]
+        cam_ts_done = cfg["cam_ts_done"]
+        cam_hist_locs = cfg["cam_hist_locs"]
+        ts_dirs = cfg["ts_dirs"]
+        overwrite_ts = cfg["overwrite_ts"]
+        start_years = cfg["start_years"]
+        end_years = cfg["end_years"]
+        case_type_string = cfg["case_type_string"]
+        hist_str_list = cfg["hist_str_list"]
 
         # Read hist_str (component.hist_num) from the yaml file, or set to default
         dmsg = f"reading from {hist_str_list} files"

--- a/lib/adf_file_utils.py
+++ b/lib/adf_file_utils.py
@@ -17,7 +17,7 @@ ts_file_span(fils)
 
 Notes
 -----
-Re-exported by adf_utils, so `utils.find_ts_files(...)` keeps working for
+Re-exported by adf_utils, so ``utils.find_ts_files(...)`` keeps working for
 every existing caller.
 """
 
@@ -26,12 +26,12 @@ from pathlib import Path
 
 def find_ts_files(ts_loc, pattern, recursive=True):
     """
-    Locate time series files matching `pattern` underneath `ts_loc`.
+    Locate time series files matching ``pattern`` underneath ``ts_loc``.
 
-    Searches `ts_loc` itself first, which is where ADF's own time series step
+    Searches ``ts_loc`` itself first, which is where ADF's own time series step
     and a flat GenTS run both put their files.  Only if that finds nothing does
     it fall back to a recursive search, so that a GenTS archive laid out as
-    <component>/proc/tseries/<frequency>/ can be used by pointing `cam_ts_loc`
+    <component>/proc/tseries/<frequency>/ can be used by pointing ``cam_ts_loc``
     at the top of the tree instead of the frequency sub-directory.
 
     Parameters
@@ -102,7 +102,7 @@ def ts_files_overlap(fils):
     Report whether time series files cover overlapping periods.
 
     ADF and GenTS both name time series files
-    `{case}.{stream}.{variable}.{start}-{end}.nc`, where the dates are
+    ``{case}.{stream}.{variable}.{start}-{end}.nc``, where the dates are
     zero-padded and all use the same width for a given variable.  A variable
     split into consecutive chunks (e.g. 001001-001912 then 002001-002912) can
     safely be opened together; two overlapping sets (e.g. years 1-20 alongside

--- a/lib/adf_file_utils.py
+++ b/lib/adf_file_utils.py
@@ -1,0 +1,169 @@
+"""
+Time series file discovery helpers.
+
+Kept apart from adf_utils so they can be unit tested without the scientific
+stack: the ADF unit test workflow installs only PyYAML and pytest, so anything
+that imports xarray/geocat at module level cannot be exercised in CI.  This
+module imports nothing but pathlib.
+
+Functions
+---------
+find_ts_files(ts_loc, pattern, recursive=True)
+    Locate time series files matching a glob pattern under a directory.
+ts_files_overlap(fils)
+    Report whether a set of time series files cover overlapping periods.
+ts_file_span(fils)
+    Report the period a set of time series files covers, taken together.
+
+Notes
+-----
+Re-exported by adf_utils, so `utils.find_ts_files(...)` keeps working for
+every existing caller.
+"""
+
+from pathlib import Path
+
+
+def find_ts_files(ts_loc, pattern, recursive=True):
+    """
+    Locate time series files matching `pattern` underneath `ts_loc`.
+
+    Searches `ts_loc` itself first, which is where ADF's own time series step
+    and a flat GenTS run both put their files.  Only if that finds nothing does
+    it fall back to a recursive search, so that a GenTS archive laid out as
+    <component>/proc/tseries/<frequency>/ can be used by pointing `cam_ts_loc`
+    at the top of the tree instead of the frequency sub-directory.
+
+    Parameters
+    ----------
+    ts_loc : str or Path
+        directory to search
+    pattern : str
+        glob pattern, e.g. "case.cam.h0a.T.*nc"
+    recursive : bool, optional
+        Whether to fall back to a recursive search when the flat one finds
+        nothing.  Default is ``True``.  A missing variable is a normal
+        condition, so a caller trying many patterns in a row should pass
+        ``False`` and make a single recursive attempt at the end rather than
+        walking the whole tree once per pattern.
+
+    Returns
+    -------
+    list of Path
+        Matching files, sorted; empty if nothing matches.
+    """
+    ts_loc = Path(ts_loc)
+    found = sorted(ts_loc.glob(pattern))
+    if found or not recursive:
+        return found
+    #End if
+    return sorted(ts_loc.rglob(pattern))
+
+
+def _ts_file_spans(fils):
+    """
+    Parse the {start}-{end} date token out of each time series file name.
+
+    Parameters
+    ----------
+    fils : list
+        strings or paths to time series files
+
+    Returns
+    -------
+    list of tuple or None
+        (start, end) string pairs sorted chronologically, or ``None`` if any
+        name could not be parsed or the dates do not all use the same width.
+        Callers treat ``None`` as "make no promises about these files".
+    """
+    spans = []
+    for fil in fils:
+        #Last dot-separated token of the stem -- second-to-last of the file
+        #name -- e.g. "001001-001112" in "case.cam.h0a.T.001001-001112.nc":
+        date_str = Path(fil).stem.split(".")[-1]
+        start, sep, end = date_str.partition("-")
+        if not sep or not start.isdigit() or not end.isdigit():
+            #Unrecognized name, so make no promises about it:
+            return None
+        spans.append((start, end))
+    #End for
+
+    #Zero-padded dates of equal width sort chronologically as strings, but
+    #mixed widths (e.g. YYYY next to YYYYMM) would not, so bail out on those:
+    if len({len(s) for span in spans for s in span}) != 1:
+        return None
+    #End if
+
+    return sorted(spans)
+
+
+def ts_files_overlap(fils):
+    """
+    Report whether time series files cover overlapping periods.
+
+    ADF and GenTS both name time series files
+    `{case}.{stream}.{variable}.{start}-{end}.nc`, where the dates are
+    zero-padded and all use the same width for a given variable.  A variable
+    split into consecutive chunks (e.g. 001001-001912 then 002001-002912) can
+    safely be opened together; two overlapping sets (e.g. years 1-20 alongside
+    years 1-40, which happens when a run is extended and the time series are
+    remade over a longer period) cannot, because the combined time axis would
+    contain duplicates.
+
+    Parameters
+    ----------
+    fils : list
+        strings or paths to time series files
+
+    Returns
+    -------
+    bool
+        True if the files overlap, or if the dates could not be read from the
+        names -- in both cases the caller should not blindly combine them.
+        False if the files are non-overlapping and safe to open together.
+    """
+    if len(fils) < 2:
+        return False
+    #End if
+
+    spans = _ts_file_spans(fils)
+    if spans is None:
+        return True
+    #End if
+
+    for (_, prev_end), (next_start, _) in zip(spans, spans[1:]):
+        if next_start <= prev_end:
+            return True
+    #End for
+
+    return False
+
+
+def ts_file_span(fils):
+    """
+    Report the period covered by a set of time series files, taken together.
+
+    Used to name a file derived from several chunked constituent files: the
+    derived file has to advertise the whole span it actually contains, not the
+    span of whichever chunk happened to sort first.  For a single file this is
+    just that file's own dates, so names are unchanged for the common case.
+
+    Parameters
+    ----------
+    fils : list
+        strings or paths to time series files
+
+    Returns
+    -------
+    tuple of str or None
+        (start, end) as they appear in the file names, or ``None`` if the
+        dates could not be read.
+    """
+    spans = _ts_file_spans(fils)
+    if not spans:
+        return None
+    #End if
+
+    #Sorted by start, so the earliest start leads; take the latest end
+    #explicitly rather than assuming the last entry carries it:
+    return spans[0][0], max(end for _, end in spans)

--- a/lib/adf_gents.py
+++ b/lib/adf_gents.py
@@ -55,10 +55,12 @@ def _import_gents():
         from gents.timeseries import TSCollection
     except ImportError as err:
         emsg = "'ts_tool: gents' requires the GenTS package, which was not found.\n"
-        emsg += "\tInstall it with: pip install gents \"numpy>=2.0,<2.3\"\n"
-        emsg += "\t(GenTS needs python>=3.10, numpy>=2.0 and netCDF4>=1.7.0, which are newer\n"
-        emsg += "\t than the pinned ADF environment, so it may need its own env.  Pin numpy\n"
-        emsg += "\t below 2.3: numba, used by the climatology step, rejects anything newer.)\n"
+        emsg += "\tInstall it with: pip install gents\n"
+        emsg += "\t(GenTS needs python>=3.10, numpy>=2.0 and netCDF4>=1.7.0, which may be\n"
+        emsg += "\t newer than the pinned ADF environment, so it may need its own env.\n"
+        emsg += "\t Afterwards check numpy against numba, which the climatology step uses:\n"
+        emsg += "\t numba caps the numpy it accepts and the cap moves with each numba\n"
+        emsg += "\t release, so a numpy your numba rejects makes every climatology fail.)\n"
         emsg += "\tOr set 'ts_tool: adf' to use the built-in ncrcat path instead."
         raise AdfError(emsg) from err
     return HFCollection, TSCollection

--- a/lib/adf_gents.py
+++ b/lib/adf_gents.py
@@ -1,0 +1,278 @@
+"""
+GenTS interface for the Atmospheric Diagnostics Framework (ADF).
+
+Provides an alternative back end for the time series generation step, so a run
+can build its time series with GenTS (https://github.com/AgentOxygen/GenTS) --
+the tool the CESM project is standardizing on -- instead of ADF's built-in
+"ncrcat" path.  Selected with 'ts_tool: gents' in the 'diag_basic_info' section
+of the config file.
+
+The two back ends are interchangeable.  Pointing GenTS at the history file
+directory itself makes its output path template collapse to the output
+directory, so it writes
+
+    $case.$hist_str.$variable.$dates.nc
+
+flat into 'cam_ts_loc' -- which is the naming ADF already looks for.  No
+downstream ADF code needs to know which back end produced the files.
+
+There is one real difference in file *content*.  ADF's ncrcat path copies
+hyam/hybm/hyai/hybi and PS into every 3-D variable's file.  GenTS copies any
+variable that is not time-varying into every file of a group, so hyam, hybm,
+hyai, hybi, P0 and gw all still ride along -- but PS is time-varying, so GenTS
+gives it its own file instead.  ADF's regridding already knows how to pick PS
+up from a separate file, but only when PS is in 'diag_var_list', so this module
+checks for that up front rather than letting every 3-D variable silently drop
+out of the regridding step later on.
+"""
+
+#++++++++++++++++++++++++++++++
+#Import standard python modules
+#++++++++++++++++++++++++++++++
+
+import sys
+from pathlib import Path
+
+import xarray as xr
+
+#ADF modules:
+from adf_base import AdfError
+from adf_derive import check_derive, derive_variable
+
+#++++++++++++++++++++++++++++++
+
+
+def _import_gents():
+    """
+    Import GenTS, or fail with an actionable message.
+
+    GenTS is an optional dependency: it needs newer netCDF4/numpy than the
+    pinned ADF environment provides, so it is deliberately not part of
+    'env/conda_environment.yaml' and is only imported when actually requested.
+    """
+    try:
+        from gents.hfcollection import HFCollection
+        from gents.timeseries import TSCollection
+    except ImportError as err:
+        emsg = "'ts_tool: gents' requires the GenTS package, which was not found.\n"
+        emsg += "\tInstall it with: pip install gents \"numpy>=2.0,<2.3\"\n"
+        emsg += "\t(GenTS needs python>=3.10, numpy>=2.0 and netCDF4>=1.7.0, which are newer\n"
+        emsg += "\t than the pinned ADF environment, so it may need its own env.  Pin numpy\n"
+        emsg += "\t below 2.3: numba, used by the climatology step, rejects anything newer.)\n"
+        emsg += "\tOr set 'ts_tool: adf' to use the built-in ncrcat path instead."
+        raise AdfError(emsg) from err
+    return HFCollection, TSCollection
+
+
+def _uses_model_levels(hist_file, variables):
+    """Return True if any of 'variables' is on model levels in 'hist_file'."""
+    with xr.open_dataset(hist_file, decode_cf=False, decode_times=False) as ds:
+        for var in variables:
+            if var in ds and ({"lev", "ilev"} & set(ds[var].dims)):
+                return True
+    return False
+
+
+def _expand_derived_vars(adf, case_name, hist_files):
+    """
+    Work out which variables GenTS actually needs to produce.
+
+    Any variable in 'diag_var_list' that is not in the history files may still
+    be derivable from constituents (e.g. RESTOM from FSNT and FLNT).  Those
+    constituents have to be part of the GenTS request, otherwise there would be
+    nothing to derive from afterwards.  Reuses ADF's existing 'check_derive' so
+    the two back ends agree on what is derivable.
+
+    Returns (variables_to_generate, constit_dict).
+    """
+    res = adf.variable_defaults
+    diag_var_list = adf.diag_var_list
+    constit_dict = {}
+
+    with xr.open_dataset(hist_files[0], decode_cf=False, decode_times=False) as hist_file_ds:
+        hist_file_var_list = list(hist_file_ds.data_vars)
+        #Iterate over a copy: check_derive extends the list with constituents.
+        for var in list(diag_var_list):
+            if var not in hist_file_var_list:
+                print(f"\t     {var} not in history file, will try to derive if possible")
+                diag_var_list, constit_dict = check_derive(adf, res, var, case_name,
+                                                           diag_var_list, constit_dict,
+                                                           hist_file_ds, hist_files[0])
+            #End if
+        #End for
+    #End with
+
+    #Only ask GenTS for variables that are actually in the history files; the
+    #derived ones are built afterwards from their constituents.
+    wanted = [v for v in diag_var_list if v in hist_file_var_list]
+    return wanted, constit_dict
+
+
+def _restrict_to_vars(tsc, variables):
+    """Keep only the GenTS orders whose primary variable was requested."""
+    wanted = set(variables)
+    return tsc.copy(ts_orders=[o for o in tsc if o["primary_var"] in wanted])
+
+
+def create_time_series_gents(adf, baseline=False):
+    """
+    Generate ADF time series files using GenTS.
+
+    Drop-in alternative to 'AdfDiag.create_time_series'; see this module's
+    docstring for how the two back ends line up.
+    """
+
+    HFCollection, TSCollection = _import_gents()
+
+    #Notify user that script has started:
+    msg = "\n  Calculating CAM time series with GenTS..."
+    print(f"{msg}\n  {'-' * (len(msg)-3)}")
+
+    #GenTS draws progress bars on stdout.  Useful interactively, but they turn
+    #a redirected ADF log into thousands of columns of bar characters, so only
+    #ask for them when stdout is actually a terminal.
+    show_progress = sys.stdout.isatty()
+
+    #GenTS options (all optional; absent means "behave like the ADF back end"):
+    opts = adf.get_basic_info("gents_options") or {}
+    all_vars = bool(opts.get("all_vars", False))
+    nested_layout = bool(opts.get("nested_layout", False))
+    slice_years = opts.get("slice_years")
+    compression = opts.get("compression")
+
+    #Same config the built-in back end uses, so the two cannot drift apart:
+    cfg = adf.get_ts_case_config(baseline=baseline)
+    case_type_string = cfg["case_type_string"]
+
+    #Loop over cases:
+    for case_idx, case_name in enumerate(cfg["case_names"]):
+
+        ts_dir = cfg["ts_dirs"][case_idx]
+
+        print(f"\n  Generating CAM time series files for '{case_name}'...")
+        print(f"\n    Writing time series files to {ts_dir}")
+
+        #Check if particular case should be processed:
+        if cfg["cam_ts_done"][case_idx]:
+            emsg = "\tNOTE: Configuration file indicates time series files have been "
+            emsg += f"pre-computed for case '{case_name}'.  Will rely on those files directly."
+            print(emsg)
+            continue
+        #End if
+
+        start_year = cfg["start_years"][case_idx]
+        end_year = cfg["end_years"][case_idx]
+
+        #Create path object for the CAM history file(s) location:
+        starting_location = Path(cfg["cam_hist_locs"][case_idx])
+
+        #Check that path actually exists:
+        if not starting_location.is_dir():
+            emsg = f"Provided {case_type_string} 'cam_hist_loc' directory"
+            emsg += f" '{starting_location}' not found.  Script is ending here."
+            adf.end_diag_fail(emsg)
+        #End if
+
+        #Check if time series directory exists, and if not, then create it:
+        Path(ts_dir).mkdir(parents=True, exist_ok=True)
+
+        for hist_str in cfg["hist_str_list"][case_idx]:
+
+            print(f"\t Processing time series for {case_type_string} {case_name}, "
+                  f"{hist_str} files:")
+
+            hist_files = sorted(starting_location.glob(f"*{hist_str}.*.nc"))
+            if not hist_files:
+                emsg = f"No history *{hist_str}.*.nc files found in '{starting_location}'."
+                emsg += " Script is ending here."
+                adf.end_diag_fail(emsg)
+            #End if
+
+            #Work out the variable list before handing over to GenTS, so that
+            #constituents of derived variables are generated too:
+            if all_vars:
+                wanted_vars = None
+                _, constit_dict = _expand_derived_vars(adf, case_name, hist_files)
+            else:
+                wanted_vars, constit_dict = _expand_derived_vars(adf, case_name, hist_files)
+            #End if
+
+            #GenTS writes PS to its own file rather than copying it into each
+            #3-D variable's file, so ADF needs it requested explicitly:
+            check_vars = wanted_vars if wanted_vars is not None else adf.diag_var_list
+            if "PS" not in adf.diag_var_list and _uses_model_levels(hist_files[0], check_vars):
+                emsg = "GenTS writes 'PS' to its own time series file instead of copying it\n"
+                emsg += "\tinto every 3-D variable's file the way ADF's built-in back end does.\n"
+                emsg += "\tADF needs 'PS' to interpolate model levels, so please add 'PS' to\n"
+                emsg += "\t'diag_var_list' when using 'ts_tool: gents'."
+                adf.end_diag_fail(emsg)
+            #End if
+
+            #Build the history file collection.  Filter on path first (free),
+            #then on year (needs file metadata, which GenTS pulls on demand):
+            hfc = HFCollection(str(starting_location), num_processes=adf.num_procs)
+            hfc = hfc.include(f"*{hist_str}.*.nc")
+            #Pull metadata explicitly so the progress bar can be silenced;
+            #include_years would otherwise trigger it with its own default.
+            hfc.pull_metadata(show_progress=show_progress)
+            hfc = hfc.include_years(start_year, end_year)
+
+            #One file per variable spanning the requested years, matching what
+            #ADF's ncrcat back end produces, unless the user asked for slices.
+            #Note GenTS defaults start_year to 0, which misaligns the slice
+            #windows for anything that does not start at year 0.
+            span = (end_year - start_year) + 1
+            hfc = hfc.slice_groups(slice_size_years=slice_years or span,
+                                   start_year=start_year)
+
+            #Build the time series orders.  Strip any trailing separator:
+            #GenTS joins the output directory to a path that already has a
+            #leading separator.
+            tsc = TSCollection(hfc, str(ts_dir).rstrip("/"), num_processes=adf.num_procs)
+
+            if wanted_vars is not None:
+                tsc = _restrict_to_vars(tsc, wanted_vars)
+            #End if
+
+            if not len(tsc):
+                wmsg = f"\t    WARNING: GenTS found nothing to generate for '{hist_str}'."
+                print(wmsg)
+                continue
+            #End if
+
+            if nested_layout:
+                #The layout the CESM project archives: <component>/proc/tseries/<freq>/
+                tsc = tsc.apply_path_swap("/hist/", "/proc/tseries/")
+                tsc = tsc.append_timestep_dirs()
+            #End if
+
+            if cfg["overwrite_ts"][case_idx]:
+                tsc = tsc.apply_overwrite("*")
+            #End if
+
+            if compression:
+                tsc = tsc.apply_compression(level=compression["level"],
+                                            alg=compression["alg"],
+                                            path_glob="*")
+            #End if
+
+            #Same provenance attributes the ncrcat back end adds via ncatted
+            #(GenTS records its own version in 'gents_version'):
+            tsc = tsc.add_attrs({"adf_user": adf.user,
+                                 "hist_file_locs": str(starting_location)})
+
+            print(f"\t - generating {len(tsc)} time series file(s) with GenTS")
+            tsc.create_directories()
+            tsc.execute(show_progress=show_progress)
+
+            #Finally, run through the derived variables if applicable:
+            if constit_dict:
+                res = adf.variable_defaults
+                for der_var, constit_list in constit_dict.items():
+                    derive_variable(adf, case_name, der_var, res, ts_dir, constit_list)
+                #End for
+            #End if
+        #End for hist_str
+    #End cases loop
+
+    print("  ...CAM time series file generation has finished successfully.")

--- a/lib/adf_gents.py
+++ b/lib/adf_gents.py
@@ -121,8 +121,36 @@ def create_time_series_gents(adf, baseline=False):
     """
     Generate ADF time series files using GenTS.
 
-    Drop-in alternative to 'AdfDiag.create_time_series'; see this module's
-    docstring for how the two back ends line up.
+    Drop-in alternative to :meth:`AdfDiag.create_time_series`; see this
+    module's docstring for how the two back ends line up.
+
+    Parameters
+    ----------
+    adf : AdfDiag
+        The diagnostics object holding the configuration information.
+    baseline : bool, optional
+        If ``True``, generate the baseline case's time series; otherwise
+        generate the test cases'.  Default is ``False``.
+
+    Returns
+    -------
+    None
+        Writes time series files into each case's ``cam_ts_loc``.
+
+    Raises
+    ------
+    AdfError
+        If GenTS is not installed, if ``gents_compression`` was given without
+        ``gents_compression_level``, if a history file directory is missing,
+        or if ``PS`` is absent from ``diag_var_list`` while model-level
+        variables are being diagnosed.
+
+    Notes
+    -----
+    Uses ``adf.get_basic_info``, ``adf.get_ts_case_config``,
+    ``adf.diag_var_list``, ``adf.variable_defaults``, ``adf.num_procs``,
+    ``adf.user`` and ``adf.end_diag_fail``, plus ``check_derive`` and
+    ``derive_variable`` from :mod:`adf_derive`.
     """
 
     HFCollection, TSCollection = _import_gents()

--- a/lib/adf_gents.py
+++ b/lib/adf_gents.py
@@ -314,7 +314,8 @@ def create_time_series_gents(adf, baseline=False):
             if constit_dict:
                 res = adf.variable_defaults
                 for der_var, constit_list in constit_dict.items():
-                    derive_variable(adf, case_name, der_var, res, ts_dir, constit_list)
+                    derive_variable(adf, case_name, der_var, res, ts_dir,
+                                    constit_list, hist_str=hist_str)
                 #End for
             #End if
         #End for hist_str

--- a/lib/adf_gents.py
+++ b/lib/adf_gents.py
@@ -133,12 +133,23 @@ def create_time_series_gents(adf, baseline=False):
     #ask for them when stdout is actually a terminal.
     show_progress = sys.stdout.isatty()
 
-    #GenTS options (all optional; absent means "behave like the ADF back end"):
-    opts = adf.get_basic_info("gents_options") or {}
-    all_vars = bool(opts.get("all_vars", False))
-    nested_layout = bool(opts.get("nested_layout", False))
-    slice_years = opts.get("slice_years")
-    compression = opts.get("compression")
+    #GenTS options (all optional; absent means "behave like the ADF back end").
+    #These are flat keys rather than a 'gents_options' sub-dictionary because
+    #ADF's config reader allows only one level of nesting (adf_config.py:111).
+    all_vars = bool(adf.get_basic_info("gents_all_vars"))
+    nested_layout = bool(adf.get_basic_info("gents_nested_layout"))
+    slice_years = adf.get_basic_info("gents_slice_years")
+    compression_alg = adf.get_basic_info("gents_compression")
+    compression_level = adf.get_basic_info("gents_compression_level")
+
+    #GenTS requires a level whenever an algorithm is given, so check here
+    #rather than letting it fail part-way through generation:
+    if compression_alg and compression_level is None:
+        emsg = f"'gents_compression' is set to '{compression_alg}', but"
+        emsg += " 'gents_compression_level' was not given.  Please provide a"
+        emsg += " compression level (0-9), or remove 'gents_compression'."
+        adf.end_diag_fail(emsg)
+    #End if
 
     #Same config the built-in back end uses, so the two cannot drift apart:
     cfg = adf.get_ts_case_config(baseline=baseline)
@@ -250,9 +261,9 @@ def create_time_series_gents(adf, baseline=False):
                 tsc = tsc.apply_overwrite("*")
             #End if
 
-            if compression:
-                tsc = tsc.apply_compression(level=compression["level"],
-                                            alg=compression["alg"],
+            if compression_alg:
+                tsc = tsc.apply_compression(level=compression_level,
+                                            alg=compression_alg,
                                             path_glob="*")
             #End if
 

--- a/lib/adf_gents.py
+++ b/lib/adf_gents.py
@@ -110,6 +110,9 @@ def _expand_derived_vars(adf, case_name, hist_files):
 
 def _restrict_to_vars(tsc, variables):
     """Keep only the GenTS orders whose primary variable was requested."""
+    #'primary_var' is a key of GenTS's own order dictionaries rather than part
+    #of its documented surface, so it is worth pinning down which GenTS version
+    #a failure came from: a rename raises KeyError here.
     wanted = set(variables)
     return tsc.copy(ts_orders=[o for o in tsc if o["primary_var"] in wanted])
 
@@ -225,6 +228,9 @@ def create_time_series_gents(adf, baseline=False):
             hfc = hfc.include(f"*{hist_str}.*.nc")
             #Pull metadata explicitly so the progress bar can be silenced;
             #include_years would otherwise trigger it with its own default.
+            #NOTE: pull_metadata mutates hfc in place and returns None, unlike
+            #the include/slice calls around it, so it is deliberately not
+            #reassigned here.
             hfc.pull_metadata(show_progress=show_progress)
             hfc = hfc.include_years(start_year, end_year)
 

--- a/lib/adf_info.py
+++ b/lib/adf_info.py
@@ -880,38 +880,46 @@ class AdfInfo(AdfConfig):
                     + [f"{case_name}*h0*.{var}.*nc"])
         #End def
 
-        #Sweep every variable flat before trying a recursive search: a missing
-        #variable is normal, and recursing per pattern would walk the whole
-        #tree len(patterns) x len(var_list) times before the first hit.
+        #Sweep by pattern rank rather than by variable: every variable is tried
+        #against the configured stream before any variable is tried against the
+        #looser fallback, so a stray file from another stream cannot outrank
+        #the stream the user actually configured.  Within a rank, the flat
+        #search comes first for every variable and the recursive one only
+        #afterwards -- a missing variable is normal, and recursing per pattern
+        #would walk the whole tree once for every pattern tried.
+        n_ranks = len(hist_strs) + 1
         ts_files = []
-        for var in var_list:
-            for pattern in ts_patterns(var):
-                ts_files = utils.find_ts_files(input_location, pattern, recursive=False)
-                if ts_files:
-                    break
-            #End for
-            if ts_files:
-                break
-            #End if
-            logmsg = "get years for time series:"
-            logmsg += f"\n\tVar '{var}' not in dataset, skip to next to try and find climo years..."
-            self.debug_log(logmsg)
-        #End for
-
-        #Nothing sitting flat in the directory, so the files may be in a nested
-        #(GenTS-style) layout.  One recursive sweep, not one per pattern:
-        if not ts_files:
-            for var in var_list:
-                for pattern in ts_patterns(var):
-                    ts_files = utils.find_ts_files(input_location, pattern)
+        skipped = var_list
+        for rank in range(n_ranks):
+            for recursive in (False, True):
+                for idx, var in enumerate(var_list):
+                    ts_files = utils.find_ts_files(input_location,
+                                                   ts_patterns(var)[rank],
+                                                   recursive=recursive)
                     if ts_files:
+                        #Everything ahead of it was tried and missed:
+                        skipped = var_list[:idx]
                         break
+                    #End if
                 #End for
                 if ts_files:
                     break
                 #End if
             #End for
-        #End if
+            if ts_files:
+                break
+            #End if
+        #End for
+
+        #Report only the variables that were genuinely passed over.  Logging
+        #inside the sweep would name every variable in diag_var_list whenever
+        #the files turned out to be in a nested layout, which is not a problem
+        #and not worth dozens of lines of debug log.
+        for var in skipped:
+            logmsg = "get years for time series:"
+            logmsg += f"\n\tVar '{var}' not in dataset, skip to next to try and find climo years..."
+            self.debug_log(logmsg)
+        #End for
 
         if not ts_files:
             errmsg = f"\t ERROR: No time series files found in '{input_ts_loc}' for case "

--- a/lib/adf_info.py
+++ b/lib/adf_info.py
@@ -872,14 +872,21 @@ class AdfInfo(AdfConfig):
 
         # Search for first available variable in var_list to get a time series file to read
         # NOTE: it is assumed all the variables have the same dates!
+        # Try the configured stream(s) first, then the older, looser search
+        # (any h0 stream) so pre-existing directories still work:
+        def ts_patterns(var):
+            """Search patterns for one variable, most specific first."""
+            return ([f"{case_name}.{hstr}.{var}.*nc" for hstr in hist_strs]
+                    + [f"{case_name}*h0*.{var}.*nc"])
+        #End def
+
+        #Sweep every variable flat before trying a recursive search: a missing
+        #variable is normal, and recursing per pattern would walk the whole
+        #tree len(patterns) x len(var_list) times before the first hit.
         ts_files = []
         for var in var_list:
-            #Try the configured stream(s) first, then fall back to the older,
-            #looser search (any h0 stream) so pre-existing directories still work:
-            patterns = [f"{case_name}.{hstr}.{var}.*nc" for hstr in hist_strs]
-            patterns.append(f"{case_name}*h0*.{var}.*nc")
-            for pattern in patterns:
-                ts_files = utils.find_ts_files(input_location, pattern)
+            for pattern in ts_patterns(var):
+                ts_files = utils.find_ts_files(input_location, pattern, recursive=False)
                 if ts_files:
                     break
             #End for
@@ -890,6 +897,21 @@ class AdfInfo(AdfConfig):
             logmsg += f"\n\tVar '{var}' not in dataset, skip to next to try and find climo years..."
             self.debug_log(logmsg)
         #End for
+
+        #Nothing sitting flat in the directory, so the files may be in a nested
+        #(GenTS-style) layout.  One recursive sweep, not one per pattern:
+        if not ts_files:
+            for var in var_list:
+                for pattern in ts_patterns(var):
+                    ts_files = utils.find_ts_files(input_location, pattern)
+                    if ts_files:
+                        break
+                #End for
+                if ts_files:
+                    break
+                #End if
+            #End for
+        #End if
 
         if not ts_files:
             errmsg = f"\t ERROR: No time series files found in '{input_ts_loc}' for case "

--- a/lib/adf_info.py
+++ b/lib/adf_info.py
@@ -44,6 +44,7 @@ import xarray as xr
 # pylint: enable=unused-import
 
 #ADF modules:
+import adf_utils as utils
 from adf_config import AdfConfig
 from adf_base   import AdfError
 
@@ -212,7 +213,7 @@ class AdfInfo(AdfConfig):
 
                 #Get years from pre-made timeseries file(s)
                 found_syear_baseline, found_eyear_baseline = self.get_climo_yrs_from_ts(
-                    input_ts_loc, data_name)
+                    input_ts_loc, data_name, hist_str=baseline_hist_str)
 
                 #History file path isn't needed if user is running ADF directly on time series.
                 #So make sure start and end year are specified:
@@ -415,7 +416,8 @@ class AdfInfo(AdfConfig):
                 print(f"Checking existing time-series files in {input_ts_loc}")
 
                 #Get years from pre-made timeseries file(s)
-                found_syear, found_eyear = self.get_climo_yrs_from_ts(input_ts_loc, case_name)
+                found_syear, found_eyear = self.get_climo_yrs_from_ts(
+                    input_ts_loc, case_name, hist_str=self.__hist_str[case_idx])
 
                 #History file path isn't needed if user is running ADF directly on time series.
                 #So make sure start and end year are specified:
@@ -826,10 +828,21 @@ class AdfInfo(AdfConfig):
     #########
 
     # Utility function to grab climo years from pre-made time series files:
-    def get_climo_yrs_from_ts(self, input_ts_loc, case_name):
+    def get_climo_yrs_from_ts(self, input_ts_loc, case_name, hist_str=None):
         """
         Grab start and end climo years if none are specified in config file
         for pre-made time series file(s)
+
+        Parameters
+        ----------
+        input_ts_loc
+            directory holding the pre-made time series files
+        case_name
+            name of the case whose files should be searched for
+        hist_str : str or list, optional
+            history stream(s) configured for this case.  When given, the
+            stream is used in the search; when absent the older, looser
+            "any h0 stream" search is used instead.
 
         Return
         ------
@@ -848,17 +861,41 @@ class AdfInfo(AdfConfig):
             errmsg = f"\t ERROR: Time series directory '{input_ts_loc}' not found.  Script is exiting."
             raise AdfError(errmsg)
 
+        #Normalize the configured history stream(s) into a list:
+        if not hist_str:
+            hist_strs = []
+        elif isinstance(hist_str, str):
+            hist_strs = [hist_str]
+        else:
+            hist_strs = [h for h in hist_str if h]
+        #End if
+
         # Search for first available variable in var_list to get a time series file to read
         # NOTE: it is assumed all the variables have the same dates!
-        # Also, it is assumed that only h0 files should be climo-ed.
+        ts_files = []
         for var in var_list:
-            ts_files = sorted(input_location.glob(f"{case_name}*h0*.{var}.*nc"))
+            #Try the configured stream(s) first, then fall back to the older,
+            #looser search (any h0 stream) so pre-existing directories still work:
+            patterns = [f"{case_name}.{hstr}.{var}.*nc" for hstr in hist_strs]
+            patterns.append(f"{case_name}*h0*.{var}.*nc")
+            for pattern in patterns:
+                ts_files = utils.find_ts_files(input_location, pattern)
+                if ts_files:
+                    break
+            #End for
             if ts_files:
                 break
-            else:
-                logmsg = "get years for time series:"
-                logmsg += f"\n\tVar '{var}' not in dataset, skip to next to try and find climo years..."
-                self.debug_log(logmsg)
+            #End if
+            logmsg = "get years for time series:"
+            logmsg += f"\n\tVar '{var}' not in dataset, skip to next to try and find climo years..."
+            self.debug_log(logmsg)
+        #End for
+
+        if not ts_files:
+            errmsg = f"\t ERROR: No time series files found in '{input_ts_loc}' for case "
+            errmsg += f"'{case_name}' for any variable in 'diag_var_list'.  Script is exiting."
+            raise AdfError(errmsg)
+        #End if
 
         #Read in file(s)
         if len(ts_files) == 1:

--- a/lib/adf_utils.py
+++ b/lib/adf_utils.py
@@ -72,7 +72,7 @@ seasons = {"ANN": np.arange(1,13,1),
 #HELPER FUNCTIONS
 #################
 
-def find_ts_files(ts_loc, pattern):
+def find_ts_files(ts_loc, pattern, recursive=True):
     """
     Locate time series files matching `pattern` underneath `ts_loc`.
 
@@ -88,6 +88,12 @@ def find_ts_files(ts_loc, pattern):
         directory to search
     pattern : str
         glob pattern, e.g. "case.cam.h0a.T.*nc"
+    recursive : bool, optional
+        Whether to fall back to a recursive search when the flat one finds
+        nothing.  Default is ``True``.  A missing variable is a normal
+        condition, so a caller trying many patterns in a row should pass
+        ``False`` and make a single recursive attempt at the end rather than
+        walking the whole tree once per pattern.
 
     Returns
     -------
@@ -95,7 +101,11 @@ def find_ts_files(ts_loc, pattern):
         Matching files, sorted; empty if nothing matches.
     """
     ts_loc = Path(ts_loc)
-    return sorted(ts_loc.glob(pattern)) or sorted(ts_loc.rglob(pattern))
+    found = sorted(ts_loc.glob(pattern))
+    if found or not recursive:
+        return found
+    #End if
+    return sorted(ts_loc.rglob(pattern))
 
 
 def _ts_file_spans(fils):

--- a/lib/adf_utils.py
+++ b/lib/adf_utils.py
@@ -3,6 +3,8 @@ Generic computation helper functions
 
 Functions
 ---------
+find_ts_files(), ts_files_overlap(), ts_file_span()
+    re-exported from adf_file_utils; time series file discovery
 load_dataset()
     generalized load dataset method used for plotting/analysis functions
 mask_land_or_ocean(arr, msk, use_nan=False)
@@ -42,14 +44,19 @@ Notes
 """
 
 #import statements:
-from pathlib import Path
-
 import numpy as np
 import xarray as xr
 import pandas as pd
 import geocat.comp as gcomp
 
 from adf_base import AdfError
+
+#Time series file discovery lives in its own module so that it can be unit
+#tested without importing the scientific stack (see adf_file_utils).  Re-export
+#here so `utils.find_ts_files(...)` keeps working for every existing caller:
+# pylint: disable=unused-import
+from adf_file_utils import find_ts_files, ts_files_overlap, ts_file_span
+# pylint: enable=unused-import
 
 import warnings  # use to warn user about missing files.
 
@@ -71,151 +78,6 @@ seasons = {"ANN": np.arange(1,13,1),
 #################
 #HELPER FUNCTIONS
 #################
-
-def find_ts_files(ts_loc, pattern, recursive=True):
-    """
-    Locate time series files matching `pattern` underneath `ts_loc`.
-
-    Searches `ts_loc` itself first, which is where ADF's own time series step
-    and a flat GenTS run both put their files.  Only if that finds nothing does
-    it fall back to a recursive search, so that a GenTS archive laid out as
-    <component>/proc/tseries/<frequency>/ can be used by pointing `cam_ts_loc`
-    at the top of the tree instead of the frequency sub-directory.
-
-    Parameters
-    ----------
-    ts_loc : str or Path
-        directory to search
-    pattern : str
-        glob pattern, e.g. "case.cam.h0a.T.*nc"
-    recursive : bool, optional
-        Whether to fall back to a recursive search when the flat one finds
-        nothing.  Default is ``True``.  A missing variable is a normal
-        condition, so a caller trying many patterns in a row should pass
-        ``False`` and make a single recursive attempt at the end rather than
-        walking the whole tree once per pattern.
-
-    Returns
-    -------
-    list of Path
-        Matching files, sorted; empty if nothing matches.
-    """
-    ts_loc = Path(ts_loc)
-    found = sorted(ts_loc.glob(pattern))
-    if found or not recursive:
-        return found
-    #End if
-    return sorted(ts_loc.rglob(pattern))
-
-
-def _ts_file_spans(fils):
-    """
-    Parse the {start}-{end} date token out of each time series file name.
-
-    Parameters
-    ----------
-    fils : list
-        strings or paths to time series files
-
-    Returns
-    -------
-    list of tuple or None
-        (start, end) string pairs sorted chronologically, or ``None`` if any
-        name could not be parsed or the dates do not all use the same width.
-        Callers treat ``None`` as "make no promises about these files".
-    """
-    spans = []
-    for fil in fils:
-        #Last dot-separated token of the stem -- second-to-last of the file
-        #name -- e.g. "001001-001112" in "case.cam.h0a.T.001001-001112.nc":
-        date_str = Path(fil).stem.split(".")[-1]
-        start, sep, end = date_str.partition("-")
-        if not sep or not start.isdigit() or not end.isdigit():
-            #Unrecognized name, so make no promises about it:
-            return None
-        spans.append((start, end))
-    #End for
-
-    #Zero-padded dates of equal width sort chronologically as strings, but
-    #mixed widths (e.g. YYYY next to YYYYMM) would not, so bail out on those:
-    if len({len(s) for span in spans for s in span}) != 1:
-        return None
-    #End if
-
-    return sorted(spans)
-
-
-def ts_files_overlap(fils):
-    """
-    Report whether time series files cover overlapping periods.
-
-    ADF and GenTS both name time series files
-    `{case}.{stream}.{variable}.{start}-{end}.nc`, where the dates are
-    zero-padded and all use the same width for a given variable.  A variable
-    split into consecutive chunks (e.g. 001001-001912 then 002001-002912) can
-    safely be opened together; two overlapping sets (e.g. years 1-20 alongside
-    years 1-40, which happens when a run is extended and the time series are
-    remade over a longer period) cannot, because the combined time axis would
-    contain duplicates.
-
-    Parameters
-    ----------
-    fils : list
-        strings or paths to time series files
-
-    Returns
-    -------
-    bool
-        True if the files overlap, or if the dates could not be read from the
-        names -- in both cases the caller should not blindly combine them.
-        False if the files are non-overlapping and safe to open together.
-    """
-    if len(fils) < 2:
-        return False
-    #End if
-
-    spans = _ts_file_spans(fils)
-    if spans is None:
-        return True
-    #End if
-
-    for (_, prev_end), (next_start, _) in zip(spans, spans[1:]):
-        if next_start <= prev_end:
-            return True
-    #End for
-
-    return False
-
-
-def ts_file_span(fils):
-    """
-    Report the period covered by a set of time series files, taken together.
-
-    Used to name a file derived from several chunked constituent files: the
-    derived file has to advertise the whole span it actually contains, not the
-    span of whichever chunk happened to sort first.  For a single file this is
-    just that file's own dates, so names are unchanged for the common case.
-
-    Parameters
-    ----------
-    fils : list
-        strings or paths to time series files
-
-    Returns
-    -------
-    tuple of str or None
-        (start, end) as they appear in the file names, or ``None`` if the
-        dates could not be read.
-    """
-    spans = _ts_file_spans(fils)
-    if not spans:
-        return None
-    #End if
-
-    #Sorted by start, so the earliest start leads; take the latest end
-    #explicitly rather than assuming the last entry carries it:
-    return spans[0][0], max(end for _, end in spans)
-
 
 def load_dataset(fils):
     """

--- a/lib/adf_utils.py
+++ b/lib/adf_utils.py
@@ -97,6 +97,61 @@ def find_ts_files(ts_loc, pattern):
     return sorted(ts_loc.glob(pattern)) or sorted(ts_loc.rglob(pattern))
 
 
+def ts_files_overlap(fils):
+    """
+    Report whether time series files cover overlapping periods.
+
+    ADF and GenTS both name time series files
+    `{case}.{stream}.{variable}.{start}-{end}.nc`, where the dates are
+    zero-padded and all use the same width for a given variable.  A variable
+    split into consecutive chunks (e.g. 001001-001912 then 002001-002912) can
+    safely be opened together; two overlapping sets (e.g. years 1-20 alongside
+    years 1-40, which happens when a run is extended and the time series are
+    remade over a longer period) cannot, because the combined time axis would
+    contain duplicates.
+
+    Parameters
+    ----------
+    fils : list
+        strings or paths to time series files
+
+    Returns
+    -------
+    bool
+        True if the files overlap, or if the dates could not be read from the
+        names -- in both cases the caller should not blindly combine them.
+        False if the files are non-overlapping and safe to open together.
+    """
+    if len(fils) < 2:
+        return False
+
+    spans = []
+    for fil in fils:
+        #Second-to-last dot-separated token, e.g. "001001-001112" in
+        #"case.cam.h0a.T.001001-001112.nc":
+        date_str = Path(fil).stem.split(".")[-1]
+        start, sep, end = date_str.partition("-")
+        if not sep or not start.isdigit() or not end.isdigit():
+            #Unrecognized name, so make no promises about it:
+            return True
+        spans.append((start, end))
+    #End for
+
+    #Zero-padded dates of equal width sort chronologically as strings, but
+    #mixed widths (e.g. YYYY next to YYYYMM) would not, so bail out on those:
+    widths = {len(s) for span in spans for s in span}
+    if len(widths) != 1:
+        return True
+
+    spans.sort()
+    for (_, prev_end), (next_start, _) in zip(spans, spans[1:]):
+        if next_start <= prev_end:
+            return True
+    #End for
+
+    return False
+
+
 def load_dataset(fils):
     """
     This method exists to get an xarray Dataset from input file information that can be passed into the plotting methods.

--- a/lib/adf_utils.py
+++ b/lib/adf_utils.py
@@ -97,6 +97,43 @@ def find_ts_files(ts_loc, pattern):
     return sorted(ts_loc.glob(pattern)) or sorted(ts_loc.rglob(pattern))
 
 
+def _ts_file_spans(fils):
+    """
+    Parse the {start}-{end} date token out of each time series file name.
+
+    Parameters
+    ----------
+    fils : list
+        strings or paths to time series files
+
+    Returns
+    -------
+    list of tuple or None
+        (start, end) string pairs sorted chronologically, or ``None`` if any
+        name could not be parsed or the dates do not all use the same width.
+        Callers treat ``None`` as "make no promises about these files".
+    """
+    spans = []
+    for fil in fils:
+        #Last dot-separated token of the stem -- second-to-last of the file
+        #name -- e.g. "001001-001112" in "case.cam.h0a.T.001001-001112.nc":
+        date_str = Path(fil).stem.split(".")[-1]
+        start, sep, end = date_str.partition("-")
+        if not sep or not start.isdigit() or not end.isdigit():
+            #Unrecognized name, so make no promises about it:
+            return None
+        spans.append((start, end))
+    #End for
+
+    #Zero-padded dates of equal width sort chronologically as strings, but
+    #mixed widths (e.g. YYYY next to YYYYMM) would not, so bail out on those:
+    if len({len(s) for span in spans for s in span}) != 1:
+        return None
+    #End if
+
+    return sorted(spans)
+
+
 def ts_files_overlap(fils):
     """
     Report whether time series files cover overlapping periods.
@@ -124,32 +161,49 @@ def ts_files_overlap(fils):
     """
     if len(fils) < 2:
         return False
+    #End if
 
-    spans = []
-    for fil in fils:
-        #Second-to-last dot-separated token, e.g. "001001-001112" in
-        #"case.cam.h0a.T.001001-001112.nc":
-        date_str = Path(fil).stem.split(".")[-1]
-        start, sep, end = date_str.partition("-")
-        if not sep or not start.isdigit() or not end.isdigit():
-            #Unrecognized name, so make no promises about it:
-            return True
-        spans.append((start, end))
-    #End for
-
-    #Zero-padded dates of equal width sort chronologically as strings, but
-    #mixed widths (e.g. YYYY next to YYYYMM) would not, so bail out on those:
-    widths = {len(s) for span in spans for s in span}
-    if len(widths) != 1:
+    spans = _ts_file_spans(fils)
+    if spans is None:
         return True
+    #End if
 
-    spans.sort()
     for (_, prev_end), (next_start, _) in zip(spans, spans[1:]):
         if next_start <= prev_end:
             return True
     #End for
 
     return False
+
+
+def ts_file_span(fils):
+    """
+    Report the period covered by a set of time series files, taken together.
+
+    Used to name a file derived from several chunked constituent files: the
+    derived file has to advertise the whole span it actually contains, not the
+    span of whichever chunk happened to sort first.  For a single file this is
+    just that file's own dates, so names are unchanged for the common case.
+
+    Parameters
+    ----------
+    fils : list
+        strings or paths to time series files
+
+    Returns
+    -------
+    tuple of str or None
+        (start, end) as they appear in the file names, or ``None`` if the
+        dates could not be read.
+    """
+    spans = _ts_file_spans(fils)
+    if not spans:
+        return None
+    #End if
+
+    #Sorted by start, so the earliest start leads; take the latest end
+    #explicitly rather than assuming the last entry carries it:
+    return spans[0][0], max(end for _, end in spans)
 
 
 def load_dataset(fils):

--- a/lib/adf_utils.py
+++ b/lib/adf_utils.py
@@ -91,7 +91,8 @@ def find_ts_files(ts_loc, pattern):
 
     Returns
     -------
-    list of Path, sorted; empty if nothing matches.
+    list of Path
+        Matching files, sorted; empty if nothing matches.
     """
     ts_loc = Path(ts_loc)
     return sorted(ts_loc.glob(pattern)) or sorted(ts_loc.rglob(pattern))

--- a/lib/adf_utils.py
+++ b/lib/adf_utils.py
@@ -42,6 +42,8 @@ Notes
 """
 
 #import statements:
+from pathlib import Path
+
 import numpy as np
 import xarray as xr
 import pandas as pd
@@ -69,6 +71,31 @@ seasons = {"ANN": np.arange(1,13,1),
 #################
 #HELPER FUNCTIONS
 #################
+
+def find_ts_files(ts_loc, pattern):
+    """
+    Locate time series files matching `pattern` underneath `ts_loc`.
+
+    Searches `ts_loc` itself first, which is where ADF's own time series step
+    and a flat GenTS run both put their files.  Only if that finds nothing does
+    it fall back to a recursive search, so that a GenTS archive laid out as
+    <component>/proc/tseries/<frequency>/ can be used by pointing `cam_ts_loc`
+    at the top of the tree instead of the frequency sub-directory.
+
+    Parameters
+    ----------
+    ts_loc : str or Path
+        directory to search
+    pattern : str
+        glob pattern, e.g. "case.cam.h0a.T.*nc"
+
+    Returns
+    -------
+    list of Path, sorted; empty if nothing matches.
+    """
+    ts_loc = Path(ts_loc)
+    return sorted(ts_loc.glob(pattern)) or sorted(ts_loc.rglob(pattern))
+
 
 def load_dataset(fils):
     """

--- a/lib/test/unit_tests/test_adf_derive.py
+++ b/lib/test/unit_tests/test_adf_derive.py
@@ -1,0 +1,280 @@
+"""
+Collection of python unit tests
+for "adf_derive.derive_variable".
+
+Covers how a derived variable is built from its constituents' time series
+files: which files are selected (case, history stream, chunking), what the
+resulting file is called, and which situations are refused rather than turned
+into a plausible-looking but wrong field.
+
+NOTE: adf_derive imports xarray and (through adf_utils) the rest of the
+scientific stack, so these are skipped in CI, which installs only PyYAML and
+pytest.  They run in a full ADF environment.
+"""
+
+#+++++++++++++++++++++++
+#Import required modules
+#+++++++++++++++++++++++
+
+import unittest
+import sys
+import os
+import os.path
+import tempfile
+from pathlib import Path
+
+#Set relevant path variables:
+_CURRDIR = os.path.abspath(os.path.dirname(__file__))
+_ADF_LIB_DIR = os.path.join(_CURRDIR, os.pardir, os.pardir)
+
+#Add ADF "lib" directory to python path:
+sys.path.append(_ADF_LIB_DIR)
+
+try:
+    import numpy as np
+    import xarray as xr
+    from adf_derive import derive_variable
+    _HAS_ADF_DERIVE = True
+except ImportError:
+    _HAS_ADF_DERIVE = False
+
+
+class _StubData:
+    """Stand-in for AdfData, whose load_dataset is all derive_variable uses."""
+
+    def load_dataset(self, fils):
+        """Mirror AdfData.load_dataset: a list in, a Dataset (or None) out."""
+        if len(fils) == 0:
+            return None
+        if len(fils) > 1:
+            return xr.open_mfdataset(fils, combine="by_coords")
+        return xr.open_dataset(str(fils[0]))
+
+
+class _StubAdf:
+    """Minimal stand-in for the AdfDiag object derive_variable is handed."""
+
+    def __init__(self):
+        self.data = _StubData()
+        self.messages = []
+
+    def debug_log(self, msg):
+        """Collect rather than write, so tests can assert on the log."""
+        self.messages.append(msg)
+
+
+def _write_ts(path, var, start_year, nyears):
+    """Write a small time series file holding `var` over `nyears` years."""
+    Path(path).parent.mkdir(parents=True, exist_ok=True)
+    time = xr.date_range(f"{start_year:04d}-01-01", periods=nyears * 12,
+                         freq="MS", calendar="noleap", use_cftime=True)
+    ds = xr.Dataset({var: (("time",), np.ones(len(time), dtype="f4"))},
+                    coords={"time": time})
+    ds[var].attrs = {"units": "W/m2", "long_name": f"{var} long name"}
+    ds.to_netcdf(path)
+
+
+#Variables that get multiplied by dry air density; SO4 is one of them:
+_AEROSOL_RES = {"aerosol_zonal_list": ["SO4"], "Rgas": 287.04}
+
+
+@unittest.skipUnless(_HAS_ADF_DERIVE, "adf_derive dependencies not available")
+class AdfDeriveTestRoutine(unittest.TestCase):
+
+    """
+    Unit tests for derived time series file creation.
+    """
+
+    def test_single_file_constituents(self):
+
+        """
+        The ordinary case, and the one every existing configuration uses: one
+        file per constituent produces one derived file named for that span.
+        """
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            for var in ("FSNT", "FLNT"):
+                _write_ts(Path(tmpdir) / f"case.cam.h0a.{var}.000101-002012.nc",
+                          var, 1, 20)
+
+            derive_variable(_StubAdf(), "case", "RESTOM", res={}, ts_dir=tmpdir,
+                            constit_list=["FSNT", "FLNT"], hist_str="cam.h0a")
+
+            out = sorted(Path(tmpdir).glob("*RESTOM*.nc"))
+            self.assertEqual([f.name for f in out],
+                             ["case.cam.h0a.RESTOM.000101-002012.nc"])
+            with xr.open_dataset(out[0]) as ds:
+                self.assertEqual(len(ds.time), 240)
+
+    def test_chunked_constituents_span_all_chunks(self):
+
+        """
+        A constituent split into consecutive chunks must produce one derived
+        file covering the whole period, named for that whole period.  Taking
+        only the first chunk gave a half-length variable that the AMWG table
+        then reported next to full-length ones.
+        """
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            for var in ("FSNT", "FLNT"):
+                _write_ts(Path(tmpdir) / f"case.cam.h0a.{var}.000101-001012.nc",
+                          var, 1, 10)
+                _write_ts(Path(tmpdir) / f"case.cam.h0a.{var}.001101-002012.nc",
+                          var, 11, 10)
+
+            derive_variable(_StubAdf(), "case", "RESTOM", res={}, ts_dir=tmpdir,
+                            constit_list=["FSNT", "FLNT"], hist_str="cam.h0a")
+
+            out = sorted(Path(tmpdir).glob("*RESTOM*.nc"))
+            self.assertEqual([f.name for f in out],
+                             ["case.cam.h0a.RESTOM.000101-002012.nc"])
+            with xr.open_dataset(out[0]) as ds:
+                self.assertEqual(len(ds.time), 240)
+
+    def test_multiple_history_streams(self):
+
+        """
+        Derivation runs once per configured history stream.  Without being
+        told which one, the search matches both streams' copies of a
+        constituent, whose dates are identical, and the variable is dropped.
+        """
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            for hstr in ("cam.h0a", "cam.h0b"):
+                for var in ("FSNT", "FLNT"):
+                    _write_ts(
+                        Path(tmpdir) / f"case.{hstr}.{var}.000101-002012.nc",
+                        var, 1, 20)
+
+            derive_variable(_StubAdf(), "case", "RESTOM", res={}, ts_dir=tmpdir,
+                            constit_list=["FSNT", "FLNT"], hist_str="cam.h0a")
+
+            out = sorted(Path(tmpdir).glob("*RESTOM*.nc"))
+            self.assertEqual([f.name for f in out],
+                             ["case.cam.h0a.RESTOM.000101-002012.nc"])
+
+    def test_aerosol_multiple_history_streams(self):
+
+        """
+        The same for the aerosol path: PMID and T present under two streams
+        must not be combined, which xarray cannot do and reports as an
+        uncaught ValueError that ends the run.
+        """
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            for var in ("so4_a1", "so4_a2"):
+                _write_ts(Path(tmpdir) / f"case.cam.h0a.{var}.000101-002012.nc",
+                          var, 1, 20)
+            for hstr in ("cam.h0a", "cam.h0b"):
+                for var in ("PMID", "T"):
+                    _write_ts(
+                        Path(tmpdir) / f"case.{hstr}.{var}.000101-002012.nc",
+                        var, 1, 20)
+
+            derive_variable(_StubAdf(), "case", "SO4", res=_AEROSOL_RES,
+                            ts_dir=tmpdir, constit_list=["so4_a1", "so4_a2"],
+                            hist_str="cam.h0a")
+
+            out = sorted(Path(tmpdir).glob("*.SO4.*.nc"))
+            self.assertEqual([f.name for f in out],
+                             ["case.cam.h0a.SO4.000101-002012.nc"])
+            with xr.open_dataset(out[0]) as ds:
+                self.assertFalse(np.isnan(ds["SO4"].values).any())
+                self.assertEqual(ds["SO4"].attrs["units"], "kg/m3")
+
+    def test_aerosol_refuses_mismatched_pmid(self):
+
+        """
+        PMID and T covering a different period than the constituents must be
+        refused.  xarray aligns on time with an outer join, so this does not
+        raise -- it silently writes an all-NaN field that looks like a real
+        one.
+        """
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            for var in ("so4_a1", "so4_a2"):
+                _write_ts(Path(tmpdir) / f"case.cam.h0a.{var}.000101-002012.nc",
+                          var, 1, 20)
+            #Only another case's PMID/T are present, over a disjoint period:
+            for var in ("PMID", "T"):
+                _write_ts(Path(tmpdir) / f"other.cam.h0a.{var}.010001-011912.nc",
+                          var, 100, 20)
+
+            derive_variable(_StubAdf(), "case", "SO4", res=_AEROSOL_RES,
+                            ts_dir=tmpdir, constit_list=["so4_a1", "so4_a2"],
+                            hist_str="cam.h0a")
+
+            self.assertEqual(sorted(Path(tmpdir).glob("*.SO4.*.nc")), [])
+
+    def test_overlapping_constituent_files_refused(self):
+
+        """
+        Two sets of files for one constituent (a run extended and re-processed
+        over a longer period) cannot be combined: the time axis would contain
+        duplicates.
+        """
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            for var in ("FSNT", "FLNT"):
+                _write_ts(Path(tmpdir) / f"case.cam.h0a.{var}.000101-002012.nc",
+                          var, 1, 20)
+                _write_ts(Path(tmpdir) / f"case.cam.h0a.{var}.000101-004012.nc",
+                          var, 1, 40)
+
+            derive_variable(_StubAdf(), "case", "RESTOM", res={}, ts_dir=tmpdir,
+                            constit_list=["FSNT", "FLNT"], hist_str="cam.h0a")
+
+            self.assertEqual(sorted(Path(tmpdir).glob("*RESTOM*.nc")), [])
+
+    def test_other_case_in_same_tree_ignored(self):
+
+        """
+        Several cases can share one time series tree, and the search recurses.
+        A derivation must use its own case's files, not whichever sorts first.
+        """
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            mine = Path(tmpdir) / "mycase" / "proc" / "tseries"
+            other = Path(tmpdir) / "acase" / "proc" / "tseries"
+            for var in ("FSNT", "FLNT"):
+                _write_ts(mine / f"mycase.cam.h0a.{var}.000101-002012.nc",
+                          var, 1, 20)
+                _write_ts(other / f"acase.cam.h0a.{var}.002101-004012.nc",
+                          var, 21, 20)
+
+            derive_variable(_StubAdf(), "mycase", "RESTOM", res={},
+                            ts_dir=tmpdir, constit_list=["FSNT", "FLNT"],
+                            hist_str="cam.h0a")
+
+            out = sorted(Path(tmpdir).rglob("*RESTOM*.nc"))
+            self.assertEqual(len(out), 1)
+            self.assertEqual(out[0].name,
+                             "mycase.cam.h0a.RESTOM.000101-002012.nc")
+            self.assertEqual(out[0].parent, mine)
+            with xr.open_dataset(out[0]) as ds:
+                self.assertEqual(len(ds.time), 240)
+
+    def test_missing_constituent_writes_nothing(self):
+
+        """
+        A constituent absent from the run means the variable cannot be built;
+        say so and move on rather than writing a partial field.
+        """
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            _write_ts(Path(tmpdir) / "case.cam.h0a.FSNT.000101-002012.nc",
+                      "FSNT", 1, 20)
+
+            derive_variable(_StubAdf(), "case", "RESTOM", res={}, ts_dir=tmpdir,
+                            constit_list=["FSNT", "FLNT"], hist_str="cam.h0a")
+
+            self.assertEqual(sorted(Path(tmpdir).glob("*RESTOM*.nc")), [])
+
+#++++++++++++++++++
+
+#Run unit tests if this script is called directly:
+if __name__ == "__main__":
+    unittest.main()
+
+#############
+#End of file

--- a/lib/test/unit_tests/test_adf_derive.py
+++ b/lib/test/unit_tests/test_adf_derive.py
@@ -254,6 +254,30 @@ class AdfDeriveTestRoutine(unittest.TestCase):
             with xr.open_dataset(out[0]) as ds:
                 self.assertEqual(len(ds.time), 240)
 
+    def test_case_name_containing_constituent_name(self):
+
+        """
+        The derived file name is built by substituting whole dot-separated
+        tokens.  A plain string replace rewrites a case name that happens to
+        contain the constituent's name too, producing a file that
+        AdfData.get_timeseries_file (which searches on the case name) can
+        never find.
+        """
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            for var in ("FSNT", "FLNT"):
+                _write_ts(
+                    Path(tmpdir) / f"bFSNTtest.cam.h0a.{var}.000101-002012.nc",
+                    var, 1, 20)
+
+            derive_variable(_StubAdf(), "bFSNTtest", "RESTOM", res={},
+                            ts_dir=tmpdir, constit_list=["FSNT", "FLNT"],
+                            hist_str="cam.h0a")
+
+            out = sorted(Path(tmpdir).glob("*RESTOM*.nc"))
+            self.assertEqual([f.name for f in out],
+                             ["bFSNTtest.cam.h0a.RESTOM.000101-002012.nc"])
+
     def test_missing_constituent_writes_nothing(self):
 
         """

--- a/lib/test/unit_tests/test_adf_file_utils.py
+++ b/lib/test/unit_tests/test_adf_file_utils.py
@@ -1,6 +1,6 @@
 """
 Collection of python unit tests
-for the "adf_utils" helper functions.
+for the "adf_file_utils" time series file discovery helpers.
 """
 
 #+++++++++++++++++++++++
@@ -21,20 +21,15 @@ _ADF_LIB_DIR = os.path.join(_CURRDIR, os.pardir, os.pardir)
 #Add ADF "lib" directory to python path:
 sys.path.append(_ADF_LIB_DIR)
 
-#adf_utils pulls in the scientific stack (xarray, geocat, ...), which isn't
-#always present in a bare test environment, so skip rather than error there:
-try:
-    from adf_utils import find_ts_files, ts_files_overlap, ts_file_span
-    _HAS_ADF_UTILS = True
-except ImportError:
-    _HAS_ADF_UTILS = False
+#adf_file_utils imports nothing but pathlib, so these run in CI, where only
+#PyYAML and pytest are installed:
+from adf_file_utils import find_ts_files, ts_files_overlap, ts_file_span
 
-#++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
-#Main adf_utils testing routine, used when script is run directly
-#++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+#++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+#Main adf_file_utils testing routine, used when script is run directly
+#++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
-@unittest.skipUnless(_HAS_ADF_UTILS, "adf_utils dependencies not available")
-class AdfUtilsTestRoutine(unittest.TestCase):
+class AdfFileUtilsTestRoutine(unittest.TestCase):
 
     """
     Unit tests for the time series file search helper, which has to cope with

--- a/lib/test/unit_tests/test_adf_info_climo_yrs.py
+++ b/lib/test/unit_tests/test_adf_info_climo_yrs.py
@@ -234,6 +234,46 @@ class AdfInfoClimoYrsTestRoutine(unittest.TestCase):
 
             self.assertEqual((syr, eyr), (100, 104))
 
+    def test_configured_stream_beats_flat_file_from_another_stream(self):
+
+        """
+        The configured stream outranks the search order.
+
+        A stray flat file from some other h0 stream must not beat the
+        configured stream's file just because the configured one happens to
+        sit in a sub-directory: 'hist_str' is what the user asked for, and the
+        loose "any h0 stream" pattern is only a fallback.
+        """
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            _write_ts(Path(tmpdir) / "case.cam.h0b.T.010001-010512.nc",
+                      "T", 100, 5)
+            _write_ts(Path(tmpdir) / "atm" / "proc" / "tseries" / "month_1"
+                      / "case.cam.h0a.T.020001-021012.nc", "T", 200, 10)
+
+            syr, eyr = _call(_StubInfo(["T"]), tmpdir, "case",
+                             hist_str="cam.h0a")
+
+            self.assertEqual((syr, eyr), (200, 209))
+
+    def test_nested_layout_does_not_flood_the_debug_log(self):
+
+        """
+        A nested archive is a supported layout, not a problem.  Reporting
+        every variable in 'diag_var_list' as missing on the way to finding it
+        would bury the real messages in a long run.
+        """
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            _write_ts(Path(tmpdir) / "atm" / "proc" / "tseries" / "month_1"
+                      / "case.cam.h0a.T.000101-002012.nc", "T", 1, 20)
+
+            stub = _StubInfo(["T", "PRECT", "PS", "U", "V"])
+            syr, eyr = _call(stub, tmpdir, "case", hist_str="cam.h0a")
+
+            self.assertEqual((syr, eyr), (1, 20))
+            self.assertEqual(stub.messages, [])
+
     def test_chunked_files_span_all_chunks(self):
 
         """

--- a/lib/test/unit_tests/test_adf_info_climo_yrs.py
+++ b/lib/test/unit_tests/test_adf_info_climo_yrs.py
@@ -1,0 +1,288 @@
+"""
+Collection of python unit tests
+for "AdfInfo.get_climo_yrs_from_ts".
+
+This is the method that works out the climatology year range when a user runs
+ADF against pre-made time series files and gives no years in the config file.
+It searches for the first variable in 'diag_var_list' it can find a file for,
+trying the configured history stream(s) before the older, looser "any h0
+stream" pattern, and looking in the directory itself before recursing into a
+nested (GenTS-style) layout.
+
+NOTE: unlike test_adf_file_utils, these tests import adf_info, which pulls in
+xarray and (through adf_utils) the rest of the scientific stack.  The ADF unit
+test workflow installs only PyYAML and pytest, so they are skipped there and
+only run in a full ADF environment.  Moving the search itself into
+adf_file_utils would make it testable in CI; that is a bigger change than the
+one these tests were written to cover.
+"""
+
+#+++++++++++++++++++++++
+#Import required modules
+#+++++++++++++++++++++++
+
+import unittest
+import sys
+import os
+import os.path
+import tempfile
+from pathlib import Path
+
+#Set relevant path variables:
+_CURRDIR = os.path.abspath(os.path.dirname(__file__))
+_ADF_LIB_DIR = os.path.join(_CURRDIR, os.pardir, os.pardir)
+
+#Add ADF "lib" directory to python path:
+sys.path.append(_ADF_LIB_DIR)
+
+try:
+    import numpy as np
+    import xarray as xr
+    from adf_base import AdfError
+    from adf_info import AdfInfo
+    _HAS_ADF_INFO = True
+except ImportError:
+    _HAS_ADF_INFO = False
+
+
+class _StubInfo:
+    """
+    Minimal stand-in for AdfInfo.
+
+    get_climo_yrs_from_ts reads only 'diag_var_list' and calls 'debug_log', so
+    the method can be exercised unbound without building a real AdfInfo (which
+    needs a full config file and existing case directories).
+    """
+
+    def __init__(self, diag_var_list):
+        self.diag_var_list = diag_var_list
+        self.messages = []
+
+    def debug_log(self, msg):
+        """Collect rather than write, so tests can assert on the log."""
+        self.messages.append(msg)
+
+
+def _write_ts(path, var, start_year, nyears):
+    """Write a small time series file holding `var` over `nyears` years."""
+    Path(path).parent.mkdir(parents=True, exist_ok=True)
+    time = xr.date_range(f"{start_year:04d}-01-01", periods=nyears * 12,
+                         freq="MS", calendar="noleap", use_cftime=True)
+    ds = xr.Dataset({var: (("time",), np.ones(len(time), dtype="f4"))},
+                    coords={"time": time})
+    ds.to_netcdf(path)
+
+
+def _call(stub, ts_loc, case_name, hist_str=None):
+    """Call the method unbound with the stub standing in for self."""
+    return AdfInfo.get_climo_yrs_from_ts(stub, ts_loc, case_name,
+                                         hist_str=hist_str)
+
+
+@unittest.skipUnless(_HAS_ADF_INFO, "adf_info dependencies not available")
+class AdfInfoClimoYrsTestRoutine(unittest.TestCase):
+
+    """
+    Unit tests for the pre-made time series year search.
+    """
+
+    def test_flat_layout_configured_stream(self):
+
+        """
+        The ordinary case: files sitting directly in 'cam_ts_loc', found using
+        the history stream the config file asked for.
+        """
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            _write_ts(Path(tmpdir) / "case.cam.h0a.T.000101-002012.nc",
+                      "T", 1, 20)
+
+            syr, eyr = _call(_StubInfo(["T"]), tmpdir, "case",
+                             hist_str="cam.h0a")
+
+            self.assertEqual((syr, eyr), (1, 20))
+
+    def test_nested_layout_found_by_recursive_sweep(self):
+
+        """
+        A GenTS-style <component>/proc/tseries/<frequency>/ tree must still be
+        found, which is what the second, recursive sweep is for.
+        """
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            _write_ts(Path(tmpdir) / "atm" / "proc" / "tseries" / "month_1"
+                      / "case.cam.h0a.T.000101-002012.nc", "T", 1, 20)
+
+            syr, eyr = _call(_StubInfo(["T"]), tmpdir, "case",
+                             hist_str="cam.h0a")
+
+            self.assertEqual((syr, eyr), (1, 20))
+
+    def test_missing_first_variable_falls_through(self):
+
+        """
+        A variable absent from the run is normal; the search moves on to the
+        next one in 'diag_var_list' and logs why.
+        """
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            _write_ts(Path(tmpdir) / "case.cam.h0a.PRECT.000101-001012.nc",
+                      "PRECT", 1, 10)
+
+            stub = _StubInfo(["T", "PRECT"])
+            syr, eyr = _call(stub, tmpdir, "case", hist_str="cam.h0a")
+
+            self.assertEqual((syr, eyr), (1, 10))
+            self.assertTrue(any("'T' not in dataset" in m
+                                for m in stub.messages))
+
+    def test_no_hist_str_uses_loose_h0_pattern(self):
+
+        """
+        With no history stream configured, the older 'any h0 stream' pattern
+        has to keep working, since that is what pre-existing directories and
+        pre-existing configs rely on.
+        """
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            _write_ts(Path(tmpdir) / "case.cam.h0a.T.000101-002012.nc",
+                      "T", 1, 20)
+
+            syr, eyr = _call(_StubInfo(["T"]), tmpdir, "case", hist_str=None)
+
+            self.assertEqual((syr, eyr), (1, 20))
+
+    def test_hist_str_list_tries_each_stream(self):
+
+        """
+        'hist_str' arrives as a list when several streams are configured; a
+        file belonging to the second one must still be found.
+        """
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            _write_ts(Path(tmpdir) / "case.cam.h1a.T.000101-000512.nc",
+                      "T", 1, 5)
+
+            syr, eyr = _call(_StubInfo(["T"]), tmpdir, "case",
+                             hist_str=["cam.h0a", "cam.h1a"])
+
+            self.assertEqual((syr, eyr), (1, 5))
+
+    def test_configured_stream_wins_over_loose_pattern(self):
+
+        """
+        When both the configured stream and some other h0 stream are present,
+        the configured one must win -- the loose pattern is a fallback, not a
+        competitor.
+        """
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            _write_ts(Path(tmpdir) / "case.cam.h0a.T.000101-002012.nc",
+                      "T", 1, 20)
+            _write_ts(Path(tmpdir) / "case.cam.h0b.T.010001-010512.nc",
+                      "T", 100, 5)
+
+            syr, eyr = _call(_StubInfo(["T"]), tmpdir, "case",
+                             hist_str="cam.h0a")
+
+            self.assertEqual((syr, eyr), (1, 20))
+
+    def test_flat_files_win_over_nested_files(self):
+
+        """
+        A file in the directory itself beats one buried in a sub-directory, so
+        a stray nested archive cannot shadow the expected location.
+        """
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            _write_ts(Path(tmpdir) / "case.cam.h0a.T.000101-002012.nc",
+                      "T", 1, 20)
+            _write_ts(Path(tmpdir) / "atm" / "proc" / "tseries" / "month_1"
+                      / "case.cam.h0a.T.010001-010512.nc", "T", 100, 5)
+
+            syr, eyr = _call(_StubInfo(["T"]), tmpdir, "case",
+                             hist_str="cam.h0a")
+
+            self.assertEqual((syr, eyr), (1, 20))
+
+    def test_flat_sweep_precedes_recursive_sweep_across_variables(self):
+
+        """
+        Pins down a deliberate consequence of sweeping flat across every
+        variable before recursing at all.
+
+        Here the first variable in 'diag_var_list' exists only nested, while a
+        later variable sits flat in the directory.  The flat sweep reaches the
+        later variable first, so the years come from that file.  Searching one
+        variable at a time -- recursing before moving on -- would instead have
+        returned the first variable's nested file.
+
+        Both are legitimate: the method documents that it assumes every
+        variable covers the same dates, and picks whichever it finds first.
+        The test exists so that the choice is a recorded decision rather than
+        an accident, and so a future change to the search order is noticed.
+        """
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            _write_ts(Path(tmpdir) / "atm" / "proc" / "tseries" / "month_1"
+                      / "case.cam.h0a.T.000101-002012.nc", "T", 1, 20)
+            _write_ts(Path(tmpdir) / "case.cam.h0a.PRECT.010001-010512.nc",
+                      "PRECT", 100, 5)
+
+            syr, eyr = _call(_StubInfo(["T", "PRECT"]), tmpdir, "case",
+                             hist_str="cam.h0a")
+
+            self.assertEqual((syr, eyr), (100, 104))
+
+    def test_chunked_files_span_all_chunks(self):
+
+        """
+        A variable split into consecutive chunks reports the whole range, not
+        just the first chunk's.
+        """
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            _write_ts(Path(tmpdir) / "case.cam.h0a.T.000101-001012.nc",
+                      "T", 1, 10)
+            _write_ts(Path(tmpdir) / "case.cam.h0a.T.001101-002012.nc",
+                      "T", 11, 10)
+
+            syr, eyr = _call(_StubInfo(["T"]), tmpdir, "case",
+                             hist_str="cam.h0a")
+
+            self.assertEqual((syr, eyr), (1, 20))
+
+    def test_nothing_found_raises(self):
+
+        """
+        No files for any variable is a configuration error, and has to say so
+        rather than failing later on an unbound variable.
+        """
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            _write_ts(Path(tmpdir) / "othercase.cam.h0a.T.000101-002012.nc",
+                      "T", 1, 20)
+
+            with self.assertRaises(AdfError):
+                _call(_StubInfo(["T"]), tmpdir, "case", hist_str="cam.h0a")
+
+    def test_missing_directory_raises(self):
+
+        """
+        'cam_ts_done' says the files already exist, so a missing directory
+        means the configuration is wrong and should be reported plainly.
+        """
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with self.assertRaises(AdfError):
+                _call(_StubInfo(["T"]), os.path.join(tmpdir, "nope"),
+                      "case", hist_str="cam.h0a")
+
+#++++++++++++++++++
+
+#Run unit tests if this script is called directly:
+if __name__ == "__main__":
+    unittest.main()
+
+#############
+#End of file

--- a/lib/test/unit_tests/test_adf_utils.py
+++ b/lib/test/unit_tests/test_adf_utils.py
@@ -24,7 +24,7 @@ sys.path.append(_ADF_LIB_DIR)
 #adf_utils pulls in the scientific stack (xarray, geocat, ...), which isn't
 #always present in a bare test environment, so skip rather than error there:
 try:
-    from adf_utils import find_ts_files, ts_files_overlap
+    from adf_utils import find_ts_files, ts_files_overlap, ts_file_span
     _HAS_ADF_UTILS = True
 except ImportError:
     _HAS_ADF_UTILS = False
@@ -170,6 +170,50 @@ class AdfUtilsTestRoutine(unittest.TestCase):
                 Path("/some/dir/case.cam.h0a.T.002001-002912.nc")]
 
         self.assertFalse(ts_files_overlap(fils))
+
+    def test_ts_file_span_single_file(self):
+
+        """
+        A single file spans its own dates, so a derived variable built from
+        one constituent file keeps exactly the name ADF has always written.
+        """
+
+        span = ts_file_span(["case.cam.h0a.FSNT.000101-002012.nc"])
+
+        self.assertEqual(span, ("000101", "002012"))
+
+    def test_ts_file_span_chunked(self):
+
+        """
+        Consecutive chunks span from the first start to the last end, which is
+        what the derived file's name has to advertise.
+        """
+
+        fils = ["case.cam.h0a.FSNT.000101-001012.nc",
+                "case.cam.h0a.FSNT.001101-002012.nc"]
+
+        self.assertEqual(ts_file_span(fils), ("000101", "002012"))
+
+    def test_ts_file_span_unordered(self):
+
+        """
+        The span must not depend on the order the files arrive in.
+        """
+
+        fils = ["case.cam.h0a.FSNT.001101-002012.nc",
+                "case.cam.h0a.FSNT.000101-001012.nc"]
+
+        self.assertEqual(ts_file_span(fils), ("000101", "002012"))
+
+    def test_ts_file_span_unparsable(self):
+
+        """
+        Names the dates cannot be read from give None, so the caller falls back
+        to leaving the name alone rather than inventing a span.
+        """
+
+        self.assertIsNone(ts_file_span(["case.cam.h0a.FSNT.somethingelse.nc"]))
+        self.assertIsNone(ts_file_span([]))
 
 #++++++++++++++++++
 

--- a/lib/test/unit_tests/test_adf_utils.py
+++ b/lib/test/unit_tests/test_adf_utils.py
@@ -12,6 +12,7 @@ import sys
 import os
 import os.path
 import tempfile
+from pathlib import Path
 
 #Set relevant path variables:
 _CURRDIR = os.path.abspath(os.path.dirname(__file__))
@@ -23,7 +24,7 @@ sys.path.append(_ADF_LIB_DIR)
 #adf_utils pulls in the scientific stack (xarray, geocat, ...), which isn't
 #always present in a bare test environment, so skip rather than error there:
 try:
-    from adf_utils import find_ts_files
+    from adf_utils import find_ts_files, ts_files_overlap
     _HAS_ADF_UTILS = True
 except ImportError:
     _HAS_ADF_UTILS = False
@@ -102,6 +103,73 @@ class AdfUtilsTestRoutine(unittest.TestCase):
             open(os.path.join(tmpdir, "case.cam.h0a.T.000101-001112.nc"), "w").close()
 
             self.assertEqual(find_ts_files(tmpdir, "case.cam.h0a.PRECT.*nc"), [])
+
+    def test_ts_files_overlap_consecutive(self):
+
+        """
+        Consecutive chunks (what GenTS writes when 'slice_years' is set, and
+        how CMIP-style archives are laid out) can safely be opened together.
+        """
+
+        fils = ["case.cam.h0a.T.001001-001912.nc",
+                "case.cam.h0a.T.002001-002912.nc"]
+
+        self.assertFalse(ts_files_overlap(fils))
+
+    def test_ts_files_overlap_overlapping(self):
+
+        """
+        Two sets covering overlapping periods (years 1-20 alongside years
+        1-40, from a run that was extended and re-processed) must be refused.
+        """
+
+        fils = ["case.cam.h0a.T.000101-002012.nc",
+                "case.cam.h0a.T.000101-004012.nc"]
+
+        self.assertTrue(ts_files_overlap(fils))
+
+    def test_ts_files_overlap_single_file(self):
+
+        """
+        A single file never overlaps anything.
+        """
+
+        self.assertFalse(ts_files_overlap(["case.cam.h0a.T.001001-001112.nc"]))
+
+    def test_ts_files_overlap_unparsable(self):
+
+        """
+        Names the date range cannot be read from are reported as overlapping,
+        so that callers do not blindly combine them.
+        """
+
+        fils = ["case.cam.h0a.T.somethingelse.nc",
+                "case.cam.h0a.T.001001-001912.nc"]
+
+        self.assertTrue(ts_files_overlap(fils))
+
+    def test_ts_files_overlap_mixed_date_widths(self):
+
+        """
+        Mixed date widths do not sort chronologically as strings, so they are
+        refused rather than compared incorrectly.
+        """
+
+        fils = ["case.cam.h0a.T.0010-0019.nc",
+                "case.cam.h0a.T.002001-002912.nc"]
+
+        self.assertTrue(ts_files_overlap(fils))
+
+    def test_ts_files_overlap_accepts_paths(self):
+
+        """
+        Callers pass Path objects from find_ts_files, not just strings.
+        """
+
+        fils = [Path("/some/dir/case.cam.h0a.T.001001-001912.nc"),
+                Path("/some/dir/case.cam.h0a.T.002001-002912.nc")]
+
+        self.assertFalse(ts_files_overlap(fils))
 
 #++++++++++++++++++
 

--- a/lib/test/unit_tests/test_adf_utils.py
+++ b/lib/test/unit_tests/test_adf_utils.py
@@ -104,6 +104,40 @@ class AdfUtilsTestRoutine(unittest.TestCase):
 
             self.assertEqual(find_ts_files(tmpdir, "case.cam.h0a.PRECT.*nc"), [])
 
+    def test_find_ts_files_no_recurse(self):
+
+        """
+        With recursive=False a nested file is not found, so a caller sweeping
+        many patterns can avoid walking the whole tree for each one.
+        """
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            subdir = os.path.join(tmpdir, "atm", "proc", "tseries", "month_1")
+            os.makedirs(subdir)
+            fname = "case.cam.h0a.T.000101-001112.nc"
+            open(os.path.join(subdir, fname), "w").close()
+
+            self.assertEqual(
+                find_ts_files(tmpdir, "case.cam.h0a.T.*nc", recursive=False), [])
+            #...but the default still finds it:
+            self.assertEqual(
+                [f.name for f in find_ts_files(tmpdir, "case.cam.h0a.T.*nc")], [fname])
+
+    def test_find_ts_files_no_recurse_still_finds_flat(self):
+
+        """
+        recursive=False must not change the flat case, which is what ADF's own
+        time series step and a flat GenTS run both produce.
+        """
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            fname = "case.cam.h0a.T.000101-001112.nc"
+            open(os.path.join(tmpdir, fname), "w").close()
+
+            found = find_ts_files(tmpdir, "case.cam.h0a.T.*nc", recursive=False)
+
+            self.assertEqual([f.name for f in found], [fname])
+
     def test_ts_files_overlap_consecutive(self):
 
         """

--- a/lib/test/unit_tests/test_adf_utils.py
+++ b/lib/test/unit_tests/test_adf_utils.py
@@ -1,0 +1,113 @@
+"""
+Collection of python unit tests
+for the "adf_utils" helper functions.
+"""
+
+#+++++++++++++++++++++++
+#Import required modules
+#+++++++++++++++++++++++
+
+import unittest
+import sys
+import os
+import os.path
+import tempfile
+
+#Set relevant path variables:
+_CURRDIR = os.path.abspath(os.path.dirname(__file__))
+_ADF_LIB_DIR = os.path.join(_CURRDIR, os.pardir, os.pardir)
+
+#Add ADF "lib" directory to python path:
+sys.path.append(_ADF_LIB_DIR)
+
+#adf_utils pulls in the scientific stack (xarray, geocat, ...), which isn't
+#always present in a bare test environment, so skip rather than error there:
+try:
+    from adf_utils import find_ts_files
+    _HAS_ADF_UTILS = True
+except ImportError:
+    _HAS_ADF_UTILS = False
+
+#++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+#Main adf_utils testing routine, used when script is run directly
+#++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+@unittest.skipUnless(_HAS_ADF_UTILS, "adf_utils dependencies not available")
+class AdfUtilsTestRoutine(unittest.TestCase):
+
+    """
+    Unit tests for the time series file search helper, which has to cope with
+    both ADF's flat time series directory and GenTS's nested
+    <component>/proc/tseries/<frequency>/ layout.
+    """
+
+    def test_find_ts_files_flat(self):
+
+        """
+        Check that a file sitting directly in the search directory is found.
+        """
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            fname = "case.cam.h0a.T.000101-001112.nc"
+            open(os.path.join(tmpdir, fname), "w").close()
+
+            found = find_ts_files(tmpdir, "case.cam.h0a.T.*nc")
+
+            self.assertEqual([f.name for f in found], [fname])
+
+    def test_find_ts_files_nested(self):
+
+        """
+        Check that a file buried in a GenTS-style sub-directory is found when
+        nothing matches at the top level.
+        """
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            subdir = os.path.join(tmpdir, "atm", "proc", "tseries", "month_1")
+            os.makedirs(subdir)
+            fname = "case.cam.h0a.T.000101-001112.nc"
+            open(os.path.join(subdir, fname), "w").close()
+
+            found = find_ts_files(tmpdir, "case.cam.h0a.T.*nc")
+
+            self.assertEqual([f.name for f in found], [fname])
+
+    def test_find_ts_files_prefers_flat(self):
+
+        """
+        Check that the flat match wins, so that a nested directory of files
+        from some other run can't shadow the expected location.
+        """
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            subdir = os.path.join(tmpdir, "atm", "proc", "tseries", "month_1")
+            os.makedirs(subdir)
+            fname = "case.cam.h0a.T.000101-001112.nc"
+            open(os.path.join(tmpdir, fname), "w").close()
+            open(os.path.join(subdir, fname), "w").close()
+
+            found = find_ts_files(tmpdir, "case.cam.h0a.T.*nc")
+
+            self.assertEqual(len(found), 1)
+            self.assertEqual(os.path.dirname(str(found[0])), tmpdir)
+
+    def test_find_ts_files_no_match(self):
+
+        """
+        Check that a search with no matches returns an empty list, rather
+        than raising, so callers can warn and move on.
+        """
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            open(os.path.join(tmpdir, "case.cam.h0a.T.000101-001112.nc"), "w").close()
+
+            self.assertEqual(find_ts_files(tmpdir, "case.cam.h0a.PRECT.*nc"), [])
+
+#++++++++++++++++++
+
+#Run unit tests if this script is called directly:
+if __name__ == "__main__":
+    unittest.main()
+
+#############
+#End of file

--- a/scripts/analysis/amwg_table.py
+++ b/scripts/analysis/amwg_table.py
@@ -213,10 +213,11 @@ def amwg_table(adf):
                 continue
             #End if
 
-            #A variable split into consecutive chunks (which is what GenTS
-            #produces when 'slice_years' is set, and how CMIP-style archives are
-            #laid out) can be opened together.  Overlapping sets cannot, because
-            #the combined time axis would contain duplicates:
+            #A variable split into consecutive chunks, which is what GenTS
+            #produces when 'slice_years' is set, can be opened together.
+            #Overlapping sets cannot, because the combined time axis would
+            #contain duplicates.  Only ADF/GenTS names have readable dates, so
+            #anything else is skipped rather than combined on a guess:
             if utils.ts_files_overlap(ts_files):
                 errmsg =  "\t    WARNING: Time series files for the variable "
                 errmsg += f"'{var}' cover overlapping or unrecognized periods, so it will be"

--- a/scripts/analysis/amwg_table.py
+++ b/scripts/analysis/amwg_table.py
@@ -213,10 +213,15 @@ def amwg_table(adf):
                 continue
             #End if
 
-            #TEMPORARY:  For now, make sure only one file exists:
-            if len(ts_files) != 1:
-                errmsg =  "\t    WARNING: Currently the AMWG table script can only handle one time series file per variable."
-                errmsg += f" Multiple files were found for the variable '{var}', so it will be skipped."
+            #A variable split into consecutive chunks (which is what GenTS
+            #produces when 'slice_years' is set, and how CMIP-style archives are
+            #laid out) can be opened together.  Overlapping sets cannot, because
+            #the combined time axis would contain duplicates:
+            if utils.ts_files_overlap(ts_files):
+                errmsg =  "\t    WARNING: Time series files for the variable "
+                errmsg += f"'{var}' cover overlapping or unrecognized periods, so it will be"
+                errmsg += " skipped.  Please leave only one set of time series files per"
+                errmsg += " variable in the directory."
                 print(errmsg)
                 continue
             #End if
@@ -356,7 +361,10 @@ def amwg_table(adf):
 def _get_row_vals(data):
     # Now that data is (time,), we can do our simple stats:
 
-    data_mean = data.data.mean()
+    #Reduce to plain floats up front.  When a variable spans several time
+    #series files these arrays are dask-backed (open_mfdataset), and a dask
+    #scalar has no .item() and does not honour a numeric format spec.
+    data_mean = float(data.data.mean())
     #Conditional Formatting depending on type of float
     if np.abs(data_mean) < 1:
         formatter = ".3g"
@@ -364,14 +372,14 @@ def _get_row_vals(data):
         formatter = ".3f"
 
     data_sample = len(data)
-    data_std = data.std()
+    data_std = float(data.std())
     data_sem = data_std / data_sample
     data_ci = data_sem * 1.96  # https://en.wikipedia.org/wiki/Standard_error
     data_trend = stats.linregress(data.year, data.values)
 
-    stdev = f'{data_std.data.item() : {formatter}}'
-    sem = f'{data_sem.data.item() : {formatter}}'
-    ci = f'{data_ci.data.item() : {formatter}}'
+    stdev = f'{data_std : {formatter}}'
+    sem = f'{data_sem : {formatter}}'
+    ci = f'{data_ci : {formatter}}'
     slope_int = f'{data_trend.intercept : {formatter}} + {data_trend.slope : {formatter}} t'
     pval = f'{data_trend.pvalue : {formatter}}'
 

--- a/scripts/analysis/amwg_table.py
+++ b/scripts/analysis/amwg_table.py
@@ -204,7 +204,7 @@ def amwg_table(adf):
 
             #Create list of time series files present for variable:
             ts_filenames = f'{case_name}.*.{var}.*nc'
-            ts_files = sorted(input_location.glob(ts_filenames))
+            ts_files = utils.find_ts_files(input_location, ts_filenames)
 
             # If no files exist, try to move to next variable. --> Means we can not proceed with this variable, and it'll be problematic later.
             if not ts_files:


### PR DESCRIPTION
## What this does

ADF turns model history files into time series files (one file per variable). Today it does that itself, by calling `ncrcat`. The CESM project is moving to a separate tool called [GenTS](https://github.com/AgentOxygen/GenTS) for this same job.

This pull request adds a switch so ADF can hand that step to GenTS instead. It also lets ADF read time series files that GenTS already made somewhere else, so you don't have to make them again.

Nothing changes unless you ask for it. If you leave the new setting out of your config file, ADF behaves exactly as it does today.

## How to use it

In your config file, under `diag_basic_info`:

```yaml
ts_tool: gents
```

Use `adf`, or leave the line out entirely, to keep the current behavior.

There are a few optional settings, all of which can be skipped:

```yaml
gents_all_vars: false        # true = make every variable in the file, not just the ones you listed
gents_nested_layout: false   # true = use the folder layout the CESM project archives
gents_slice_years: 10        # leave out = one file per variable covering all your years
gents_compression: zlib      # leave out = no compression
gents_compression_level: 2   # required whenever gents_compression is given
```

These are separate entries rather than one indented block, because ADF's config
reader only allows one level of indentation.

## Why the change is small

I expected this to be a big job and it wasn't, for two reasons.

First, GenTS already names its files the same way ADF does, so nothing downstream needed to be taught a new naming scheme.

Second, if you point GenTS at the folder holding the history files, its output lands in one flat folder, just like ADF's own output. The nested folder layout only shows up if you ask for it.

I also worried that GenTS would leave out the extra pieces ADF needs to work with model levels (`hyam`, `hybm`, and friends). It doesn't. GenTS copies anything that doesn't change over time into every file, so those come along automatically.

## One thing to watch out for

There is one real difference in behavior, and it's worth understanding.

When ADF makes the time series itself, it tucks a copy of surface pressure (`PS`) into every 3-D variable's file. GenTS doesn't do that. Because surface pressure changes over time, GenTS treats it as a variable in its own right and gives it its own file.

ADF can already find surface pressure in a separate file, but only if you have listed `PS` in `diag_var_list`. So **if you use GenTS, add `PS` to your variable list.** If you forget, ADF now stops with a clear message explaining why, instead of quietly dropping all your 3-D variables later on.

## Installing GenTS

GenTS is optional and is deliberately **not** added to ADF's conda environment file. It needs newer versions of some packages than ADF currently pins, and changing those pins for everyone is a much bigger decision than this pull request.

Install it yourself, and please pin numpy:

```
pip install gents "numpy>=2.0,<2.3"
```

The pin matters. GenTS wants numpy 2.0 or newer. But `numba`, which gets pulled in while ADF computes climatologies, refuses anything newer than 2.2. If you just run `pip install gents`, you get numpy 2.5 and **every climatology fails**, while ADF still prints that it finished successfully. I hit this during testing and it took a while to spot.

If you install into a virtual environment on top of a conda environment, you will also need to set `PROJ_DATA` and `ESMFMKFILE` yourself, because virtual environments don't pick those up automatically.

## A known problem you will see when testing this

While testing I found that **every variable fails to be regridded**, on this branch and on `main` alike.

The cause is a file-naming mismatch that has nothing to do with GenTS. The climatology step writes files named like `mycase_cam.h0a_T_climo.nc`, but the regridding step looks for `mycase_T_*.nc`. Those never match, so regridding quietly finds nothing. The run still says "completed successfully", because that step only prints a warning, which is why it's easy to miss.

**This is already fixed in #435**, which rewrites the regridding step to look up climatology files through the shared data-access code instead of matching filenames by hand.

I did not fix it here, to keep this pull request focused. I branched off `main`, which is why the problem shows up in my test runs.

## Related issues

This addresses, or helps with, a few open issues:

- **#466 (incorporate GenTS)** — this is that work.
- **#1 (time series generation requires NCO/ncrcat)** — that issue lists three ways forward, the third being "a config option that lets the user choose". That is what this does. GenTS uses the netCDF library directly and never calls `ncrcat`, so with `ts_tool: gents` an ADF install no longer needs NCO for this step. The default path still uses `ncrcat`, so the requirement isn't gone, just avoidable.
- **#161 (AMWG tables with more than one time series file per variable)** — fixed. The table script had a note in it saying it could only handle one file per variable and skipped anything else. It now combines files that cover consecutive periods. Files covering *overlapping* periods are still skipped, with a clearer message, because combining those would double up the time axis. The example in that issue is a CMIP-style archive laid out exactly the way GenTS lays one out.
- **#442 (time series creation times out a terminal)** — helped. That issue asks for something to be printed periodically so a session doesn't go silent and drop. GenTS prints a progress bar while it works, and this branch shows it when you're at a terminal and hides it when output is going to a log file.
- **#22 (option to compress generated netCDF files)** — partly. `gents_compression` compresses the time series files when GenTS is doing the work. Climatology and regridded files, and the default path, are unaffected.
- **#179 (CMIP-style time series in chunks)** — partly. Reading a variable that is split into consecutive chunks now works. Picking a subset of years out of a longer archive still does not.

Two related issues I looked at and deliberately did **not** fold in:

- **#433 (multiple time ranges present at once)** needs ADF to choose files by year, which is a real piece of work. This branch doesn't fix it, but it does make the failure obvious instead of confusing: you now get a message naming the variable and saying the periods overlap.
- **#297 (deriving variables from pre-made time series)** needs a way to derive without reading history files, which is genuinely a separate change.

There is also **#440 (make the time series directory instead of aborting)**, which suggests a change to the same function I touched. I'd push back on that one gently. That code only runs when `cam_ts_done` is true, which is the user saying "my time series already exist". If the directory isn't there, something is wrong with the configuration, and creating an empty directory just moves the failure somewhere less obvious. I think the clear error is the right behavior, so I left it alone — happy to be told otherwise.

## Suggested order for merging

1. **#435 first.** It fixes the regridding problem described above. Merging it first means everything after it can be properly tested, including the map plots that are currently broken for everyone.
2. **This one second.** It shares three files with #435 (`adf_dataset.py`, `adf_info.py`, `adf_utils.py`), but the edits are in different parts of those files, so any conflicts should be small and mechanical. Merging it after #435 also means the GenTS option can finally be checked against working regridding, which is exactly where the surface pressure difference described above matters.
3. **#417 whenever convenient.** It only overlaps with this branch in the example config file, and in a different section of it. It is independent of the other two.

## Testing done

Run end to end on Casper, comparing cases `b.e23_alpha17f.BLT1850.ne30_t232.098` and `.093` (years 10-11).

- Ran the whole pipeline the old way (`ts_tool: adf`) to confirm nothing broke. Finished successfully.
- Ran the whole pipeline the new way (`ts_tool: gents`). Finished successfully.
- Compared the two. Both made 17 files with **identical names**. Opening the temperature file from each, the temperature data and the time values are **exactly identical**. Both runs produced the same 14 plots.
- Confirmed the vertical-coordinate pieces (`hyam`, `hybm`, and so on) really are inside the GenTS files, and that the "cannot be regridded" message never appears in either run.
- Confirmed the new error message appears if you forget to add `PS`.
- Read back a folder of GenTS files with `cam_ts_done: true` and no years given. ADF skipped making files and correctly worked out the years were 10 to 11.
- Confirmed ADF can also find files in GenTS's nested folder layout.
- All 55 unit tests pass, including 38 new ones.

Two things turned up while testing and are fixed here:

- The optional settings were originally written as one indented `gents_options` block. That silently doesn't work, because ADF's config reader only allows one level of indentation. They are now separate entries.
- Turning on `gents_slice_years` produced four files per variable and revealed that the AMWG table script skipped every variable in that situation (#161 above). Fixing that in turn exposed that the table statistics assumed data loaded from a single file. Both are fixed, and re-running the single-file case reproduces the old tables exactly, character for character.

One caveat on the comparison: because regridding is broken on `main` (see above), the matching plot counts only cover the plots that don't need regridding. The map plots weren't exercised for either option. That leg is worth redoing once #435 is in.


## Review round (added after the first review)

An AGENTS.md-driven review of this branch is [in the comments](https://github.com/NCAR/ADF/pull/467#issuecomment-5455244397).
It found one blocker; a second, worse one turned up while fixing it. Both were in
`derive_variable`, and both are fixed here.

**Blocker 1 - chunked constituents were truncated.** `derive_variable` took
`constit_matches[0]`, the first chunk only. With `gents_slice_years: 10` over years
1-20, RESTOM came out covering years 1-10, named for that shorter span, and the AMWG
table then reported it alongside full-length variables with no warning. All of a
constituent's files are now opened together and the derived variable is written as a
single file spanning them, matching what the built-in back end produces. Constituents
whose own files overlap are refused, reusing `ts_files_overlap`.

**Blocker 2 - `TypeError` on the aerosol path.** `load_dataset` was handed a `Path`
where it needs a list; it starts with `len(fils)`, and `len(PosixPath)` raises. This
only worked before the switch to `find_ts_files` because `glob.glob()[0]` returned a
*string*. It fires for any variable that is both derived and in `aerosol_zonal_list` -
SO4, SOA, BC, POM and DUST all qualify - which is why my test case (which only derives
RESTOM) never hit it. PMID and T now take the whole list, which also stops a
single-chunk PMID from silently NaN-ing a full-span product through time-axis
alignment.

Also addressed from the review:

- **Cross-case contamination.** The constituent, PMID and T patterns carried no case
  name, and `find_ts_files` falls back to a recursive search. With two cases under one
  tree covering adjacent (so non-overlapping) periods, `mycase`'s RESTOM was built from
  *both* cases' data and written under the other case's directory under the other
  case's name: `acase/acase.cam.h0a.RESTOM.000101-004012.nc`, 480 times, instead of
  `mycase/mycase.cam.h0a.RESTOM.000101-002012.nc`, 240 times. Now anchored to the case
  name, falling back to the looser pattern so existing directories keep working.
- **The new unit tests were skipping in CI.** `adf_utils` imports numpy/xarray/pandas/
  geocat at module level, and the unit test workflow installs only PyYAML and pytest,
  so all ten tests were skipped and CI reported green. The three helpers moved to
  `lib/adf_file_utils.py`, which imports nothing but pathlib; `adf_utils` re-exports
  them so every caller is unchanged. Checked in a venv holding only pyyaml and pytest:
  10 skipped before, 33 passing and 0 skipped now.
- **Recursive tree walks.** A missing variable is normal, and
  `get_climo_yrs_from_ts` could trigger a full recursive walk per pattern per variable.
  `find_ts_files` gained a `recursive` keyword (default unchanged); the year search now
  sweeps flat first and makes a single recursive pass afterwards.
- NumPy-style `Parameters`/`Returns` on `get_ts_case_config` and
  `create_time_series_gents` (AGENTS.md 6.2), and comments on the two GenTS assumptions
  that read like bugs (`pull_metadata` mutating in place, `primary_var` being a GenTS
  internal).

**Not changed here, deliberately.** The review also flagged that
`amwg_table._get_row_vals` computes the standard error as `std / n` rather than
`std / sqrt(n)`, and uses `data.std()` (ddof=0) where a sample standard deviation is
wanted. Both predate this PR. They change published table numbers, so they belong in
their own PR rather than riding along here.

Single-file constituents produce byte-identical filenames and contents, so the default
`ts_tool: adf` path is unchanged. pylint on `adf_diag.py` and `adf_info.py` is 9.81
against the 9.5 CI threshold (`main` is exactly 9.50).


## Second review round

The fixes above were themselves reviewed, by an agent given only the diff and
`AGENTS.md` and none of the reasoning behind them. That was worth doing: **it found
two blocking bugs that the first round introduced or left**, both verified before
fixing.

**Derived variables were lost for cases with several history streams.** Derivation runs
once per configured stream, but `derive_variable` was never told which one, so the
constituent search matched every stream's copy — and two streams hold files with
identical dates. The overlap guard then rejected the constituent, and a case with
`hist_str: [cam.h0a, cam.h0b]` lost every derived variable. On the aerosol path PMID and
T from two streams went into `open_mfdataset` together, which cannot order datasets with
identical time coordinates, and the `ValueError` propagated out of `create_time_series`
and ended the run with a traceback (AGENTS.md §4.5 rules that out for framework code).

Verified against the round-one code and against this PR as originally submitted:

| | as submitted | round one | now |
| --- | --- | --- | --- |
| RESTOM, two streams | file written | **nothing written** | file written |
| SO4 aerosol, two streams | `TypeError` | `ValueError` | file written |

`hist_str` now reaches `derive_variable` from both back ends and is the first pattern
tried. Note the middle column: round one was a real regression on the first row.

**The configured history stream could lose to the loose fallback.** The flat-then-recursive
sweep in `get_climo_yrs_from_ts` checked every pattern flat, for every variable, before
recursing at all — so a stray flat file from another stream beat the configured stream's
file whenever that sat in a nested archive, contradicting the comment two lines above it.
Sweeping by pattern rank restores the precedence and keeps the performance win. Compared
old against new over 5100 combinations of 8 file layouts × 4 variable lists × 5 `hist_str`
settings:

```
identical result                                                4428
found vs not-found differs                                         0
new picks a non-configured stream where the old picked a
    configured one                                                 0
differ only in which *variable* supplied the dates               672
```

Those 672 are a deliberate consequence, recorded in a test: a flat match for a later
variable now beats a nested match for an earlier one. The method documents that it assumes
every variable covers the same dates, so which variable supplies them is not meaningful,
whereas which stream does is.

Also from this round:

- **A silently all-NaN aerosol field.** PMID and T are looked up with a fallback that can
  reach another case's files, and xarray aligns on time with an outer join — so a disjoint
  pair does not raise, it writes an all-NaN field that looks real. Reproduced writing SO4
  with `nan_frac = 1.0`; now refused with a message naming the variable.
- **A mangled derived file name.** The name came from a plain string replace of the
  constituent, so case `bFSNTtest` deriving RESTOM from FSNT produced
  `bRESTOMtest.cam.h0a.RESTOM...`, which `AdfData.get_timeseries_file` searches for by case
  name and can never find. Whole dot-separated tokens are substituted now.
- **A support claim that was not true.** Two comments said chunked CMIP-style archives
  work. They do not — the date token is the last dot-separated part of the stem, and a CMIP
  name has no interior dots, so it cannot be parsed and the files are refused. Refusing is
  right; claiming support was not. The comments now say only ADF/GenTS names have readable
  dates.
- `lib/adf_file_utils.py` is added to the linting workflow's `testable_files` set (it scores
  10.00/10), and no longer reports every variable as missing while walking a nested archive.

**Tests.** 38 new, up from the 16 after round one: `test_adf_file_utils.py` (13, and these
run in CI), `test_adf_derive.py` (9) and `test_adf_info_climo_yrs.py` (13). The latter two
import xarray so they skip in CI, which installs only PyYAML and pytest — noted in their
module docstrings, with moving the searches into `adf_file_utils` as the follow-up that
would make them CI-visible. Each set was run against the preceding commit to confirm it
fails there: of the 8 original `test_adf_derive.py` cases, 5 pass against round one and the
3 that fail are exactly the bugs above.

pylint on `adf_diag.py` and `adf_info.py` is 9.81 against the 9.5 threshold.

## A note on speed

GenTS groups all the variables from one set of history files into a single task, so for a typical ADF run it works through them one at a time. In my test, 17 variables took about two minutes, where ADF's own approach spreads variables across processors. It's not wrong, just slower for this shape of job. Worth measuring before recommending GenTS for very large runs.




---

## End-to-end runs on real data

Run on Casper against two deliberately dissimilar cases — different stream naming,
different era, different vertical grid:

- **test**: `b.e30_alpha09e_m.B1850C_MTso_Gris_Marbl.ne30_t233_wgx3.389`, `cam.h0a`, 93 levels, years 11–15
- **baseline**: `ceresmip_amip02`, `cam.h0`, 32 levels, years 2000–2004

Variables `PS, TS, ICEFRAC, RESTOM, PRECT, Q` — covering a derived variable, a 3-D
field needing vertical interpolation, and two fields with no obs entry.

| run | regrid | PNGs | zonal | polar | Q levels | website | tables |
| --- | --- | --- | --- | --- | --- | --- | --- |
| model vs model, `ts_tool: adf` | 13 | 280 | 70 | 140 | 200/850 hPa | yes | 3 csv |
| model vs model, `ts_tool: gents` | 13 | 280 | 70 | 140 | 200/850 hPa | yes | 3 csv |
| model vs obs | 6 | 200 | 50 | 100 | 200/850 hPa | yes | 1 csv |

**The two back ends are equivalent.** Same eight variables, identical file names,
identical time axes, and `np.array_equal` true on every variable's data — including
`Q` at `(60, 93, 192, 288)`. The AMWG tables match character for character. The only
differences are the two documented ones: GenTS puts `hyam`/`hybm`/`hyai`/`hybi` in
every file, and the built-in back end embeds `PS` in the 3-D file where GenTS gives it
its own.

`RESTOM` derived correctly under both. The obs run correctly plotted only the four
variables that have obs entries and skipped `ICEFRAC` and `RESTOM`, which have none.
Zonal and polar plots were checked by eye, not just counted: Arctic `ICEFRAC` with
correct coastlines and more ice in the 1850 control than in AMIP; `Q` zonal showing the
tropical surface humidity maximum with Antarctic topography masked; obs `TS` against
ERAI at 288.55 vs 288.30 K, RMSE 1.34 K.

**These runs needed #435.** Two blockers, both in the regridding step and both fixed
there rather than here — see the merge order below, which they confirm:

1. On `main` the test-case climo lookup never matches, so all three configs produced
   zero plots while reporting success. Fixed by #435.
2. GenTS output tripped `_determine_vertical_coord_type`, which inspected the dataset's
   dimensions rather than the variable's, so 2-D fields were sent into hybrid
   interpolation and the run died with `KeyError: 'lev'`. Fixed in
   [#435](https://github.com/NCAR/ADF/pull/435); it is that PR's function and this
   branch only exposes it.

## Correction: the numpy pin above is out of date

The install guidance said to pin `numpy>=2.0,<2.3` because numba rejects anything
newer. That was true of the numba installed when this was written, but the cap moves
with each numba release — numba 0.65.0 declares `numpy<2.5,>=1.22`. On the stack these
runs used (numba 0.65.0, numpy 2.4.3, gents 1.2.0, netCDF4 1.7.4) `pip install gents`
needed **no dependency changes at all**, and every climatology succeeded. The comment
and the ImportError message now describe the real constraint and say to check numpy
against numba after installing, rather than pinning a bound that may be wrong for your
environment.
