### PR TITLE
Use the configured years to choose time series files (#433)

### DIFF
--- a/lib/adf_dataset.py
+++ b/lib/adf_dataset.py
@@ -140,10 +140,15 @@ class AdfData:
         """
         chosen = utils.select_ts_files(fils, syr, eyr)
         if len(chosen) != len(fils):
-            msg = f"time series for '{field}': {len(fils)} files found, using "
-            msg += f"the {len(chosen)} needed for years {syr}-{eyr}: "
-            msg += ", ".join(str(Path(f).name) for f in chosen)
-            self.adf.debug_log(msg)
+            msg = f"\t    INFO: '{field}' has {len(fils)} time series files that "
+            msg += "cannot be used together, so the "
+            msg += f"{len(chosen)} needed for years {syr}-{eyr} were used."
+            #Say it on screen as well as in the log: the numbers a user sees
+            #change when this happens, and that should not be silent.
+            print(msg)
+            self.adf.debug_log(
+                msg + "  Files used: "
+                + ", ".join(str(Path(f).name) for f in chosen))
         #End if
         return chosen
 

--- a/lib/adf_dataset.py
+++ b/lib/adf_dataset.py
@@ -137,6 +137,11 @@ class AdfData:
 
         If hist_str is given, restrict the search to that history stream
         (time series files are named {case}.{hist_str}.{field}.*.nc).
+
+        The files are narrowed to those needed for the case's climatology
+        years, so that a directory holding more than one set for the same
+        variable (years 1-20 alongside years 1-40, say) does not produce a
+        combined time axis with duplicate times.
         """
         # list of paths (could be multiple cases)
         ts_locs = self.adf.get_cam_info("cam_ts_loc", required=True)
@@ -146,13 +151,17 @@ class AdfData:
             ts_filenames = f'{case}.{hist_str}.{field}.*nc'
         else:
             ts_filenames = f'{case}.*.{field}.*nc'
-        return utils.find_ts_files(ts_loc, ts_filenames)
+        fils = utils.find_ts_files(ts_loc, ts_filenames)
+        climo_yrs = self.adf.climo_yrs
+        return utils.select_ts_files(fils, climo_yrs["syears"][caseindex],
+                                     climo_yrs["eyears"][caseindex])
 
     # Reference case (baseline/obs)
     def get_ref_timeseries_file(self, field, hist_str=None):
         """Return list of reference time series files.
 
         If hist_str is given, restrict the search to that history stream.
+        Narrowed to the baseline's climatology years, as for the test cases.
         """
         if self.adf.compare_obs:
             warnings.warn("\t    WARNING: ADF does not currently expect "
@@ -163,7 +172,10 @@ class AdfData:
             ts_filenames = f'{self.ref_case_label}.{hist_str}.{field}.*nc'
         else:
             ts_filenames = f'{self.ref_case_label}.*.{field}.*nc'
-        return utils.find_ts_files(ts_loc, ts_filenames)
+        fils = utils.find_ts_files(ts_loc, ts_filenames)
+        climo_yrs = self.adf.climo_yrs
+        return utils.select_ts_files(fils, climo_yrs["syear_baseline"],
+                                     climo_yrs["eyear_baseline"])
 
 
     def load_timeseries_dataset(self, fils):

--- a/lib/adf_dataset.py
+++ b/lib/adf_dataset.py
@@ -132,6 +132,21 @@ class AdfData:
     # Time series files
     #------------------
     # Test case(s)
+    def _select_ts_files(self, fils, syr, eyr, field):
+        """Narrow time series files to the years wanted, saying so in the log.
+
+        Files are only narrowed when they could not be opened together, so a
+        message here means the directory held more than one set for `field`.
+        """
+        chosen = utils.select_ts_files(fils, syr, eyr)
+        if len(chosen) != len(fils):
+            msg = f"time series for '{field}': {len(fils)} files found, using "
+            msg += f"the {len(chosen)} needed for years {syr}-{eyr}: "
+            msg += ", ".join(str(Path(f).name) for f in chosen)
+            self.adf.debug_log(msg)
+        #End if
+        return chosen
+
     def get_timeseries_file(self, case, field, hist_str=None):
         """Return list of test time series files.
 
@@ -153,8 +168,8 @@ class AdfData:
             ts_filenames = f'{case}.*.{field}.*nc'
         fils = utils.find_ts_files(ts_loc, ts_filenames)
         climo_yrs = self.adf.climo_yrs
-        return utils.select_ts_files(fils, climo_yrs["syears"][caseindex],
-                                     climo_yrs["eyears"][caseindex])
+        return self._select_ts_files(fils, climo_yrs["syears"][caseindex],
+                                     climo_yrs["eyears"][caseindex], field)
 
     # Reference case (baseline/obs)
     def get_ref_timeseries_file(self, field, hist_str=None):
@@ -174,8 +189,8 @@ class AdfData:
             ts_filenames = f'{self.ref_case_label}.*.{field}.*nc'
         fils = utils.find_ts_files(ts_loc, ts_filenames)
         climo_yrs = self.adf.climo_yrs
-        return utils.select_ts_files(fils, climo_yrs["syear_baseline"],
-                                     climo_yrs["eyear_baseline"])
+        return self._select_ts_files(fils, climo_yrs["syear_baseline"],
+                                     climo_yrs["eyear_baseline"], field)
 
 
     def load_timeseries_dataset(self, fils):

--- a/lib/adf_derive.py
+++ b/lib/adf_derive.py
@@ -152,7 +152,8 @@ def check_derive(self, res, var, case_name, diag_var_list, constit_dict, hist_fi
 
 ########
 
-def _find_constit(ts_dir, case_name, constit, hist_str=None):
+def _find_constit(ts_dir, case_name, constit, hist_str=None, *,
+                  syr=None, eyr=None):
     """
     Locate a constituent's time series file(s) for one case and stream.
 
@@ -174,6 +175,11 @@ def _find_constit(ts_dir, case_name, constit, hist_str=None):
         variable name to search for
     hist_str : str, optional
         history stream being processed, e.g. "cam.h0a"
+    syr, eyr : int, optional
+        first and last year being processed.  When given, only the files
+        needed to cover them are returned, so a directory holding more than
+        one set of files for the same constituent (years 1-20 alongside years
+        1-40, say) can still be used.
 
     Returns
     -------
@@ -189,17 +195,24 @@ def _find_constit(ts_dir, case_name, constit, hist_str=None):
     for pattern in patterns:
         found = utils.find_ts_files(ts_dir, pattern)
         if found:
-            return found
+            return utils.select_ts_files(found, syr, eyr)
         #End if
     #End for
     return []
 
 
 def derive_variable(self, case_name, var, res=None, ts_dir=None,
-                         constit_list=None, overwrite=None, hist_str=None):
+                         constit_list=None, overwrite=None, hist_str=None, *,
+                         syr=None, eyr=None):
     """
     Derive variables acccording to steps given here.  Since derivations will depend on the
     variable, each variable to derive will need its own set of steps below.
+
+    The years being processed (`syr`, `eyr`) narrow each constituent's files
+    to the ones needed, so a directory that holds two sets for the same
+    constituent -- years 1-20 alongside years 1-40, which happens when a run
+    is extended and the time series are remade over a longer period -- can
+    still be used.
 
     A constituent may be split across several consecutive time series files,
     which is what GenTS produces when 'gents_slice_years' is set.  All of a
@@ -232,7 +245,8 @@ def derive_variable(self, case_name, var, res=None, ts_dir=None,
     constit_matches = {}
     for constit in constit_list:
         # Check if the constituent file(s) are present, if so add them to the dict
-        matches = _find_constit(ts_dir, case_name, constit, hist_str)
+        matches = _find_constit(ts_dir, case_name, constit, hist_str,
+                                syr=syr, eyr=eyr)
         if not matches:
             continue
         if utils.ts_files_overlap(matches):
@@ -342,7 +356,8 @@ def derive_variable(self, case_name, var, res=None, ts_dir=None,
             # the whole list: taking [0] would multiply a full-span variable by
             # a single chunk, which time-axis alignment turns silently into NaN.
             # Check if PMID is in file:
-            ds_pmid = self.data.load_dataset(_find_constit(ts_dir, case_name, "PMID", hist_str))
+            ds_pmid = self.data.load_dataset(_find_constit(ts_dir, case_name, "PMID", hist_str,
+                                                          syr=syr, eyr=eyr))
             if not ds_pmid:
                 errmsg = "Missing necessary files for dry air density (rho) "
                 errmsg += "calculation.\nPlease make sure 'PMID' is in the CAM "
@@ -354,7 +369,8 @@ def derive_variable(self, case_name, var, res=None, ts_dir=None,
                 return
 
             # Check if T is in file:
-            ds_t = self.data.load_dataset(_find_constit(ts_dir, case_name, "T", hist_str))
+            ds_t = self.data.load_dataset(_find_constit(ts_dir, case_name, "T", hist_str,
+                                                       syr=syr, eyr=eyr))
             if not ds_t:
                 errmsg = "Missing necessary files for dry air density (rho) "
                 errmsg += "calculation.\nPlease make sure 'T' is in the CAM "

--- a/lib/adf_diag.py
+++ b/lib/adf_diag.py
@@ -1273,11 +1273,14 @@ class AdfDiag(AdfWeb):
                         if verbose > 1:
                             print(f"Copying ts file: {adf_file_list} to MDTF dir")
                     elif len(adf_file_list) > 1:
-                        if verbose > 0:
+                        # A variable split into consecutive files, which is what
+                        # GenTS writes when 'gents_slice_years' is set.  MDTF
+                        # wants one file per variable, so these are combined
+                        # below rather than one of them being picked.
+                        if verbose > 1:
                             print(
-                                f"""WARNING: found multiple timeseries files {adf_file_list}.
-                                 Continuing with best guess; suggest cleaning up multiple 
-                                    dates in ts dir"""
+                                f"Combining {len(adf_file_list)} ts files into "
+                                "one file for the MDTF dir"
                             )
                     else:
                         if verbose > 1:
@@ -1286,6 +1289,7 @@ class AdfDiag(AdfWeb):
                                      found in {adf_file_str}. Skipping"""
                             )
                         continue  # skip this case/hist_str/var file
+                    adf_file_list = sorted(adf_file_list)
                     adf_file = adf_file_list[0]
 
                     # If freq is not set, it means we just started this hist_str. 
@@ -1353,9 +1357,21 @@ class AdfDiag(AdfWeb):
                             )
                         continue  # simply skip file copy for this variable:
 
-                    if verbose > 1:
-                        print(f"copying {adf_file} to {mdtf_file}")
-                    shutil.copyfile(adf_file, mdtf_file)
+                    if len(adf_file_list) == 1:
+                        if verbose > 1:
+                            print(f"copying {adf_file} to {mdtf_file}")
+                        shutil.copyfile(adf_file, mdtf_file)
+                    else:
+                        # Consecutive files, so write them out as the single
+                        # file MDTF expects instead of copying just the first:
+                        if verbose > 1:
+                            print(f"writing {adf_file_list} to {mdtf_file}")
+                        with xr.open_mfdataset(
+                            adf_file_list, decode_times=False, combine="by_coords"
+                        ) as mdtf_ds:
+                            mdtf_ds.to_netcdf(mdtf_file)
+                        # End with
+                    # End if
                 # end for hist_str
             # end for var
         # end for case

--- a/lib/adf_diag.py
+++ b/lib/adf_diag.py
@@ -95,7 +95,7 @@ for root, dirs, files in os.walk(_DIAG_SCRIPTS_PATH):
 # +++++++++++++++++++++++++++++
 
 # Finally, import needed ADF modules:
-from adf_file_utils import select_ts_files, ts_files_overlap
+from adf_file_utils import select_ts_files, ts_files_need_combining
 from adf_web import AdfWeb
 from adf_dataset import AdfData
 from adf_derive import check_derive, derive_variable
@@ -1275,8 +1275,7 @@ class AdfDiag(AdfWeb):
                     # cannot be combined -- select_ts_files hands back a set it
                     # could not resolve -- so those keep the older behavior of
                     # copying the first and saying so.
-                    combine_files = (len(adf_file_list) > 1
-                                     and not ts_files_overlap(adf_file_list))
+                    combine_files = ts_files_need_combining(adf_file_list)
 
                     if len(adf_file_list) == 1:
                         if verbose > 1:

--- a/lib/adf_diag.py
+++ b/lib/adf_diag.py
@@ -95,6 +95,7 @@ for root, dirs, files in os.walk(_DIAG_SCRIPTS_PATH):
 # +++++++++++++++++++++++++++++
 
 # Finally, import needed ADF modules:
+from adf_file_utils import select_ts_files
 from adf_web import AdfWeb
 from adf_dataset import AdfData
 from adf_derive import check_derive, derive_variable
@@ -734,7 +735,8 @@ class AdfDiag(AdfWeb):
                 if constit_dict:
                     for der_var, constit_list in constit_dict.items():
                         derive_variable(self, case_name, der_var, res,
-                                        ts_dir, constit_list, hist_str=hist_str)
+                                        ts_dir, constit_list, hist_str=hist_str,
+                                        syr=start_year, eyr=end_year)
             # End for hist_str
         # End cases loop
 
@@ -1258,6 +1260,14 @@ class AdfDiag(AdfWeb):
                         + ".".join([case_name, hist_str, var, "*"])
                     )  # * to match timestamp: could be multiples
                     adf_file_list = glob.glob(adf_file_str)
+
+                    #Keep only the files needed for this case's years, so that
+                    #a directory holding more than one set for the same
+                    #variable does not come down to a guess:
+                    adf_file_list = select_ts_files(
+                        adf_file_list,
+                        self.climo_yrs["syears"][case_idx],
+                        self.climo_yrs["eyears"][case_idx])
 
                     if len(adf_file_list) == 1:
                         if verbose > 1:

--- a/lib/adf_diag.py
+++ b/lib/adf_diag.py
@@ -95,7 +95,7 @@ for root, dirs, files in os.walk(_DIAG_SCRIPTS_PATH):
 # +++++++++++++++++++++++++++++
 
 # Finally, import needed ADF modules:
-from adf_file_utils import select_ts_files
+from adf_file_utils import select_ts_files, ts_files_overlap
 from adf_web import AdfWeb
 from adf_dataset import AdfData
 from adf_derive import check_derive, derive_variable
@@ -1269,18 +1269,30 @@ class AdfDiag(AdfWeb):
                         self.climo_yrs["syears"][case_idx],
                         self.climo_yrs["eyears"][case_idx])
 
+                    # Consecutive files, which is what GenTS writes when
+                    # 'gents_slice_years' is set, are combined below, since
+                    # MDTF wants one file per variable.  Files that overlap
+                    # cannot be combined -- select_ts_files hands back a set it
+                    # could not resolve -- so those keep the older behavior of
+                    # copying the first and saying so.
+                    combine_files = (len(adf_file_list) > 1
+                                     and not ts_files_overlap(adf_file_list))
+
                     if len(adf_file_list) == 1:
                         if verbose > 1:
                             print(f"Copying ts file: {adf_file_list} to MDTF dir")
-                    elif len(adf_file_list) > 1:
-                        # A variable split into consecutive files, which is what
-                        # GenTS writes when 'gents_slice_years' is set.  MDTF
-                        # wants one file per variable, so these are combined
-                        # below rather than one of them being picked.
+                    elif combine_files:
                         if verbose > 1:
                             print(
                                 f"Combining {len(adf_file_list)} ts files into "
                                 "one file for the MDTF dir"
+                            )
+                    elif len(adf_file_list) > 1:
+                        if verbose > 0:
+                            print(
+                                f"""WARNING: found multiple timeseries files {adf_file_list}
+                                 covering overlapping periods. Continuing with the first;
+                                    suggest cleaning up multiple dates in ts dir"""
                             )
                     else:
                         if verbose > 1:
@@ -1357,21 +1369,32 @@ class AdfDiag(AdfWeb):
                             )
                         continue  # simply skip file copy for this variable:
 
-                    if len(adf_file_list) == 1:
-                        if verbose > 1:
-                            print(f"copying {adf_file} to {mdtf_file}")
-                        shutil.copyfile(adf_file, mdtf_file)
-                    else:
-                        # Consecutive files, so write them out as the single
-                        # file MDTF expects instead of copying just the first:
+                    if combine_files:
+                        # Write the consecutive files out as the single file
+                        # MDTF expects instead of copying just the first.  If
+                        # combining fails for any reason, copying one file is
+                        # still better than ending the whole ADF run:
                         if verbose > 1:
                             print(f"writing {adf_file_list} to {mdtf_file}")
-                        with xr.open_mfdataset(
-                            adf_file_list, decode_times=False, combine="by_coords"
-                        ) as mdtf_ds:
-                            mdtf_ds.to_netcdf(mdtf_file)
-                        # End with
+                        try:
+                            with xr.open_mfdataset(
+                                adf_file_list, decode_times=False, combine="by_coords"
+                            ) as mdtf_ds:
+                                mdtf_ds.to_netcdf(mdtf_file)
+                            # End with
+                            continue
+                        except (ValueError, OSError) as err:
+                            if verbose > 0:
+                                print(
+                                    f"""WARNING: could not combine {adf_file_list}
+                                     into one file ({err}). Continuing with the first."""
+                                )
+                        # End try
                     # End if
+
+                    if verbose > 1:
+                        print(f"copying {adf_file} to {mdtf_file}")
+                    shutil.copyfile(adf_file, mdtf_file)
                 # end for hist_str
             # end for var
         # end for case

--- a/lib/adf_file_utils.py
+++ b/lib/adf_file_utils.py
@@ -14,6 +14,8 @@ select_ts_files(fils, syr, eyr)
     Narrow a set of time series files to those needed for a year range.
 ts_files_overlap(fils)
     Report whether a set of time series files cover overlapping periods.
+ts_files_need_combining(fils)
+    Report whether a set of time series files has to be combined into one.
 ts_file_span(fils)
     Report the period a set of time series files covers, taken together.
 
@@ -301,6 +303,31 @@ def ts_files_overlap(fils):
     #End for
 
     return False
+
+
+def ts_files_need_combining(fils):
+    """
+    Report whether time series files have to be combined into a single file.
+
+    Answers the question a caller that wants one file per variable has to ask,
+    which is not the same as whether the files overlap: one file needs no
+    combining, several consecutive files do, and several overlapping files
+    cannot be combined at all and so must not be attempted.
+
+    Parameters
+    ----------
+    fils : list
+        strings or paths to time series files
+
+    Returns
+    -------
+    bool
+        True only when there is more than one file and the files can be opened
+        together.  False for a single file, for files that overlap, and for
+        names whose dates could not be read -- in each of those cases combining
+        is either unnecessary or unsafe.
+    """
+    return len(fils) > 1 and not ts_files_overlap(fils)
 
 
 def ts_file_span(fils):

--- a/lib/adf_file_utils.py
+++ b/lib/adf_file_utils.py
@@ -132,6 +132,10 @@ def select_ts_files(fils, syr, eyr):
         return fils
     #End if
     syr, eyr = int(syr), int(eyr)
+    if syr > eyr:
+        #A backwards range covers nothing, so there is no choice to make:
+        return fils
+    #End if
 
     #Files that overlap the requested range at all:
     candidates = []

--- a/lib/adf_file_utils.py
+++ b/lib/adf_file_utils.py
@@ -10,6 +10,8 @@ Functions
 ---------
 find_ts_files(ts_loc, pattern, recursive=True)
     Locate time series files matching a glob pattern under a directory.
+select_ts_files(fils, syr, eyr)
+    Narrow a set of time series files to those needed for a year range.
 ts_files_overlap(fils)
     Report whether a set of time series files cover overlapping periods.
 ts_file_span(fils)
@@ -58,6 +60,106 @@ def find_ts_files(ts_loc, pattern, recursive=True):
         return found
     #End if
     return sorted(ts_loc.rglob(pattern))
+
+
+def _ts_file_years(fil):
+    """
+    Read the (start, end) years out of a time series file name.
+
+    Parameters
+    ----------
+    fil : str or Path
+        path to a time series file
+
+    Returns
+    -------
+    tuple of int or None
+        (start year, end year), or ``None`` if the name could not be read.
+    """
+    spans = _ts_file_spans([fil])
+    if not spans:
+        return None
+    #End if
+    start, end = spans[0]
+    #Dates are YYYY, YYYYMM or YYYYMMDD, so the year is always the first four:
+    if len(start) < 4:
+        return None
+    #End if
+    return int(start[:4]), int(end[:4])
+
+
+def select_ts_files(fils, syr, eyr):
+    """
+    Narrow a set of time series files to those needed to cover a year range.
+
+    A time series directory can hold more than one set of files for the same
+    variable: a run post-processed over years 1-20 and then, once it had been
+    extended, over years 1-40 leaves both sets behind.  Those sets cannot be
+    opened together -- the combined time axis would have duplicate times -- but
+    either one alone is fine as long as it covers the years being plotted, so
+    the configured ``start_year``/``end_year`` are enough to choose between
+    them.
+
+    Files are picked greedily: at each step take the file that starts at or
+    before the first year not yet covered and reaches furthest, so a variable
+    split into consecutive chunks (what GenTS produces with 'slice_years')
+    still gets all of its chunks, while a duplicate set is passed over in
+    favor of whichever single set covers the request.
+
+    Parameters
+    ----------
+    fils : list
+        strings or paths to time series files
+    syr : int or str or None
+        first year needed
+    eyr : int or str or None
+        last year needed
+
+    Returns
+    -------
+    list
+        The files needed for [syr, eyr], in chronological order.  The input
+        list is returned unchanged when there is nothing to choose between
+        (fewer than two files), when no years were given, when a name's dates
+        could not be read, or when the files leave a gap in the requested
+        range -- in each of those cases this function has nothing to add and
+        the caller is left with the behavior it had before.
+    """
+    fils = list(fils)
+    if len(fils) < 2 or syr is None or eyr is None or syr == "" or eyr == "":
+        return fils
+    #End if
+    syr, eyr = int(syr), int(eyr)
+
+    #Files that overlap the requested range at all:
+    candidates = []
+    for fil in fils:
+        years = _ts_file_years(fil)
+        if years is None:
+            #Unrecognized name, so make no promises about the set:
+            return fils
+        #End if
+        start, end = years
+        if start <= eyr and end >= syr:
+            candidates.append((start, end, fil))
+        #End if
+    #End for
+
+    chosen = []
+    needed = syr
+    while needed <= eyr:
+        reaching = [c for c in candidates if c[0] <= needed <= c[1]]
+        if not reaching:
+            #The requested years are not covered, which is a configuration
+            #problem rather than a choice to be made here:
+            return fils
+        #End if
+        start, end, fil = max(reaching, key=lambda c: c[1])
+        chosen.append(fil)
+        needed = end + 1
+    #End while
+
+    return chosen
 
 
 def _ts_file_spans(fils):

--- a/lib/adf_file_utils.py
+++ b/lib/adf_file_utils.py
@@ -62,32 +62,6 @@ def find_ts_files(ts_loc, pattern, recursive=True):
     return sorted(ts_loc.rglob(pattern))
 
 
-def _ts_file_years(fil):
-    """
-    Read the (start, end) years out of a time series file name.
-
-    Parameters
-    ----------
-    fil : str or Path
-        path to a time series file
-
-    Returns
-    -------
-    tuple of int or None
-        (start year, end year), or ``None`` if the name could not be read.
-    """
-    spans = _ts_file_spans([fil])
-    if not spans:
-        return None
-    #End if
-    start, end = spans[0]
-    #Dates are YYYY, YYYYMM or YYYYMMDD, so the year is always the first four:
-    if len(start) < 4:
-        return None
-    #End if
-    return int(start[:4]), int(end[:4])
-
-
 def select_ts_files(fils, syr, eyr):
     """
     Narrow a set of time series files to those needed for a year range.
@@ -277,14 +251,12 @@ def _ts_file_spans(fils):
         name could not be parsed or the dates do not all use the same width.
         Callers treat ``None`` as "make no promises about these files".
     """
-    spans = []
-    for start, end, _ in _ts_file_span_pairs(fils) or [(None, None, None)]:
-        if start is None:
-            #Unrecognized name, so make no promises about it:
-            return None
-        #End if
-        spans.append((start, end))
-    #End for
+    pairs = _ts_file_span_pairs(fils)
+    if not pairs:
+        #Unrecognized names, so make no promises about them:
+        return None
+    #End if
+    spans = [(start, end) for start, end, _ in pairs]
 
     return sorted(spans)
 

--- a/lib/adf_file_utils.py
+++ b/lib/adf_file_utils.py
@@ -101,10 +101,12 @@ def select_ts_files(fils, syr, eyr):
     them.
 
     Files are picked greedily: at each step take the file that starts at or
-    before the first year not yet covered and reaches furthest, so a variable
-    split into consecutive chunks (what GenTS produces with 'slice_years')
-    still gets all of its chunks, while a duplicate set is passed over in
-    favor of whichever single set covers the request.
+    before the first year not yet covered, preferring the smallest one that
+    holds all of the years still needed and otherwise the one that reaches
+    furthest.  A variable split into consecutive chunks (what GenTS produces
+    with 'slice_years') therefore still gets all of its chunks, while a
+    duplicate set is passed over in favor of the smallest single set that
+    covers the request.
 
     Parameters
     ----------
@@ -154,7 +156,16 @@ def select_ts_files(fils, syr, eyr):
             #problem rather than a choice to be made here:
             return fils
         #End if
-        start, end, fil = max(reaching, key=lambda c: c[1])
+        #Prefer a file that holds all of what is left to cover, and the
+        #smallest such, so that a 40-year file is not read to build a 20-year
+        #climatology.  Failing that take the one reaching furthest, which is
+        #what lets consecutive chunks be picked up in turn:
+        covering = [c for c in reaching if c[1] >= eyr]
+        if covering:
+            _, end, fil = min(covering, key=lambda c: c[1] - c[0])
+        else:
+            _, end, fil = max(reaching, key=lambda c: c[1])
+        #End if
         chosen.append(fil)
         needed = end + 1
     #End while

--- a/lib/adf_file_utils.py
+++ b/lib/adf_file_utils.py
@@ -90,23 +90,26 @@ def _ts_file_years(fil):
 
 def select_ts_files(fils, syr, eyr):
     """
-    Narrow a set of time series files to those needed to cover a year range.
+    Narrow a set of time series files to those needed for a year range.
 
     A time series directory can hold more than one set of files for the same
     variable: a run post-processed over years 1-20 and then, once it had been
     extended, over years 1-40 leaves both sets behind.  Those sets cannot be
-    opened together -- the combined time axis would have duplicate times -- but
-    either one alone is fine as long as it covers the years being plotted, so
-    the configured ``start_year``/``end_year`` are enough to choose between
+    opened together -- the combined time axis would have duplicate times --
+    but either one alone is fine as long as it covers the years being plotted,
+    so the configured ``start_year``/``end_year`` are enough to choose between
     them.
 
-    Files are picked greedily: at each step take the file that starts at or
-    before the first year not yet covered, preferring the smallest one that
-    holds all of the years still needed and otherwise the one that reaches
-    furthest.  A variable split into consecutive chunks (what GenTS produces
-    with 'slice_years') therefore still gets all of its chunks, while a
-    duplicate set is passed over in favor of the smallest single set that
-    covers the request.
+    Only a set that cannot be opened as it stands is narrowed.  Files that
+    combine cleanly, including a variable split into consecutive chunks (what
+    GenTS produces with 'slice_years'), are returned untouched: the plots that
+    show a whole record ask for every file a case has, not only the years the
+    climatologies use, and there is nothing to resolve for them anyway.
+
+    Where a choice is needed, files are picked greedily: at each step take the
+    file that starts at or before the first year not yet covered, preferring
+    the smallest one that holds all of the years still needed and otherwise
+    the one that reaches furthest.
 
     Parameters
     ----------
@@ -121,14 +124,25 @@ def select_ts_files(fils, syr, eyr):
     -------
     list
         The files needed for [syr, eyr], in chronological order.  The input
-        list is returned unchanged when there is nothing to choose between
-        (fewer than two files), when no years were given, when a name's dates
-        could not be read, or when the files leave a gap in the requested
-        range -- in each of those cases this function has nothing to add and
-        the caller is left with the behavior it had before.
+        list is returned unchanged whenever this function has nothing to add:
+        fewer than two files, files that already combine cleanly, no years
+        given, a year range given backwards, names whose dates could not be
+        read, dates that would have to be compared at finer than year
+        resolution, a gap in the requested range, or a set whose files cannot
+        be reduced to a combinable choice.  In each case the caller is left
+        with the behavior it had before.
     """
     fils = list(fils)
-    if len(fils) < 2 or syr is None or eyr is None or syr == "" or eyr == "":
+    if len(fils) < 2:
+        return fils
+    #End if
+
+    #Files that can be opened together need no choosing:
+    if not ts_files_overlap(fils):
+        return fils
+    #End if
+
+    if syr is None or eyr is None or syr == "" or eyr == "":
         return fils
     #End if
     syr, eyr = int(syr), int(eyr)
@@ -137,19 +151,25 @@ def select_ts_files(fils, syr, eyr):
         return fils
     #End if
 
-    #Files that overlap the requested range at all:
-    candidates = []
-    for fil in fils:
-        years = _ts_file_years(fil)
-        if years is None:
-            #Unrecognized name, so make no promises about the set:
-            return fils
-        #End if
-        start, end = years
-        if start <= eyr and end >= syr:
-            candidates.append((start, end, fil))
-        #End if
-    #End for
+    pairs = _ts_file_span_pairs(fils)
+    if pairs is None:
+        #Unrecognized names, so make no promises about the set:
+        return fils
+    #End if
+
+    #The requested years as dates, so that what is dropped can be checked
+    #below at the resolution the file names actually use:
+    fill = {4: ("", ""), 6: ("01", "12"), 8: ("0101", "1231")}
+    width = len(pairs[0][0])
+    if width not in fill:
+        #An unfamiliar date width, so make no promises about the set:
+        return fils
+    #End if
+    req = (f"{syr:04d}{fill[width][0]}", f"{eyr:04d}{fill[width][1]}")
+
+    #Files that hold some of the requested years:
+    candidates = [(int(start[:4]), int(end[:4]), fil) for start, end, fil in pairs
+                  if int(start[:4]) <= eyr and int(end[:4]) >= syr]
 
     chosen = []
     needed = syr
@@ -166,15 +186,79 @@ def select_ts_files(fils, syr, eyr):
         #what lets consecutive chunks be picked up in turn:
         covering = [c for c in reaching if c[1] >= eyr]
         if covering:
-            _, end, fil = min(covering, key=lambda c: c[1] - c[0])
+            _, end_yr, fil = min(covering, key=lambda c: c[1] - c[0])
         else:
-            _, end, fil = max(reaching, key=lambda c: c[1])
+            _, end_yr, fil = max(reaching, key=lambda c: c[1])
         #End if
         chosen.append(fil)
-        needed = end + 1
+        needed = end_yr + 1
     #End while
 
+    #A greedy walk can still end up holding two files that overlap (a 25-year
+    #set beside 10-year chunks of the same run, say).  Handing back a set that
+    #cannot be opened would be no better than not choosing at all:
+    if ts_files_overlap(chosen):
+        return fils
+    #End if
+
+    #Only years were compared above, so make sure nothing was dropped that
+    #the chosen files do not hold.  Two halves of a year
+    #(00010101-00010630 beside 00010701-00011231) look alike by year, and
+    #dropping one of them would quietly lose half the data; a file that merely
+    #runs on past the requested years (years 10-40 beside years 1-20, with
+    #years 1-20 asked for) is a different matter and is dropped safely:
+    kept = [(start, end) for start, end, fil in pairs if fil in chosen]
+    for start, end, fil in pairs:
+        if fil in chosen:
+            continue
+        #End if
+        lower, upper = max(start, req[0]), min(end, req[1])
+        if lower > upper:
+            #Holds none of the requested period:
+            continue
+        #End if
+        if not any(k_start <= lower and k_end >= upper for k_start, k_end in kept):
+            return fils
+        #End if
+    #End for
+
     return chosen
+
+
+def _ts_file_span_pairs(fils):
+    """
+    Parse the {start}-{end} date token out of each name, keeping the file.
+
+    Parameters
+    ----------
+    fils : list
+        strings or paths to time series files
+
+    Returns
+    -------
+    list of tuple or None
+        (start, end, file) in the order given, or ``None`` if any name could
+        not be parsed or the dates do not all use the same width.
+    """
+    pairs = []
+    for fil in fils:
+        #Last dot-separated token of the stem -- second-to-last of the file
+        #name -- e.g. "001001-001112" in "case.cam.h0a.T.001001-001112.nc":
+        date_str = Path(fil).stem.split(".")[-1]
+        start, sep, end = date_str.partition("-")
+        if not sep or not start.isdigit() or not end.isdigit():
+            return None
+        #End if
+        pairs.append((start, end, fil))
+    #End for
+
+    #Zero-padded dates of equal width sort chronologically as strings, but
+    #mixed widths (e.g. YYYY next to YYYYMM) would not, so bail out on those:
+    if len({len(d) for start, end, _ in pairs for d in (start, end)}) != 1:
+        return None
+    #End if
+
+    return pairs
 
 
 def _ts_file_spans(fils):
@@ -194,22 +278,13 @@ def _ts_file_spans(fils):
         Callers treat ``None`` as "make no promises about these files".
     """
     spans = []
-    for fil in fils:
-        #Last dot-separated token of the stem -- second-to-last of the file
-        #name -- e.g. "001001-001112" in "case.cam.h0a.T.001001-001112.nc":
-        date_str = Path(fil).stem.split(".")[-1]
-        start, sep, end = date_str.partition("-")
-        if not sep or not start.isdigit() or not end.isdigit():
+    for start, end, _ in _ts_file_span_pairs(fils) or [(None, None, None)]:
+        if start is None:
             #Unrecognized name, so make no promises about it:
             return None
+        #End if
         spans.append((start, end))
     #End for
-
-    #Zero-padded dates of equal width sort chronologically as strings, but
-    #mixed widths (e.g. YYYY next to YYYYMM) would not, so bail out on those:
-    if len({len(s) for span in spans for s in span}) != 1:
-        return None
-    #End if
 
     return sorted(spans)
 

--- a/lib/adf_gents.py
+++ b/lib/adf_gents.py
@@ -317,7 +317,8 @@ def create_time_series_gents(adf, baseline=False):
                 res = adf.variable_defaults
                 for der_var, constit_list in constit_dict.items():
                     derive_variable(adf, case_name, der_var, res, ts_dir,
-                                    constit_list, hist_str=hist_str)
+                                    constit_list, hist_str=hist_str,
+                                    syr=start_year, eyr=end_year)
                 #End for
             #End if
         #End for hist_str

--- a/lib/adf_info.py
+++ b/lib/adf_info.py
@@ -48,6 +48,16 @@ import adf_utils as utils
 from adf_config import AdfConfig
 from adf_base   import AdfError
 
+
+def _warn_on_long_climo_range(syr, eyr):
+    """Tell the user when the year range worked out from the files is large."""
+    if eyr-syr >= 100:
+        msg = f"WARNING: the found climo year range is large: {eyr-syr} years, "
+        msg += "this may take a long time!"
+        print(msg)
+    #End if
+
+
 #+++++++++++++++++++
 #Define Obs class
 #+++++++++++++++++++
@@ -868,6 +878,14 @@ class AdfInfo(AdfConfig):
         ------
           - start year
           - end year
+
+        Notes
+        -----
+        The period is read from the file names when they carry it, so a
+        directory holding more than one set of files for the same variable
+        (years 1-20 alongside years 1-40) reports the whole available span
+        instead of failing to open the files together.  Names whose dates
+        cannot be read fall back to reading the period from the data.
         """
 
         #Grab variable list
@@ -947,7 +965,21 @@ class AdfInfo(AdfConfig):
             raise AdfError(errmsg)
         #End if
 
-        #Read in file(s)
+        #The file names carry the period they hold, so use those rather than
+        #opening the files: overlapping sets (years 1-20 alongside years 1-40,
+        #left behind when a run is extended and the time series are remade)
+        #cannot be opened together, and this runs during ADF setup, so failing
+        #here takes down the whole run before any diagnostic starts.
+        span = utils.ts_file_span(ts_files)
+        if span and len(span[0]) >= 4:
+            syr = int(span[0][:4])
+            eyr = int(span[1][:4])
+            _warn_on_long_climo_range(syr, eyr)
+            return syr, eyr
+        #End if
+
+        #Read in file(s) -- names whose dates could not be read, so the period
+        #has to come from the data itself:
         if len(ts_files) == 1:
             cam_ts_data = xr.open_dataset(ts_files[0], decode_times=True)
         else:
@@ -974,10 +1006,7 @@ class AdfInfo(AdfConfig):
         syr = int(cam_ts_data.time[0].dt.year.values)
         eyr = int(cam_ts_data.time[-1].dt.year.values)
 
-        if eyr-syr >= 100:
-            msg = f"WARNING: the found climo year range is large: {eyr-syr} years, "
-            msg += "this may take a long time!"
-            print(msg)
+        _warn_on_long_climo_range(syr, eyr)
 
         return syr, eyr
 

--- a/lib/adf_utils.py
+++ b/lib/adf_utils.py
@@ -3,7 +3,7 @@ Generic computation helper functions
 
 Functions
 ---------
-find_ts_files(), ts_files_overlap(), ts_file_span()
+find_ts_files(), select_ts_files(), ts_files_overlap(), ts_file_span()
     re-exported from adf_file_utils; time series file discovery
 load_dataset()
     generalized load dataset method used for plotting/analysis functions
@@ -57,7 +57,8 @@ from adf_base import AdfError
 #tested without importing the scientific stack (see adf_file_utils).  Re-export
 #here so `utils.find_ts_files(...)` keeps working for every existing caller:
 # pylint: disable=unused-import
-from adf_file_utils import find_ts_files, ts_files_overlap, ts_file_span
+from adf_file_utils import (find_ts_files, select_ts_files, ts_files_overlap,
+                            ts_file_span)
 # pylint: enable=unused-import
 
 import warnings  # use to warn user about missing files.

--- a/lib/test/unit_tests/test_adf_derive.py
+++ b/lib/test/unit_tests/test_adf_derive.py
@@ -226,6 +226,31 @@ class AdfDeriveTestRoutine(unittest.TestCase):
 
             self.assertEqual(sorted(Path(tmpdir).glob("*RESTOM*.nc")), [])
 
+    def test_overlapping_constituents_resolved_by_years(self):
+
+        """
+        The same two sets, but with the years being processed given: the set
+        covering them is used and the derived variable is produced, which is
+        the point of passing the years down at all.
+        """
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            for var in ("FSNT", "FLNT"):
+                _write_ts(Path(tmpdir) / f"case.cam.h0a.{var}.000101-002012.nc",
+                          var, 1, 20)
+                _write_ts(Path(tmpdir) / f"case.cam.h0a.{var}.000101-004012.nc",
+                          var, 1, 40)
+
+            derive_variable(_StubAdf(), "case", "RESTOM", res={}, ts_dir=tmpdir,
+                            constit_list=["FSNT", "FLNT"], hist_str="cam.h0a",
+                            syr=1, eyr=40)
+
+            out = sorted(Path(tmpdir).glob("*RESTOM*.nc"))
+            self.assertEqual([f.name for f in out],
+                             ["case.cam.h0a.RESTOM.000101-004012.nc"])
+            with xr.open_dataset(out[0]) as ds:
+                self.assertEqual(len(ds.time), 480)
+
     def test_other_case_in_same_tree_ignored(self):
 
         """

--- a/lib/test/unit_tests/test_adf_file_utils.py
+++ b/lib/test/unit_tests/test_adf_file_utils.py
@@ -267,17 +267,16 @@ class AdfFileUtilsTestRoutine(unittest.TestCase):
     def test_select_nested_sets_short_range(self):
 
         """
-        Asking for only the first 20 years of the same directory must also
-        give a single self-consistent set.
+        Asking for only the first 20 years of the same directory must give a
+        single self-consistent set, and the smaller of the two: reading the
+        40-year file to average 20 years of it is twice the work for the same
+        answer.
         """
 
         short = "case.cam.h0a.T.000101-002012.nc"
         long = "case.cam.h0a.T.000101-004012.nc"
 
-        chosen = select_ts_files([short, long], 1, 20)
-
-        self.assertEqual(len(chosen), 1)
-        self.assertFalse(ts_files_overlap(chosen))
+        self.assertEqual(select_ts_files([short, long], 1, 20), [short])
 
     def test_select_sub_window_of_one_file(self):
 
@@ -289,10 +288,7 @@ class AdfFileUtilsTestRoutine(unittest.TestCase):
         short = "case.cam.h0a.T.000101-002012.nc"
         long = "case.cam.h0a.T.000101-004012.nc"
 
-        chosen = select_ts_files([short, long], 5, 15)
-
-        self.assertEqual(len(chosen), 1)
-        self.assertFalse(ts_files_overlap(chosen))
+        self.assertEqual(select_ts_files([short, long], 5, 15), [short])
 
     def test_select_keeps_consecutive_chunks(self):
 

--- a/lib/test/unit_tests/test_adf_file_utils.py
+++ b/lib/test/unit_tests/test_adf_file_utils.py
@@ -23,7 +23,8 @@ sys.path.append(_ADF_LIB_DIR)
 
 #adf_file_utils imports nothing but pathlib, so these run in CI, where only
 #PyYAML and pytest are installed:
-from adf_file_utils import find_ts_files, ts_files_overlap, ts_file_span
+from adf_file_utils import (find_ts_files, select_ts_files, ts_files_overlap,
+                            ts_file_span)
 
 #++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 #Main adf_file_utils testing routine, used when script is run directly
@@ -243,6 +244,142 @@ class AdfFileUtilsTestRoutine(unittest.TestCase):
 
         self.assertIsNone(ts_file_span(["case.cam.h0a.FSNT.somethingelse.nc"]))
         self.assertIsNone(ts_file_span([]))
+
+
+    #+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+    #select_ts_files: choosing between sets that cover the same years
+    #+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+    def test_select_nested_sets_full_range(self):
+
+        """
+        Years 1-20 alongside years 1-40, which is what a re-post-processed run
+        leaves behind, must resolve to the one set covering the years asked
+        for.  These cannot be opened together, so choosing is the whole point.
+        """
+
+        short = "case.cam.h0a.T.000101-002012.nc"
+        long = "case.cam.h0a.T.000101-004012.nc"
+
+        self.assertEqual(select_ts_files([short, long], 1, 40), [long])
+        self.assertFalse(ts_files_overlap(select_ts_files([short, long], 1, 40)))
+
+    def test_select_nested_sets_short_range(self):
+
+        """
+        Asking for only the first 20 years of the same directory must also
+        give a single self-consistent set.
+        """
+
+        short = "case.cam.h0a.T.000101-002012.nc"
+        long = "case.cam.h0a.T.000101-004012.nc"
+
+        chosen = select_ts_files([short, long], 1, 20)
+
+        self.assertEqual(len(chosen), 1)
+        self.assertFalse(ts_files_overlap(chosen))
+
+    def test_select_sub_window_of_one_file(self):
+
+        """
+        A range sitting inside a file is the ordinary case for ADF (climo over
+        part of a time series), so it must not be treated as "not covered".
+        """
+
+        short = "case.cam.h0a.T.000101-002012.nc"
+        long = "case.cam.h0a.T.000101-004012.nc"
+
+        chosen = select_ts_files([short, long], 5, 15)
+
+        self.assertEqual(len(chosen), 1)
+        self.assertFalse(ts_files_overlap(chosen))
+
+    def test_select_keeps_consecutive_chunks(self):
+
+        """
+        A variable split into consecutive chunks -- what GenTS writes with
+        'slice_years' -- has to keep every chunk the range needs, and only
+        those.
+        """
+
+        fils = ["case.cam.h0a.T.000101-001012.nc",
+                "case.cam.h0a.T.001101-002012.nc",
+                "case.cam.h0a.T.002101-003012.nc"]
+
+        self.assertEqual(select_ts_files(fils, 1, 20), fils[:2])
+        self.assertEqual(select_ts_files(fils, 15, 25), fils[1:])
+
+    def test_select_prefers_whole_set_over_chunks(self):
+
+        """
+        A chunked set and a single whole-period set in the same directory
+        overlap, so exactly one of them must be chosen.
+        """
+
+        chunks = ["case.cam.h0a.T.000101-001012.nc",
+                  "case.cam.h0a.T.001101-002012.nc"]
+        whole = "case.cam.h0a.T.000101-002012.nc"
+
+        chosen = select_ts_files(chunks + [whole], 1, 20)
+
+        self.assertEqual(chosen, [whole])
+
+    def test_select_drops_files_outside_range(self):
+
+        """
+        Files that hold none of the requested years are of no use and must not
+        be handed on.
+        """
+
+        fils = ["case.cam.h0a.T.000101-001012.nc",
+                "case.cam.h0a.T.001101-002012.nc"]
+
+        self.assertEqual(select_ts_files(fils, 11, 20), fils[1:])
+
+    def test_select_passes_through_when_undecidable(self):
+
+        """
+        With no years given, unreadable names, or a gap in the requested
+        range, there is nothing to choose, so the caller must be left with
+        exactly the behavior it had before.
+        """
+
+        fils = ["case.cam.h0a.T.000101-001012.nc",
+                "case.cam.h0a.T.002101-003012.nc"]
+
+        #No years given:
+        self.assertEqual(select_ts_files(fils, None, None), fils)
+        self.assertEqual(select_ts_files(fils, "", ""), fils)
+        #Gap between the two files:
+        self.assertEqual(select_ts_files(fils, 1, 30), fils)
+        #Unreadable names:
+        unreadable = ["case.cam.h0a.T.first.nc", "case.cam.h0a.T.second.nc"]
+        self.assertEqual(select_ts_files(unreadable, 1, 20), unreadable)
+        #Nothing to choose between:
+        self.assertEqual(select_ts_files(fils[:1], 1, 10), fils[:1])
+
+    def test_select_accepts_paths_and_year_strings(self):
+
+        """
+        Callers pass Path objects, and years arrive from the config file as
+        either integers or strings.
+        """
+
+        short = Path("/ts/case.cam.h0a.T.000101-002012.nc")
+        long = Path("/ts/case.cam.h0a.T.000101-004012.nc")
+
+        self.assertEqual(select_ts_files([short, long], "1", "40"), [long])
+
+    def test_select_annual_dates(self):
+
+        """
+        Time series dates can be YYYY rather than YYYYMM.
+        """
+
+        short = "case.cam.h0a.T.0001-0020.nc"
+        long = "case.cam.h0a.T.0001-0040.nc"
+
+        self.assertEqual(select_ts_files([short, long], 1, 40), [long])
 
 #++++++++++++++++++
 

--- a/lib/test/unit_tests/test_adf_file_utils.py
+++ b/lib/test/unit_tests/test_adf_file_utils.py
@@ -24,7 +24,7 @@ sys.path.append(_ADF_LIB_DIR)
 #adf_file_utils imports nothing but pathlib, so these run in CI, where only
 #PyYAML and pytest are installed:
 from adf_file_utils import (find_ts_files, select_ts_files, ts_files_overlap,
-                            ts_file_span)
+                            ts_files_need_combining, ts_file_span)
 
 #++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 #Main adf_file_utils testing routine, used when script is run directly
@@ -200,6 +200,46 @@ class AdfFileUtilsTestRoutine(unittest.TestCase):
                 Path("/some/dir/case.cam.h0a.T.002001-002912.nc")]
 
         self.assertFalse(ts_files_overlap(fils))
+
+    def test_need_combining(self):
+
+        """
+        The question a caller wanting one file per variable has to ask.
+
+        Used by the MDTF file move, which writes one file per variable: one
+        file needs no combining, consecutive files do, and overlapping files
+        cannot be combined at all -- attempting it raises and would end the
+        run.
+        """
+
+        one = ["case.cam.h0a.T.000101-002012.nc"]
+        chunks = ["case.cam.h0a.T.000101-001012.nc",
+                  "case.cam.h0a.T.001101-002012.nc"]
+        overlapping = ["case.cam.h0a.T.000101-002012.nc",
+                       "case.cam.h0a.T.001001-004012.nc"]
+        unreadable = ["case.cam.h0a.T.first.nc", "case.cam.h0a.T.second.nc"]
+
+        self.assertFalse(ts_files_need_combining([]))
+        self.assertFalse(ts_files_need_combining(one))
+        self.assertTrue(ts_files_need_combining(chunks))
+        self.assertFalse(ts_files_need_combining(overlapping))
+        self.assertFalse(ts_files_need_combining(unreadable))
+
+    def test_need_combining_agrees_with_selection(self):
+
+        """
+        The two functions have to agree, because the caller applies them in
+        turn: whatever selection could not resolve must not then be combined.
+        """
+
+        overlapping = ["case.cam.h0a.T.000101-002012.nc",
+                       "case.cam.h0a.T.001001-004012.nc"]
+
+        #Years 1-40 cannot be covered without holding both files, so selection
+        #passes them through -- and they must not be combined:
+        chosen = select_ts_files(overlapping, 1, 40)
+        self.assertEqual(chosen, overlapping)
+        self.assertFalse(ts_files_need_combining(chosen))
 
     def test_ts_file_span_single_file(self):
 

--- a/lib/test/unit_tests/test_adf_file_utils.py
+++ b/lib/test/unit_tests/test_adf_file_utils.py
@@ -353,6 +353,8 @@ class AdfFileUtilsTestRoutine(unittest.TestCase):
         self.assertEqual(select_ts_files(unreadable, 1, 20), unreadable)
         #Nothing to choose between:
         self.assertEqual(select_ts_files(fils[:1], 1, 10), fils[:1])
+        #A backwards range, which would otherwise cover nothing at all:
+        self.assertEqual(select_ts_files(fils, 20, 1), fils)
 
     def test_select_accepts_paths_and_year_strings(self):
 

--- a/lib/test/unit_tests/test_adf_file_utils.py
+++ b/lib/test/unit_tests/test_adf_file_utils.py
@@ -290,20 +290,40 @@ class AdfFileUtilsTestRoutine(unittest.TestCase):
 
         self.assertEqual(select_ts_files([short, long], 5, 15), [short])
 
-    def test_select_keeps_consecutive_chunks(self):
+    def test_select_leaves_consecutive_chunks_alone(self):
 
         """
         A variable split into consecutive chunks -- what GenTS writes with
-        'slice_years' -- has to keep every chunk the range needs, and only
-        those.
+        'slice_years' -- opens as it stands, so there is nothing to choose and
+        every file must come back.
+
+        Narrowing these would break the plots that show a whole record: they
+        ask for all of a case's files, not only the climatology years.
         """
 
         fils = ["case.cam.h0a.T.000101-001012.nc",
                 "case.cam.h0a.T.001101-002012.nc",
                 "case.cam.h0a.T.002101-003012.nc"]
 
-        self.assertEqual(select_ts_files(fils, 1, 20), fils[:2])
-        self.assertEqual(select_ts_files(fils, 15, 25), fils[1:])
+        self.assertEqual(select_ts_files(fils, 1, 20), fils)
+        self.assertEqual(select_ts_files(fils, 15, 25), fils)
+
+    def test_select_keeps_chunks_needed_against_a_duplicate(self):
+
+        """
+        The same chunks, but with a whole-period file of the same run beside
+        them, which is a set that cannot be opened.  Now a choice is needed,
+        and it has to be one self-consistent set.
+        """
+
+        chunks = ["case.cam.h0a.T.000101-001012.nc",
+                  "case.cam.h0a.T.001101-002012.nc"]
+        whole = "case.cam.h0a.T.000101-002012.nc"
+
+        chosen = select_ts_files(chunks + [whole], 1, 20)
+
+        self.assertFalse(ts_files_overlap(chosen))
+        self.assertTrue(chosen == [whole] or chosen == chunks)
 
     def test_select_prefers_whole_set_over_chunks(self):
 
@@ -323,14 +343,76 @@ class AdfFileUtilsTestRoutine(unittest.TestCase):
     def test_select_drops_files_outside_range(self):
 
         """
-        Files that hold none of the requested years are of no use and must not
-        be handed on.
+        When a choice has to be made, a file holding none of the requested
+        years is of no use and must not be handed on.
         """
 
-        fils = ["case.cam.h0a.T.000101-001012.nc",
-                "case.cam.h0a.T.001101-002012.nc"]
+        short = "case.cam.h0a.T.000101-002012.nc"
+        long = "case.cam.h0a.T.000101-004012.nc"
 
-        self.assertEqual(select_ts_files(fils, 11, 20), fils[1:])
+        self.assertEqual(select_ts_files([short, long], 21, 40), [long])
+
+    def test_select_leaves_sub_year_files_alone(self):
+
+        """
+        Only years are compared, so halves of a year must never be weighed
+        against one another: dropping one would quietly lose half the data.
+        """
+
+        halves = ["case.cam.h1a.PRECT.00010101-00010630.nc",
+                  "case.cam.h1a.PRECT.00010701-00011231.nc"]
+
+        #These combine cleanly, so they are left alone on that count:
+        self.assertEqual(select_ts_files(halves, 1, 1), halves)
+
+        #And still left alone when a whole-year file of the same run makes the
+        #set one that cannot be opened:
+        whole = "case.cam.h1a.PRECT.00010101-00011231.nc"
+        self.assertEqual(select_ts_files(halves + [whole], 1, 1),
+                         halves + [whole])
+
+    def test_select_resolves_partly_overlapping_sets(self):
+
+        """
+        Years 1-20 beside years 10-40 is the layout that raised "Resulting
+        object does not have monotonic global indexes".  A file that runs on
+        past the requested years is dropped safely, because the file kept
+        holds all of the years asked for.
+        """
+
+        early = "case.cam.h0a.T.000101-002012.nc"
+        late = "case.cam.h0a.T.001001-004012.nc"
+
+        self.assertEqual(select_ts_files([early, late], 1, 20), [early])
+        self.assertEqual(select_ts_files([early, late], 10, 40), [late])
+
+    def test_select_leaves_sub_year_boundaries_alone(self):
+
+        """
+        Two sets whose boundary falls inside a year: keeping only the first
+        would drop the second half of year 5 from a five-year request, which
+        comparing years alone cannot see.  So the set comes back whole.
+        """
+
+        fils = ["case.cam.h0a.T.00010101-00050630.nc",
+                "case.cam.h0a.T.00050701-00101231.nc"]
+
+        self.assertEqual(select_ts_files(fils, 1, 5), fils)
+
+    def test_select_refuses_a_cover_it_cannot_open(self):
+
+        """
+        A 25-year set beside 10-year chunks of the same run: the greedy walk
+        would hold the 25-year file and the last chunk, which overlap.  Handing
+        that back is no better than not choosing, so the set comes back whole.
+        """
+
+        fils = ["case.cam.h0a.T.000101-002512.nc",
+                "case.cam.h0a.T.000101-001012.nc",
+                "case.cam.h0a.T.001101-002012.nc",
+                "case.cam.h0a.T.002101-003012.nc"]
+
+        self.assertEqual(select_ts_files(fils, 1, 30), fils)
 
     def test_select_passes_through_when_undecidable(self):
 
@@ -340,19 +422,25 @@ class AdfFileUtilsTestRoutine(unittest.TestCase):
         exactly the behavior it had before.
         """
 
+        #Two sets of the same run with a gap after them, so a choice is
+        #wanted but the requested range cannot be covered:
         fils = ["case.cam.h0a.T.000101-001012.nc",
-                "case.cam.h0a.T.002101-003012.nc"]
+                "case.cam.h0a.T.000101-000512.nc"]
 
         #No years given:
         self.assertEqual(select_ts_files(fils, None, None), fils)
         self.assertEqual(select_ts_files(fils, "", ""), fils)
-        #Gap between the two files:
+        #Years past what the files hold:
         self.assertEqual(select_ts_files(fils, 1, 30), fils)
         #Unreadable names:
         unreadable = ["case.cam.h0a.T.first.nc", "case.cam.h0a.T.second.nc"]
         self.assertEqual(select_ts_files(unreadable, 1, 20), unreadable)
         #Nothing to choose between:
         self.assertEqual(select_ts_files(fils[:1], 1, 10), fils[:1])
+        #Files that open together as they stand:
+        clean = ["case.cam.h0a.T.000101-001012.nc",
+                 "case.cam.h0a.T.001101-002012.nc"]
+        self.assertEqual(select_ts_files(clean, 1, 10), clean)
         #A backwards range, which would otherwise cover nothing at all:
         self.assertEqual(select_ts_files(fils, 20, 1), fils)
 

--- a/lib/test/unit_tests/test_adf_info_climo_yrs.py
+++ b/lib/test/unit_tests/test_adf_info_climo_yrs.py
@@ -179,7 +179,7 @@ class AdfInfoClimoYrsTestRoutine(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmpdir:
             _write_ts(Path(tmpdir) / "case.cam.h0a.T.000101-002012.nc",
                       "T", 1, 20)
-            _write_ts(Path(tmpdir) / "case.cam.h0b.T.010001-010512.nc",
+            _write_ts(Path(tmpdir) / "case.cam.h0b.T.010001-010412.nc",
                       "T", 100, 5)
 
             syr, eyr = _call(_StubInfo(["T"]), tmpdir, "case",
@@ -198,7 +198,7 @@ class AdfInfoClimoYrsTestRoutine(unittest.TestCase):
             _write_ts(Path(tmpdir) / "case.cam.h0a.T.000101-002012.nc",
                       "T", 1, 20)
             _write_ts(Path(tmpdir) / "atm" / "proc" / "tseries" / "month_1"
-                      / "case.cam.h0a.T.010001-010512.nc", "T", 100, 5)
+                      / "case.cam.h0a.T.010001-010412.nc", "T", 100, 5)
 
             syr, eyr = _call(_StubInfo(["T"]), tmpdir, "case",
                              hist_str="cam.h0a")
@@ -226,7 +226,7 @@ class AdfInfoClimoYrsTestRoutine(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmpdir:
             _write_ts(Path(tmpdir) / "atm" / "proc" / "tseries" / "month_1"
                       / "case.cam.h0a.T.000101-002012.nc", "T", 1, 20)
-            _write_ts(Path(tmpdir) / "case.cam.h0a.PRECT.010001-010512.nc",
+            _write_ts(Path(tmpdir) / "case.cam.h0a.PRECT.010001-010412.nc",
                       "PRECT", 100, 5)
 
             syr, eyr = _call(_StubInfo(["T", "PRECT"]), tmpdir, "case",
@@ -246,15 +246,73 @@ class AdfInfoClimoYrsTestRoutine(unittest.TestCase):
         """
 
         with tempfile.TemporaryDirectory() as tmpdir:
-            _write_ts(Path(tmpdir) / "case.cam.h0b.T.010001-010512.nc",
+            _write_ts(Path(tmpdir) / "case.cam.h0b.T.010001-010412.nc",
                       "T", 100, 5)
             _write_ts(Path(tmpdir) / "atm" / "proc" / "tseries" / "month_1"
-                      / "case.cam.h0a.T.020001-021012.nc", "T", 200, 10)
+                      / "case.cam.h0a.T.020001-020912.nc", "T", 200, 10)
 
             syr, eyr = _call(_StubInfo(["T"]), tmpdir, "case",
                              hist_str="cam.h0a")
 
             self.assertEqual((syr, eyr), (200, 209))
+
+    def test_overlapping_sets_report_full_span(self):
+
+        """
+        Years 1-20 alongside years 1-40, which is what a re-post-processed run
+        leaves behind, must report the whole available span.
+
+        These files cannot be opened together -- the combined time axis would
+        have duplicate times -- and this method runs during ADF setup, so
+        reading the period from the file names rather than the data is what
+        keeps the run alive long enough for the year range in the config file
+        to be honored.
+        """
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            _write_ts(Path(tmpdir) / "case.cam.h0a.T.000101-002012.nc",
+                      "T", 1, 20)
+            _write_ts(Path(tmpdir) / "case.cam.h0a.T.000101-004012.nc",
+                      "T", 1, 40)
+
+            syr, eyr = _call(_StubInfo(["T"]), tmpdir, "case",
+                             hist_str="cam.h0a")
+
+            self.assertEqual((syr, eyr), (1, 40))
+
+    def test_partially_overlapping_sets_report_full_span(self):
+
+        """
+        The same, for sets that only partly overlap (years 1-20 alongside
+        years 10-40), which is the layout that used to raise
+        'Resulting object does not have monotonic global indexes'.
+        """
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            _write_ts(Path(tmpdir) / "case.cam.h0a.T.000101-002012.nc",
+                      "T", 1, 20)
+            _write_ts(Path(tmpdir) / "case.cam.h0a.T.001001-004012.nc",
+                      "T", 10, 31)
+
+            syr, eyr = _call(_StubInfo(["T"]), tmpdir, "case",
+                             hist_str="cam.h0a")
+
+            self.assertEqual((syr, eyr), (1, 40))
+
+    def test_unreadable_dates_fall_back_to_the_data(self):
+
+        """
+        A directory whose names do not carry the period still has to work,
+        which is what the fallback that opens the files is for.
+        """
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            _write_ts(Path(tmpdir) / "case.cam.h0a.T.someperiod.nc", "T", 7, 3)
+
+            syr, eyr = _call(_StubInfo(["T"]), tmpdir, "case",
+                             hist_str="cam.h0a")
+
+            self.assertEqual((syr, eyr), (7, 9))
 
     def test_nested_layout_does_not_flood_the_debug_log(self):
 

--- a/lib/test/unit_tests/test_ts_file_combine.py
+++ b/lib/test/unit_tests/test_ts_file_combine.py
@@ -1,0 +1,137 @@
+"""
+Collection of python unit tests
+for combining time series files into one file.
+
+The MDTF file move writes one file per variable, so a variable split into
+consecutive files has to be combined.  Whether that is safe is decided by
+"adf_file_utils.ts_files_need_combining", which reads the periods out of the
+file names.  These tests check that decision against what xarray actually does
+with the files, so the two cannot drift apart: a set the decision calls
+combinable must open, and a set it rejects must be one that really would fail.
+
+Getting that wrong ended the whole ADF run rather than one variable, because
+the exception was raised where nothing catches it.
+
+NOTE: these tests import xarray, so they are skipped in CI, which installs only
+PyYAML and pytest.  The decision itself is tested without xarray in
+test_adf_file_utils.py.
+"""
+
+#+++++++++++++++++++++++
+#Import required modules
+#+++++++++++++++++++++++
+
+import unittest
+import sys
+import os
+import os.path
+import tempfile
+from pathlib import Path
+
+#Set relevant path variables:
+_CURRDIR = os.path.abspath(os.path.dirname(__file__))
+_ADF_LIB_DIR = os.path.join(_CURRDIR, os.pardir, os.pardir)
+
+#Add ADF "lib" directory to python path:
+sys.path.append(_ADF_LIB_DIR)
+
+from adf_file_utils import ts_files_need_combining
+
+try:
+    import numpy as np
+    import xarray as xr
+    _HAS_XARRAY = True
+except ImportError:
+    _HAS_XARRAY = False
+
+
+#Every file of a case carries the same reference date, because ncrcat and
+#GenTS both take it from the history files.  That matters here: files with
+#different reference dates hold numbers that do not overlap even when the
+#periods do, which hides the failure this module is about.
+_UNITS = "days since 0001-01-01 00:00:00"
+
+
+def _write_ts(path, first_month, nmonths):
+    """Write a time series file covering `nmonths` months, monthly."""
+    time = np.arange(first_month, first_month + nmonths) * 30.0
+    ds = xr.Dataset({"T": (("time",), np.arange(nmonths, dtype="f4"))},
+                    coords={"time": time})
+    ds.time.attrs = {"units": _UNITS, "calendar": "noleap"}
+    ds.to_netcdf(path)
+
+
+@unittest.skipUnless(_HAS_XARRAY, "xarray not available")
+class TsFileCombineTestRoutine(unittest.TestCase):
+
+    """
+    Unit tests pairing the combine decision with xarray's own behavior.
+    """
+
+    def test_consecutive_files_combine(self):
+
+        """
+        Consecutive files -- what GenTS writes when 'gents_slice_years' is set
+        -- are the case the combine exists for: they must be combinable, and
+        combining must give one continuous record.
+        """
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            fils = [str(Path(tmpdir) / "case.cam.h0a.T.000101-001012.nc"),
+                    str(Path(tmpdir) / "case.cam.h0a.T.001101-002012.nc")]
+            _write_ts(fils[0], 0, 120)
+            _write_ts(fils[1], 120, 120)
+
+            self.assertTrue(ts_files_need_combining(fils))
+
+            with xr.open_mfdataset(fils, decode_times=False,
+                                   combine="by_coords") as ds:
+                self.assertEqual(len(ds.time), 240)
+                self.assertTrue(bool(np.all(np.diff(ds.time.values) > 0)))
+            #End with
+
+    def test_overlapping_files_are_not_combined(self):
+
+        """
+        Two sets covering years 1-20 and 10-40, which is what extending a run
+        and re-processing the time series leaves behind.
+
+        The decision has to reject these, and the test also shows why: opening
+        them together raises, and the caller raised where nothing catches it,
+        so the whole run ended.
+        """
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            fils = [str(Path(tmpdir) / "case.cam.h0a.T.000101-002012.nc"),
+                    str(Path(tmpdir) / "case.cam.h0a.T.001001-004012.nc")]
+            _write_ts(fils[0], 0, 240)
+            _write_ts(fils[1], 108, 372)
+
+            self.assertFalse(ts_files_need_combining(fils))
+
+            with self.assertRaises(ValueError):
+                xr.open_mfdataset(fils, decode_times=False,
+                                  combine="by_coords")
+            #End with
+
+    def test_single_file_needs_no_combining(self):
+
+        """
+        One file is the ordinary case, and is copied rather than rewritten.
+        """
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            fil = str(Path(tmpdir) / "case.cam.h0a.T.000101-002012.nc")
+            _write_ts(fil, 0, 240)
+
+            self.assertFalse(ts_files_need_combining([fil]))
+
+#++++++++++++++++++
+
+#Run unit tests if this script is called directly:
+if __name__ == "__main__":
+    unittest.main()
+
+#############
+#End of file
+#############

--- a/scripts/analysis/amwg_table.py
+++ b/scripts/analysis/amwg_table.py
@@ -206,6 +206,12 @@ def amwg_table(adf):
             ts_filenames = f'{case_name}.*.{var}.*nc'
             ts_files = utils.find_ts_files(input_location, ts_filenames)
 
+            #Keep only the files needed for this case's years, so that a
+            #directory holding more than one set for the same variable
+            #(years 1-20 alongside years 1-40, say) is not a problem:
+            ts_files = utils.select_ts_files(ts_files, syear_cases[case_idx],
+                                             eyear_cases[case_idx])
+
             # If no files exist, try to move to next variable. --> Means we can not proceed with this variable, and it'll be problematic later.
             if not ts_files:
                 errmsg = f"\t    WARNING: Time series files for variable '{var}' not found.  Script will continue to next variable."

--- a/scripts/plotting/qbo.py
+++ b/scripts/plotting/qbo.py
@@ -34,6 +34,10 @@ def qbo(adfobj):
     base_name = adfobj.get_baseline_info('cam_case_name')
     base_loc = adfobj.get_baseline_info('cam_ts_loc')
     obsdir = adfobj.get_basic_info('obs_data_loc', required=True)
+    #Years are needed only to choose between sets of time series files that
+    #cannot be opened together; the plot itself shows the whole record:
+    syears = adfobj.climo_yrs["syears"]
+    eyears = adfobj.climo_yrs["eyears"]
     plot_locations = adfobj.plot_location
     plot_type = adfobj.get_basic_info('plot_type')
 
@@ -88,6 +92,8 @@ def qbo(adfobj):
     if not adfobj.compare_obs:
         case_loc.append(base_loc)
         case_names.append(base_name)
+        syears.append(adfobj.climo_yrs["syear_baseline"])
+        eyears.append(adfobj.climo_yrs["eyear_baseline"])
     #End if
 
     #----Read in the OBS (ERA5, 5S-5N average already
@@ -95,7 +101,11 @@ def qbo(adfobj):
 
     #----Read in the case data and baseline
     ncases = len(case_loc)
-    casedat = [utils.load_dataset(sorted(Path(case_loc[i]).glob(f"{case_names[i]}.*.U.*.nc"))) for i in range(0,ncases,1)]
+    casedat = [utils.load_dataset(
+                   utils.select_ts_files(
+                       sorted(Path(case_loc[i]).glob(f"{case_names[i]}.*.U.*.nc")),
+                       syears[i], eyears[i]))
+               for i in range(0,ncases,1)]
 
     #Find indices for all case datasets that don't contain a zonal wind field (U):
     bad_idxs = []

--- a/scripts/plotting/regional_map_multicase.py
+++ b/scripts/plotting/regional_map_multicase.py
@@ -78,6 +78,9 @@ def regional_map_multicase(adfobj):
         print("ERROR: regional_map_multicase is limited to <= 10 cases.")
         return
     case_loc = adfobj.get_cam_info("cam_ts_loc", required=True)
+    #Years are needed only to choose between sets of time series files that
+    #could not be opened together:
+    climo_yrs = adfobj.climo_yrs
     #
     # Determine input "reference case"
     #
@@ -112,7 +115,8 @@ def regional_map_multicase(adfobj):
         # the reference case
         data_to_plot = {}
         refcasetmp = _retrieve(
-            regional_opts, v, data_name, data_loc
+            regional_opts, v, data_name, data_loc,
+            syr=climo_yrs["syear_baseline"], eyr=climo_yrs["eyear_baseline"]
         )  # get the baseline field
 
         if refcasetmp is None:
@@ -135,7 +139,9 @@ def regional_map_multicase(adfobj):
 
         # each of the other cases
         for casenumber, case in enumerate(case_names):
-            casetmp = _retrieve(regional_opts, v, case, case_loc[casenumber])
+            casetmp = _retrieve(regional_opts, v, case, case_loc[casenumber],
+                                syr=climo_yrs["syears"][casenumber],
+                                eyr=climo_yrs["eyears"][casenumber])
             if casetmp is None:
                  wmsg = f"Variable '{v}' not found for case '{case}',"
                  wmsg += " so skipping that case/variable combo."
@@ -183,7 +189,8 @@ def regional_map_multicase(adfobj):
 # - autoscale_title
 # - simple_case_shortener
 
-def _retrieve(ropt, variable, casename, location, return_dataset=False):
+def _retrieve(ropt, variable, casename, location, return_dataset=False,
+              syr=None, eyr=None):
     """Custom function that retrieves a variable.
        Returns the variable as a DataArray, unless keyword return_dataset=True.
 
@@ -200,9 +207,16 @@ def _retrieve(ropt, variable, casename, location, return_dataset=False):
     kwarg:
     return_dataset -> bool, if true, return the dataset object, otherwise return the DataArray
                       with `variable`
+
+    kwarg:
+    syr, eyr -> int, the case's climatology years.  Used only to choose between
+                sets of time series files that could not be opened together;
+                the time selection applied below is the regional one from
+                `ropt`, which is unchanged.
     """
     # note: this function assumes monthly data
     fils = sorted(Path(location).glob(f"{casename}*.{variable}.*.nc"))
+    fils = utils.select_ts_files(fils, syr, eyr)
     if len(fils) == 0:
         #The variable doesn't appear to have been output during this
         #particular case run, so return None:

--- a/scripts/plotting/tape_recorder.py
+++ b/scripts/plotting/tape_recorder.py
@@ -181,6 +181,9 @@ def tape_recorder(adfobj):
         ts_loc = Path(case_ts_locs[idx])
         hist_str = hist_strs[idx]
         fils = sorted(ts_loc.glob(f'*{hist_str}.{var}.*.nc'))
+        #A directory can hold more than one set of files for one variable, so
+        #keep the set needed for this case's years:
+        fils = utils.select_ts_files(fils, start_years[idx], end_years[idx])
         dat = adfobj.data.load_timeseries_dataset(fils)
 
         if not dat:


### PR DESCRIPTION
Fixes #433.

## The problem

A time series directory can end up holding two sets of files for the same
variable. This happens when a run is post-processed over years 1-20, the run
is then extended, and the time series are made again over years 1-40. Both
sets are left in place.

ADF found all of those files and opened them together, because nothing looked
at `start_year` and `end_year` when searching for files. What happened next
depended on the two sets:

- If the sets only partly overlap (years 1-20 next to years 10-40), xarray
  raised `Resulting object does not have monotonic global indexes along
  dimension time` and the run stopped.
- If the sets start in the same year (years 1-20 next to years 1-40), the
  files opened without any error, and the values in the overlapping years came
  from whichever file happened to win. This gave an answer that looked fine
  but was not built from the data the user asked for.

The first place this happens is `AdfInfo.get_climo_yrs_from_ts`, which runs
while ADF is still reading its configuration. So the run died before any
diagnostic started.

## The fix

`start_year` and `end_year` are already in the config file. They now decide
which files are used, so no new setting is needed.

- New `adf_file_utils.select_ts_files(files, start_year, end_year)`. It reads
  the dates out of each file name and keeps only the files needed to cover the
  requested years. At each step it takes the file that begins at or before the
  first year still needed, preferring the smallest file that holds all of the
  rest, and otherwise the file that reaches furthest. A variable split into
  consecutive pieces (what GenTS writes when `slice_years` is set) therefore
  keeps every piece it needs, while a duplicate set is passed over.
- It is called from every place that finds time series files: the shared
  search in `AdfData` (which covers climatologies, regridding and the time
  series plots), `amwg_table`, `adf_derive` (the years are passed down through
  `derive_variable` from both time series back ends), the three plotting
  scripts that do their own search (`qbo`, `tape_recorder`,
  `regional_map_multicase`), and the MDTF file move.
- The MDTF file move used to take the first file it found and warn that it was
  "continuing with best guess". A variable split into consecutive files is now
  written out as the single file MDTF expects. A lone file is still copied.
- `AdfData` writes a line to the debug log naming the files it used whenever a
  directory turned out to hold more than one set.
- `AdfInfo.get_climo_yrs_from_ts` now takes the available years from the file
  names instead of opening the files. This is what keeps the run alive long
  enough for the configured years to be used.

Only a set of files that cannot be opened as it stands is narrowed. Anything
that already combines cleanly is passed through untouched and ADF behaves
exactly as before, which matters because the plots that show a whole record
(`global_mean_timeseries`, for one) ask for every file a case has, not only
the climatology years. The other pass-through cases are: fewer than two files,
no years given, a year range given backwards, file names whose dates cannot be
read, dates that would have to be compared at finer than year resolution, a
gap in the requested range, and a set that cannot be reduced to a usable
choice at all.

One case is improved rather than fixed. If two sets only partly overlap
(years 1-20 beside years 10-40) *and* the config gives no years at all, the
available range is reported as years 1-40, both files are needed to cover it,
and opening them still fails. It now fails in the climatology step, where it
is caught and reported for that one variable, instead of stopping the whole
run during setup. Giving the years, which is what the issue asks for, avoids
it entirely.

## Testing

Unit tests: 89 pass. New cases cover the two overlapping layouts, consecutive
pieces, a range that sits inside a single file, a chunked set next to a
whole-period set, files split inside a year, a set that cannot be reduced to a
usable choice, and every pass-through case. Three cases were added for
`get_climo_yrs_from_ts` and one for `derive_variable`.

I also corrected five file names in `test_adf_info_climo_yrs.py` that claimed
one year more than the file held (for example `010001-010512.nc` holding years
100-104). Nothing read those names before, so they were harmless until now.

End to end on Casper, model against model, two deliberately different cases
(CESM3 alpha 1850 control, `cam.h0a`, 93 levels; and an AMIP run, `cam.h0`,
32 levels):

1. Made a 5-year set of time series.
2. Made a 10-year set in the same directory, which is the situation in the
   issue.
3. Ran the 5-year years again with both sets present.

All three finished with no errors, and each climatology file records in its own
attributes that it used the single correct set of files.

Regression check, same machine, with the three existing test configurations
(built-in back end, GenTS back end, and comparison against observations): all
finished, with the same number of climatology, regridded, plot, table and web
page products as before the change, and the two time series back ends still
produce identical data.

`global_mean_timeseries`, `tape_recorder` and `regional_map_multicase` were
also run against a directory holding two sets, and the debug log confirms which
file each variable used.

## Two things left for follow-up

- The one-line change to `qbo` is compile-checked but was not run. It needs a
  `U` time series, which the test configuration does not have. Same one-line
  change as the other two scripts.
- Three problems that already exist on `main` came to light while running those
  scripts. None is touched here, and each looks worth its own issue:
  1. `tape_recorder` line 147 calls `pd.date_range(..., freq='M')`, which
     recent pandas refuses ("'M' is no longer supported for offsets. Please use
     'ME' instead"). It stops the whole plotting stage. Picking the right fix
     is a question of which pandas versions the ADF supports, since `'ME'` does
     not exist before pandas 2.2.
  2. `AdfInfo` only records the baseline history string when it reads history
     files, so with `cam_ts_done: true` it stays an empty string.
     `tape_recorder` then builds a shorter list of history strings than it has
     cases and raises `IndexError`, which means it cannot run against pre-made
     time series at all.
  3. `regional_map_multicase` calls `prep_contour_plot` with three positional
     arguments, but that function now requires four (`pctdata`), so it raises
     `TypeError` as soon as it tries to plot.
