### PR TITLE
Let the tape recorder plot run against pre-made time series (#470, #471)

### DIFF
--- a/lib/adf_file_utils.py
+++ b/lib/adf_file_utils.py
@@ -18,6 +18,10 @@ ts_files_need_combining(fils)
     Report whether a set of time series files has to be combined into one.
 ts_file_span(fils)
     Report the period a set of time series files covers, taken together.
+as_hist_str_list(value)
+    Normalize a configured history stream setting to a list.
+pick_hist_str(value, wanted)
+    Choose the one history stream a case should be searched for.
 
 Notes
 -----
@@ -26,6 +30,62 @@ every existing caller.
 """
 
 from pathlib import Path
+
+
+def as_hist_str_list(value):
+    """
+    Normalize a configured history stream setting to a list.
+
+    The ADF holds one stream as a plain string, several as a list, and an
+    empty string when none was configured, so all three have to be accepted.
+    Iterating a plain string would walk its characters instead of its value.
+
+    Parameters
+    ----------
+    value : str or list or None
+        a history stream setting as the ADF stores it
+
+    Returns
+    -------
+    list
+        the streams it names; empty when none were configured
+    """
+    if not value:
+        return []
+    # End if
+    if isinstance(value, str):
+        return [value]
+    # End if
+    return list(value)
+
+
+def pick_hist_str(value, wanted):
+    """
+    Choose the one history stream a case should be searched for.
+
+    Parameters
+    ----------
+    value : str or list or None
+        the case's configured stream(s)
+    wanted : set
+        the streams the caller can use, e.g. ``{"cam.h0", "cam.h0a"}``
+
+    Returns
+    -------
+    str
+        the first configured stream the caller can use, or ``""`` when the
+        case has none.
+
+    Notes
+    -----
+    Every case has to yield exactly one answer.  Callers build a list of these
+    and index it by case number, alongside the case names, file locations and
+    years, so a case that contributed nothing would shift every case after it
+    onto the wrong entry.  An empty string leaves the file search unanchored to
+    a stream, which finds the files whichever stream they are in.
+    """
+    matches = [stream for stream in as_hist_str_list(value) if stream in wanted]
+    return matches[0] if matches else ""
 
 
 def find_ts_files(ts_loc, pattern, recursive=True):

--- a/lib/adf_info.py
+++ b/lib/adf_info.py
@@ -401,6 +401,16 @@ class AdfInfo(AdfConfig):
         #Extract cam history files location:
         cam_hist_locs = self.get_cam_info('cam_hist_loc')
 
+        # A history file location is not needed by a case running on pre-made
+        # time series, so it can be absent altogether or given for only some
+        # cases.  Normalize it to one entry per case, as the years above are,
+        # so that it can be indexed by case number and set per case below.
+        if cam_hist_locs is None:
+            cam_hist_locs = [None] * self.__num_cases
+        elif not isinstance(cam_hist_locs, list):
+            cam_hist_locs = [cam_hist_locs] * self.__num_cases
+        # End if
+
         #Get cleaned nested list of hist_str for test case(s) (component.hist_num, eg cam.h0)
         cam_hist_str = self.__cam_climo_info.get('hist_str', None)
 
@@ -467,7 +477,11 @@ class AdfInfo(AdfConfig):
 
             #Check if history file path exists:
             hist_str_case = hist_str[case_idx]
-            if any(cam_hist_locs):
+            # This case's own location, not any case's: with several cases,
+            # some on pre-made time series and some not, asking whether any of
+            # them has one sent a case with none into the search below and
+            # tripped over its empty location.
+            if cam_hist_locs[case_idx]:
                 #Grab first possible hist string, just looking for years of run
                 hist_str_use = hist_str_case[0]
 

--- a/lib/adf_info.py
+++ b/lib/adf_info.py
@@ -208,6 +208,18 @@ class AdfInfo(AdfConfig):
             # Read hist_str (component.hist_num, eg cam.h0) from the yaml file
             baseline_hist_str = self.get_baseline_info("hist_str")
 
+            # Record the stream the user configured straight away, so that it
+            # is available whether the years come from history files or from
+            # pre-made time series.  Only what was actually given is recorded:
+            # with pre-made time series and no stream configured this stays
+            # empty, and the searches downstream go on matching any stream.
+            if baseline_hist_str and not isinstance(baseline_hist_str, list):
+                baseline_hist_str = [baseline_hist_str]
+            # End if
+            if baseline_hist_str:
+                self.__base_hist_str = baseline_hist_str
+            # End if
+
             #Check if any time series files are pre-made
             baseline_ts_done   = self.get_baseline_info("cam_ts_done")
 
@@ -251,15 +263,12 @@ class AdfInfo(AdfConfig):
 
             # Check if history file path exists:
             elif baseline_hist_locs and any(baseline_hist_locs):
-                #Check if user provided
+                # History files are found by name, so a stream is needed here
+                # even when the user did not give one:
                 if not baseline_hist_str:
-                    baseline_hist_str = ['cam.h0a']
-                else:
-                    #Make list if not already
-                    if not isinstance(baseline_hist_str, list):
-                        baseline_hist_str = [baseline_hist_str]
-                #Initialize baseline history string list
-                self.__base_hist_str = baseline_hist_str
+                    baseline_hist_str = ["cam.h0a"]
+                    self.__base_hist_str = baseline_hist_str
+                # End if
 
                 #Grab first possible hist string, just looking for years of run
                 base_hist_str = baseline_hist_str[0]

--- a/lib/adf_utils.py
+++ b/lib/adf_utils.py
@@ -1,9 +1,10 @@
-"""                                                                    .
+""".
 Generic computation helper functions
 
 Functions
 ---------
-find_ts_files(), select_ts_files(), ts_files_overlap(), ts_file_span()
+find_ts_files(), select_ts_files(), ts_files_overlap(), ts_file_span(),
+as_hist_str_list(), pick_hist_str()
     re-exported from adf_file_utils; time series file discovery
 load_dataset()
     generalized load dataset method used for plotting/analysis functions
@@ -57,8 +58,15 @@ from adf_base import AdfError
 #tested without importing the scientific stack (see adf_file_utils).  Re-export
 #here so `utils.find_ts_files(...)` keeps working for every existing caller:
 # pylint: disable=unused-import
-from adf_file_utils import (find_ts_files, select_ts_files, ts_files_overlap,
-                            ts_file_span)
+from adf_file_utils import (
+    as_hist_str_list,
+    find_ts_files,
+    pick_hist_str,
+    select_ts_files,
+    ts_files_overlap,
+    ts_file_span,
+)
+
 # pylint: enable=unused-import
 
 import warnings  # use to warn user about missing files.

--- a/lib/test/unit_tests/test_climo_stream_fallback.py
+++ b/lib/test/unit_tests/test_climo_stream_fallback.py
@@ -1,0 +1,170 @@
+"""
+Collection of python unit tests
+for "create_climo_files.find_ts_for_variable".
+
+Climatologies are built per history stream, so the stream configured for a case
+decides which time series files are used.  That stream does not have to match
+the names of pre-made time series files: the example config carries
+``hist_str: cam.h0a`` in both case blocks, while a CESM2-era run's files are
+named ``cam.h0``.  Before the stream was recorded for runs on pre-made time
+series, those runs searched without one and found the files anyway; once it is
+recorded, a mismatched stream would find nothing and the variable would be
+skipped, leaving no baseline to compare against.  So a search that comes back
+empty for every configured stream falls back to searching without one.
+
+NOTE: these tests import create_climo_files, which imports xarray, so they are
+skipped in CI, which installs only PyYAML and pytest.  They run in a full ADF
+environment.
+"""
+
+import os
+import os.path
+import sys
+import unittest
+
+# Set relevant path variables:
+_CURRDIR = os.path.abspath(os.path.dirname(__file__))
+_ADF_LIB_DIR = os.path.join(_CURRDIR, os.pardir, os.pardir)
+_ADF_AVERAGING_DIR = os.path.join(
+    _CURRDIR, os.pardir, os.pardir, os.pardir, "scripts", "averaging"
+)
+
+# Add ADF "lib" and averaging script directories to python path:
+sys.path.append(_ADF_LIB_DIR)
+sys.path.append(_ADF_AVERAGING_DIR)
+
+try:
+    from create_climo_files import find_ts_for_variable
+
+    _HAS_CREATE_CLIMO = True
+except ImportError:
+    _HAS_CREATE_CLIMO = False
+
+
+class _StubData:
+    """Stand-in for AdfData: answers file searches from a stream -> files map."""
+
+    def __init__(self, available):
+        self.available = available
+
+    def get_ref_timeseries_file(self, var, hist_str=None):
+        """Files for one stream, or for any stream when hist_str is None."""
+        if hist_str is None:
+            return [fil for fils in self.available.values() for fil in fils]
+        return self.available.get(hist_str, [])
+
+    def get_timeseries_file(self, case, var, hist_str=None):
+        """Test cases are searched the same way, with the case name added."""
+        return self.get_ref_timeseries_file(var, hist_str=hist_str)
+
+
+class _StubAdf:
+    """Minimal stand-in for the ADF object: only its data member is used."""
+
+    def __init__(self, available):
+        self.data = _StubData(available)
+
+
+@unittest.skipUnless(_HAS_CREATE_CLIMO, "create_climo_files dependencies not available")
+class ClimoStreamFallbackTestRoutine(unittest.TestCase):
+    """
+    Unit tests for finding a variable's time series across history streams.
+    """
+
+    # A case whose files are named for one stream:
+    FILES = {"cam.h0": ["case.cam.h0.Q.200001-200412.nc"]}
+
+    def test_configured_stream_is_used(self):
+        """The ordinary case: the stream matches, and is used and reported."""
+
+        found = find_ts_for_variable(
+            _StubAdf(self.FILES), "case", "Q", ["cam.h0"], True
+        )
+
+        self.assertEqual(len(found), 1)
+        self.assertEqual(found[0][0], "cam.h0")
+
+    def test_mismatched_stream_falls_back(self):
+        """
+        The case this exists for: a stream is configured but does not match the
+        file names, which is what the example config gives a CESM2-era baseline
+        on pre-made time series.
+
+        The files are found, and reported against no stream, so the climatology
+        keeps the stream-agnostic name rather than claiming a stream its data
+        did not come from.
+        """
+
+        found = find_ts_for_variable(
+            _StubAdf(self.FILES), "case", "Q", ["cam.h0a"], True
+        )
+
+        self.assertEqual(len(found), 1)
+        self.assertIsNone(found[0][0])
+        self.assertEqual(len(found[0][1]), 1)
+
+    def test_matching_stream_does_not_also_fall_back(self):
+        """
+        The fallback is a last resort.  If it ran anyway, a variable would be
+        written twice: once under its stream and once without.
+        """
+
+        found = find_ts_for_variable(
+            _StubAdf(self.FILES), "case", "Q", ["cam.h0a", "cam.h0"], True
+        )
+
+        self.assertEqual([hist_str for hist_str, _ in found], ["cam.h0"])
+
+    def test_several_streams_hold_the_variable(self):
+        """A variable can be in more than one stream, and each is kept."""
+
+        files = {
+            "cam.h0": ["case.cam.h0.Q.200001-200412.nc"],
+            "cam.h1": ["case.cam.h1.Q.200001-200412.nc"],
+        }
+
+        found = find_ts_for_variable(
+            _StubAdf(files), "case", "Q", ["cam.h0", "cam.h1"], True
+        )
+
+        self.assertEqual([hist_str for hist_str, _ in found], ["cam.h0", "cam.h1"])
+
+    def test_no_stream_known_searches_without_one(self):
+        """
+        A case with no stream recorded searches without one, and must not then
+        search a second time and report the files twice.
+        """
+
+        found = find_ts_for_variable(_StubAdf(self.FILES), "case", "Q", [None], True)
+
+        self.assertEqual(len(found), 1)
+        self.assertIsNone(found[0][0])
+
+    def test_variable_genuinely_absent(self):
+        """
+        A variable that is not in the run at all is normal, and has to come
+        back empty so the caller can warn and move on.
+        """
+
+        found = find_ts_for_variable(_StubAdf({}), "case", "Q", ["cam.h0a"], True)
+
+        self.assertEqual(found, [])
+
+    def test_test_case_search_matches_baseline_search(self):
+        """Test cases take the same path, with the case name passed along."""
+
+        found = find_ts_for_variable(
+            _StubAdf(self.FILES), "case", "Q", ["cam.h0a"], False
+        )
+
+        self.assertEqual(len(found), 1)
+        self.assertIsNone(found[0][0])
+
+
+# Run unit tests if this script is called directly:
+if __name__ == "__main__":
+    unittest.main()
+
+#############
+# End of file
+#############

--- a/lib/test/unit_tests/test_hist_str_selection.py
+++ b/lib/test/unit_tests/test_hist_str_selection.py
@@ -1,6 +1,6 @@
 """
 Collection of python unit tests
-for the history stream choice in "tape_recorder".
+for choosing a case's history stream.
 
 The tape recorder plot builds a list of history streams and then indexes it by
 case number, alongside the case names, time series locations and years.  So the
@@ -11,9 +11,9 @@ read off the wrong entry.  A baseline running on pre-made time series had no
 stream recorded at all, so the plot raised IndexError and could not be used
 against pre-made time series (NCAR/ADF issue #471).
 
-NOTE: these tests import tape_recorder, which pulls in matplotlib and xarray,
-so they are skipped in CI, which installs only PyYAML and pytest.  They run in
-a full ADF environment.
+Both the tape recorder plot and the aerosol and gas tables build such a list,
+so the choice lives in adf_file_utils, which imports nothing but pathlib and
+can therefore be tested in CI.
 """
 
 # +++++++++++++++++++++++
@@ -28,59 +28,48 @@ import os.path
 # Set relevant path variables:
 _CURRDIR = os.path.abspath(os.path.dirname(__file__))
 _ADF_LIB_DIR = os.path.join(_CURRDIR, os.pardir, os.pardir)
-_ADF_SCRIPTS_DIR = os.path.join(
-    _CURRDIR, os.pardir, os.pardir, os.pardir, "scripts", "plotting"
-)
 
-# Add ADF "lib" and plotting script directories to python path:
+# Add ADF "lib" directory to python path:
 sys.path.append(_ADF_LIB_DIR)
-sys.path.append(_ADF_SCRIPTS_DIR)
 
-try:
-    from tape_recorder import _as_list, _pick_hist_str
+from adf_file_utils import as_hist_str_list, pick_hist_str
 
-    _HAS_TAPE_RECORDER = True
-except ImportError:
-    _HAS_TAPE_RECORDER = False
-
-
-# The streams the tape recorder can use, as the script defines them:
+# The streams the tape recorder can use, as that script defines them:
 _SUBSTRINGS = {"cam.h0", "cam.h0a"}
 
 
-@unittest.skipUnless(_HAS_TAPE_RECORDER, "tape_recorder dependencies not available")
-class TapeRecorderHistStrTestRoutine(unittest.TestCase):
+class HistStrSelectionTestRoutine(unittest.TestCase):
     """
     Unit tests for choosing one history stream per case.
     """
 
-    def test_as_list_accepts_what_the_adf_stores(self):
+    def test_as_hist_str_list_accepts_what_the_adf_stores(self):
         """
         The ADF holds one stream as a plain string, several as a list, and an
         empty string when none was configured.  All three have to be accepted:
         iterating a plain string would walk its characters instead.
         """
 
-        self.assertEqual(_as_list("cam.h0"), ["cam.h0"])
-        self.assertEqual(_as_list(["cam.h0", "cam.h1"]), ["cam.h0", "cam.h1"])
-        self.assertEqual(_as_list(""), [])
-        self.assertEqual(_as_list(None), [])
-        self.assertEqual(_as_list([]), [])
+        self.assertEqual(as_hist_str_list("cam.h0"), ["cam.h0"])
+        self.assertEqual(as_hist_str_list(["cam.h0", "cam.h1"]), ["cam.h0", "cam.h1"])
+        self.assertEqual(as_hist_str_list(""), [])
+        self.assertEqual(as_hist_str_list(None), [])
+        self.assertEqual(as_hist_str_list([]), [])
 
     def test_pick_from_a_list_of_streams(self):
         """
         A case with several streams contributes the one the plot can use.
         """
 
-        self.assertEqual(_pick_hist_str(["cam.h1", "cam.h0a"], _SUBSTRINGS), "cam.h0a")
-        self.assertEqual(_pick_hist_str(["cam.h0"], _SUBSTRINGS), "cam.h0")
+        self.assertEqual(pick_hist_str(["cam.h1", "cam.h0a"], _SUBSTRINGS), "cam.h0a")
+        self.assertEqual(pick_hist_str(["cam.h0"], _SUBSTRINGS), "cam.h0")
 
     def test_pick_from_a_plain_string(self):
         """
         One configured stream arrives as a string, not a list of one.
         """
 
-        self.assertEqual(_pick_hist_str("cam.h0", _SUBSTRINGS), "cam.h0")
+        self.assertEqual(pick_hist_str("cam.h0", _SUBSTRINGS), "cam.h0")
 
     def test_no_usable_stream_still_answers(self):
         """
@@ -92,10 +81,10 @@ class TapeRecorderHistStrTestRoutine(unittest.TestCase):
         which is what the search did before any of this was filtered.
         """
 
-        self.assertEqual(_pick_hist_str("", _SUBSTRINGS), "")
-        self.assertEqual(_pick_hist_str([], _SUBSTRINGS), "")
-        self.assertEqual(_pick_hist_str("cam.h3", _SUBSTRINGS), "")
-        self.assertEqual(_pick_hist_str(["cam.h1", "cam.h2"], _SUBSTRINGS), "")
+        self.assertEqual(pick_hist_str("", _SUBSTRINGS), "")
+        self.assertEqual(pick_hist_str([], _SUBSTRINGS), "")
+        self.assertEqual(pick_hist_str("cam.h3", _SUBSTRINGS), "")
+        self.assertEqual(pick_hist_str(["cam.h1", "cam.h2"], _SUBSTRINGS), "")
 
     def test_one_entry_per_case(self):
         """
@@ -105,7 +94,7 @@ class TapeRecorderHistStrTestRoutine(unittest.TestCase):
 
         cases = [["cam.h0a"], ["cam.h3"], "cam.h0", "", ["cam.h1", "cam.h0a"]]
 
-        picked = [_pick_hist_str(case, _SUBSTRINGS) for case in cases]
+        picked = [pick_hist_str(case, _SUBSTRINGS) for case in cases]
 
         self.assertEqual(len(picked), len(cases))
         self.assertEqual(picked, ["cam.h0a", "", "cam.h0", "", "cam.h0a"])

--- a/lib/test/unit_tests/test_tape_recorder_hist_strs.py
+++ b/lib/test/unit_tests/test_tape_recorder_hist_strs.py
@@ -1,0 +1,122 @@
+"""
+Collection of python unit tests
+for the history stream choice in "tape_recorder".
+
+The tape recorder plot builds a list of history streams and then indexes it by
+case number, alongside the case names, time series locations and years.  So the
+list has to hold exactly one entry per case: an earlier version appended only
+when a case had a "cam.h0" or "cam.h0a" stream, which made the list shorter
+than the cases whenever one did not, and every case after the missing one was
+read off the wrong entry.  A baseline running on pre-made time series had no
+stream recorded at all, so the plot raised IndexError and could not be used
+against pre-made time series (NCAR/ADF issue #471).
+
+NOTE: these tests import tape_recorder, which pulls in matplotlib and xarray,
+so they are skipped in CI, which installs only PyYAML and pytest.  They run in
+a full ADF environment.
+"""
+
+# +++++++++++++++++++++++
+# Import required modules
+# +++++++++++++++++++++++
+
+import unittest
+import sys
+import os
+import os.path
+
+# Set relevant path variables:
+_CURRDIR = os.path.abspath(os.path.dirname(__file__))
+_ADF_LIB_DIR = os.path.join(_CURRDIR, os.pardir, os.pardir)
+_ADF_SCRIPTS_DIR = os.path.join(
+    _CURRDIR, os.pardir, os.pardir, os.pardir, "scripts", "plotting"
+)
+
+# Add ADF "lib" and plotting script directories to python path:
+sys.path.append(_ADF_LIB_DIR)
+sys.path.append(_ADF_SCRIPTS_DIR)
+
+try:
+    from tape_recorder import _as_list, _pick_hist_str
+
+    _HAS_TAPE_RECORDER = True
+except ImportError:
+    _HAS_TAPE_RECORDER = False
+
+
+# The streams the tape recorder can use, as the script defines them:
+_SUBSTRINGS = {"cam.h0", "cam.h0a"}
+
+
+@unittest.skipUnless(_HAS_TAPE_RECORDER, "tape_recorder dependencies not available")
+class TapeRecorderHistStrTestRoutine(unittest.TestCase):
+    """
+    Unit tests for choosing one history stream per case.
+    """
+
+    def test_as_list_accepts_what_the_adf_stores(self):
+        """
+        The ADF holds one stream as a plain string, several as a list, and an
+        empty string when none was configured.  All three have to be accepted:
+        iterating a plain string would walk its characters instead.
+        """
+
+        self.assertEqual(_as_list("cam.h0"), ["cam.h0"])
+        self.assertEqual(_as_list(["cam.h0", "cam.h1"]), ["cam.h0", "cam.h1"])
+        self.assertEqual(_as_list(""), [])
+        self.assertEqual(_as_list(None), [])
+        self.assertEqual(_as_list([]), [])
+
+    def test_pick_from_a_list_of_streams(self):
+        """
+        A case with several streams contributes the one the plot can use.
+        """
+
+        self.assertEqual(_pick_hist_str(["cam.h1", "cam.h0a"], _SUBSTRINGS), "cam.h0a")
+        self.assertEqual(_pick_hist_str(["cam.h0"], _SUBSTRINGS), "cam.h0")
+
+    def test_pick_from_a_plain_string(self):
+        """
+        One configured stream arrives as a string, not a list of one.
+        """
+
+        self.assertEqual(_pick_hist_str("cam.h0", _SUBSTRINGS), "cam.h0")
+
+    def test_no_usable_stream_still_answers(self):
+        """
+        The case this exists for: an unset stream, which is what a baseline on
+        pre-made time series used to have, and a stream the plot cannot use.
+
+        Both give an empty string rather than nothing at all.  An empty string
+        leaves the file search matching whichever stream the files are in,
+        which is what the search did before any of this was filtered.
+        """
+
+        self.assertEqual(_pick_hist_str("", _SUBSTRINGS), "")
+        self.assertEqual(_pick_hist_str([], _SUBSTRINGS), "")
+        self.assertEqual(_pick_hist_str("cam.h3", _SUBSTRINGS), "")
+        self.assertEqual(_pick_hist_str(["cam.h1", "cam.h2"], _SUBSTRINGS), "")
+
+    def test_one_entry_per_case(self):
+        """
+        The property the plot depends on: as many entries as there are cases,
+        in the same order, whatever each case holds.
+        """
+
+        cases = [["cam.h0a"], ["cam.h3"], "cam.h0", "", ["cam.h1", "cam.h0a"]]
+
+        picked = [_pick_hist_str(case, _SUBSTRINGS) for case in cases]
+
+        self.assertEqual(len(picked), len(cases))
+        self.assertEqual(picked, ["cam.h0a", "", "cam.h0", "", "cam.h0a"])
+
+
+# ++++++++++++++++++
+
+# Run unit tests if this script is called directly:
+if __name__ == "__main__":
+    unittest.main()
+
+#############
+# End of file
+#############

--- a/scripts/analysis/aerosol_gas_tables.py
+++ b/scripts/analysis/aerosol_gas_tables.py
@@ -9,6 +9,7 @@ import pandas as pd
 
 # Import necessary ADF modules:
 from adf_base import AdfError
+import adf_utils as utils
 
 def aerosol_gas_tables(adfobj, trop_val=None, **kwargs):
     '''
@@ -214,13 +215,13 @@ def aerosol_gas_tables(adfobj, trop_val=None, **kwargs):
     # Filter the list to include only strings that are possible h0 strings
     # - Search for either h0 or h0a
     substrings = {"cam.h0","cam.h0a","cam.hm"}
-    case_hist_strs = []
-    for cam_case_str in hist_strs:
-        # Check each possible h0 string
-        for string in cam_case_str:
-            if string in substrings:
-                case_hist_strs.append(string)
-                break
+    # Exactly one entry per case, so that this list stays aligned with the
+    # cases it is indexed by below.  A case with none of these streams
+    # contributes an empty string rather than dropping out and shifting every
+    # case after it onto another case's stream.
+    case_hist_strs = [
+        utils.pick_hist_str(cam_case_str, substrings) for cam_case_str in hist_strs
+    ]
 
     # Create path object for the CAM history file(s) location:
     data_dirs = []
@@ -390,9 +391,13 @@ def Get_files(adfobj, data_dir, start_year, end_year, h_case, **kwargs):
     current_files = list_files(adfobj, data_dir, start_year, end_year,h_case)
     # get the Lat and Lons for each case
     tmp_file = xr.open_dataset(Path(data_dir) / current_files[0])
-    lon = tmp_file['lon'+ext1_SE].data
-    lon[lon > 180.] -= 360 # shift longitude from 0-360˚ to -180-180˚
-    lat = tmp_file['lat'+ext1_SE].data
+    # Copy before shifting: the array belongs to the open file, and recent
+    # xarray hands it back read-only, so shifting it in place raises
+    # "assignment destination is read-only" -- and where it did work, it was
+    # editing the file's own cached values.
+    lon = tmp_file["lon" + ext1_SE].data.copy()
+    lon[lon > 180.0] -= 360  # shift longitude from 0-360˚ to -180-180˚
+    lat = tmp_file["lat" + ext1_SE].data
 
     if area == True:
         try:

--- a/scripts/averaging/create_climo_files.py
+++ b/scripts/averaging/create_climo_files.py
@@ -48,6 +48,64 @@ def get_time_slice_by_year(time, startyear, endyear):
 
 
 
+def find_ts_for_variable(adf, case_name, var, hist_strs, is_baseline):
+    """
+    Find a variable's time series files, per history stream.
+
+    Parameters
+    ----------
+    adf
+        the ADF object
+    case_name : str
+        name of the case being processed
+    var : str
+        variable to look for
+    hist_strs : list
+        history stream(s) configured for the case; ``[None]`` when none is
+        known, which searches without a stream
+    is_baseline : bool
+        whether the case is the baseline
+
+    Returns
+    -------
+    list of tuple
+        ``(hist_str, files)`` for each stream that has the variable; empty if
+        the variable was not found at all.
+
+    Notes
+    -----
+    A variable is usually in one stream but may be in several, so every
+    configured stream is searched.  If none of them has it, one last search is
+    made without a stream: a configured stream need not match the names of
+    pre-made time series files (a baseline whose files are named for
+    ``cam.h0`` while the config says ``cam.h0a``, which is what the example
+    config carries), and before the stream was known those runs searched
+    without one.  The same fallback is made by ``get_climo_yrs_from_ts`` and
+    ``get_reference_climo_file``.
+    """
+
+    def search(hist_str):
+        """Look for the variable in one stream, or in none if hist_str is None."""
+        if is_baseline:
+            return adf.data.get_ref_timeseries_file(var, hist_str=hist_str)
+        return adf.data.get_timeseries_file(case_name, var, hist_str=hist_str)
+
+    # End def
+
+    found = [
+        (hist_str, files)
+        for hist_str, files in ((h, search(h)) for h in hist_strs)
+        if files
+    ]
+    if not found and hist_strs != [None]:
+        files = search(None)
+        if files:
+            found = [(None, files)]
+        # End if
+    # End if
+    return found
+
+
 ##############
 #Main function
 ##############
@@ -210,20 +268,13 @@ def create_climo_files(adf, clobber=False, search=None):  # pylint: disable=unus
             # Notify user of new climo file:
             print(f"\t - climatology for {var}")
 
-            #Look for the variable's time series in each configured stream. A
-            #variable is usually in just one stream, but may exist in several.
-            found_in_any_stream = False
-            for hist_str in case_hist_strs:
-                if is_baseline:
-                    ts_files = adf.data.get_ref_timeseries_file(var, hist_str=hist_str)
-                else:
-                    ts_files = adf.data.get_timeseries_file(case_name, var, hist_str=hist_str)
-
-                #If no files exist for this stream, try the next stream:
-                if not ts_files:
-                    continue
-                found_in_any_stream = True
-
+            # Look for the variable's time series in each configured stream,
+            # and failing that without one:
+            found_streams = find_ts_for_variable(
+                adf, case_name, var, case_hist_strs, is_baseline
+            )
+            found_in_any_stream = bool(found_streams)
+            for hist_str, ts_files in found_streams:
                 # Create name of climatology output file (which includes the full path),
                 # now including the history stream when known, and check whether it is
                 # there (don't do computation if we don't want to overwrite):

--- a/scripts/plotting/tape_recorder.py
+++ b/scripts/plotting/tape_recorder.py
@@ -12,7 +12,7 @@ import adf_utils as utils
 def _pick_hist_str(value, substrings):
     """Return the one history stream to search for a case.
 
-    Returns an empty string when the case has no stream among `substrings`.
+    Returns an empty string when the case has no stream among ``substrings``.
     Every case has to yield exactly one answer: the lists built from this are
     indexed by case number, so dropping a case would shift every case after it
     onto the wrong entry.
@@ -78,8 +78,9 @@ def tape_recorder(adfobj):
     # cases it is indexed by below.  A case with no h0 stream contributes an
     # empty string, which makes the search match whichever stream the files
     # are in rather than dropping the case and shifting the rest.
-    case_hist_strs = [_pick_hist_str(cam_case_str, substrings)
-                      for cam_case_str in cam_hist_strs]
+    case_hist_strs = [
+        _pick_hist_str(cam_case_str, substrings) for cam_case_str in cam_hist_strs
+    ]
 
     #Grab test case climo years
     start_years = adfobj.climo_yrs["syears"]
@@ -214,6 +215,13 @@ def tape_recorder(adfobj):
         ts_loc = Path(case_ts_locs[idx])
         hist_str = hist_strs[idx]
         fils = sorted(ts_loc.glob(f'*{hist_str}.{var}.*.nc'))
+        if not fils and hist_str:
+            # A configured stream need not match the names of pre-made time
+            # series files, so fall back to searching without it rather than
+            # dropping the case out of the plot.  This is what
+            # create_climo_files does for the same reason.
+            fils = sorted(ts_loc.glob(f"*.{var}.*.nc"))
+        # End if
         #A directory can hold more than one set of files for one variable, so
         #keep the set needed for this case's years:
         fils = utils.select_ts_files(fils, start_years[idx], end_years[idx])

--- a/scripts/plotting/tape_recorder.py
+++ b/scripts/plotting/tape_recorder.py
@@ -9,33 +9,6 @@ from pathlib import Path
 import adf_utils as utils
 
 
-def _pick_hist_str(value, substrings):
-    """Return the one history stream to search for a case.
-
-    Returns an empty string when the case has no stream among ``substrings``.
-    Every case has to yield exactly one answer: the lists built from this are
-    indexed by case number, so dropping a case would shift every case after it
-    onto the wrong entry.
-    """
-    matches = [string for string in _as_list(value) if string in substrings]
-    return matches[0] if matches else ""
-
-
-def _as_list(value):
-    """Return a history string setting as a list.
-
-    The ADF holds one stream as a plain string, several as a list, and an
-    empty string when none was configured, so all three have to be accepted.
-    """
-    if not value:
-        return []
-    # End if
-    if isinstance(value, str):
-        return [value]
-    # End if
-    return list(value)
-
-
 def tape_recorder(adfobj):
     """
     Calculate the weighted latitude average for the simulations and 
@@ -79,7 +52,7 @@ def tape_recorder(adfobj):
     # empty string, which makes the search match whichever stream the files
     # are in rather than dropping the case and shifting the rest.
     case_hist_strs = [
-        _pick_hist_str(cam_case_str, substrings) for cam_case_str in cam_hist_strs
+        utils.pick_hist_str(cam_case_str, substrings) for cam_case_str in cam_hist_strs
     ]
 
     #Grab test case climo years
@@ -115,7 +88,7 @@ def tape_recorder(adfobj):
         # several are, and empty when the baseline runs on pre-made time series
         # with no stream given.  It contributes one entry in every case.
         hist_strs = case_hist_strs + [
-            _pick_hist_str(adfobj.hist_string["base_hist_str"], substrings)
+            utils.pick_hist_str(adfobj.hist_string["base_hist_str"], substrings)
         ]
     else:
         hist_strs = case_hist_strs

--- a/scripts/plotting/tape_recorder.py
+++ b/scripts/plotting/tape_recorder.py
@@ -8,6 +8,34 @@ import pandas as pd
 from pathlib import Path
 import adf_utils as utils
 
+
+def _pick_hist_str(value, substrings):
+    """Return the one history stream to search for a case.
+
+    Returns an empty string when the case has no stream among `substrings`.
+    Every case has to yield exactly one answer: the lists built from this are
+    indexed by case number, so dropping a case would shift every case after it
+    onto the wrong entry.
+    """
+    matches = [string for string in _as_list(value) if string in substrings]
+    return matches[0] if matches else ""
+
+
+def _as_list(value):
+    """Return a history string setting as a list.
+
+    The ADF holds one stream as a plain string, several as a list, and an
+    empty string when none was configured, so all three have to be accepted.
+    """
+    if not value:
+        return []
+    # End if
+    if isinstance(value, str):
+        return [value]
+    # End if
+    return list(value)
+
+
 def tape_recorder(adfobj):
     """
     Calculate the weighted latitude average for the simulations and 
@@ -46,13 +74,12 @@ def tape_recorder(adfobj):
     # Filter the list to include only strings that are exactly in the possible h0 strings
     # - Search for either h0 or h0a
     substrings = {"cam.h0","cam.h0a"}
-    case_hist_strs = []
-    for cam_case_str in cam_hist_strs:
-        # Check each possible h0 string
-        for string in cam_case_str:
-            if string in substrings:
-               case_hist_strs.append(string)
-               break
+    # Exactly one entry per case, so that this list stays aligned with the
+    # cases it is indexed by below.  A case with no h0 stream contributes an
+    # empty string, which makes the search match whichever stream the files
+    # are in rather than dropping the case and shifting the rest.
+    case_hist_strs = [_pick_hist_str(cam_case_str, substrings)
+                      for cam_case_str in cam_hist_strs]
 
     #Grab test case climo years
     start_years = adfobj.climo_yrs["syears"]
@@ -83,10 +110,12 @@ def tape_recorder(adfobj):
         end_years = end_years+[data_end_year]
 
         #Grab history string:
-        baseline_hist_strs = adfobj.hist_string["base_hist_str"]
-        # Filter the list to include only strings that are exactly in the substrings list
-        base_hist_strs = [string for string in baseline_hist_strs if string in substrings]
-        hist_strs = case_hist_strs + base_hist_strs
+        # The baseline stream is a string when one is configured, a list when
+        # several are, and empty when the baseline runs on pre-made time series
+        # with no stream given.  It contributes one entry in every case.
+        hist_strs = case_hist_strs + [
+            _pick_hist_str(adfobj.hist_string["base_hist_str"], substrings)
+        ]
     else:
         hist_strs = case_hist_strs
     #End if
@@ -144,7 +173,11 @@ def tape_recorder(adfobj):
     # MLS data
     mls = xr.open_dataset(obs_loc / "mls_h2o_latNpressNtime_3d_monthly_v5.nc")
     mls = mls.rename(x='lat', y='lev', t='time')
-    time = pd.date_range("2004-09","2021-11",freq='M')
+    # Monthly from September 2004, as many steps as the file holds.  'MS'
+    # (month start) is used rather than the month-end alias, which pandas
+    # renamed from 'M' to 'ME' in 2.2 and removed in 3.0; only the month of
+    # each step matters, since the data are grouped by month below.
+    time = pd.date_range("2004-09-01", periods=mls.sizes["time"], freq="MS")
     mls['time'] = time
     mls = cosweightlat(mls.H2O,-10,10)
     mls = mls.groupby('time.month').mean('time')


### PR DESCRIPTION
Fixes #471. Fixes #470.

`tape_recorder` could not run against pre-made time series at all. Two separate
problems sat one behind the other, so fixing either alone leaves the plot
broken.

## The history stream is not recorded (#471)

`AdfInfo` records the baseline history stream only in the branch that reads
history files. A run on pre-made time series (`cam_ts_done: true`) skips that
branch, so the stream stays an empty string.

`tape_recorder` then filters that empty string as if it were a list of streams.
Iterating a string walks its characters, none of which match, so the baseline
contributes nothing. The list of streams ends up shorter than the list of
cases, and indexing it by case number raises `IndexError`.

Two changes:

- The stream the user configured is recorded as soon as it is read, whichever
  way the years are worked out. Only what was actually given is recorded. With
  pre-made time series and no stream configured it stays empty, and the file
  searches downstream go on matching any stream, exactly as before. Defaulting
  it to `cam.h0a` there would have narrowed those searches instead, and skipped
  variables for any baseline on a `cam.h0` stream.
- The plot builds exactly one stream per case, empty when the case has none, so
  the lists it indexes by case number stay aligned. An empty stream leaves the
  file search matching whichever stream the files are in, which is what it did
  before any filtering was added. The choice is now a small function so it can
  be tested on its own.

## The pandas offset alias (#470)

Behind that, pandas 3 refuses `freq='M'`, which recent versions renamed to
`'ME'`. Rather than pick a spelling and thereby pick which pandas versions the
ADF supports, the dates are now built with `'MS'`, which pandas has never
renamed, and with as many steps as the file holds instead of a hard-coded date
range.

Month start rather than month end makes no difference here, because the data
are grouped by month a few lines later, and taking the length from the file
preserves the 206 months the file contains. The previous range happened to
produce exactly 206; rebuilding it from a fixed range with a different alias
would have given 207 and quietly shifted the axis.

This was the only use of a renamed offset alias in the ADF. Everything else
already uses `'MS'` or `'QS-DEC'`.

## Testing

Unit tests: 124 pass, up from 112. The new ones pin the property the plot
depends on: one stream per case, in the same order, whatever each case holds,
including the unset stream that caused this. They import `tape_recorder`, so
they are skipped in CI along with the other tests that need the scientific
stack.

End to end on Casper, model against model, with `tape_recorder` in
`plotting_scripts`, in three configurations:

1. Pre-made time series with a stream configured.
2. Pre-made time series with no stream configured.
3. History files.

All three finish with no errors and no case skipped, which none of them did
before. The first two produce identical plots, so the empty-stream path finds
the same files as the explicit one.

The time series directory used holds two sets of files for each variable, so
this also exercises the file selection added in #469.

## A configured stream that does not match the files

Recording the stream means it is now used, and a configured stream need not
match the names of pre-made time series files. The example config carries
`hist_str: cam.h0a` in both case blocks, so a baseline whose files are named
for `cam.h0`, which is any CESM2-era run, was searching for a stream that is
not there. Before this branch the stream was empty for those runs and the
searches were stream-agnostic, so they found the files anyway.

`create_climo_files` was the only lookup with no fallback: it warned, skipped
the variable, and wrote no baseline climatology, so every comparison against
the baseline was quietly left out. Its siblings `get_climo_yrs_from_ts` and
`get_reference_climo_file` already fall back, and it now does too. Each
configured stream is tried, and only if none of them holds the variable is one
last search made without a stream, so a variable found under its own stream is
unaffected and no duplicate climatology is produced. The tape recorder searches
for its own files and needed the same fallback, or the plot came out missing
its baseline panel.

Checked with a baseline on pre-made time series named for `cam.h0` and
`hist_str: cam.h0a` configured, which is what copying the example config gives:
the climatologies are written and the plot is byte-identical to the same run
with the stream configured correctly.

One more thing worth a release note: for runs on pre-made time series, baseline
climatology files are now named `{case}_{stream}_{var}_climo.nc` when the
stream matches, where they were `{case}_{var}_climo.nc` before. Lookups prefer
the stream-aware name and fall back to the old one, so nothing breaks, but an
existing output directory will end up holding both.

## Four pre-existing problems, fixed here

Reviewing this change turned up four bugs already on `main`. Each one blocks a
configuration this pull request is meant to support, so leaving them would mean
the change could not be tested end to end. They were reported as #470, #471 and
a third that turned out to be already fixed; these are the rest.

**A missing history file location.** A case running on pre-made time series
does not need `cam_hist_loc`, so it can be absent from the config altogether.
`AdfInfo` assumed it was always there and always one entry per case. It
assigned into it by case number, which raised `TypeError` when the setting was
absent, and then asked whether *any* case had a location before using *this*
case's, which sent a case with none into the history file search and tripped
over its empty location. The upshot is that a run driven purely from pre-made
time series, which is the configuration #471 is about, could not start at all
with more than one case. The setting is now normalised to one entry per case,
the way the years above it already are, and each case is asked about its own.

**The same list alignment bug in the aerosol and gas tables.** That script
builds a list of history streams and indexes it by case, appending only when a
case has one of the three streams it looks for, so a case without one shifts
every later case onto another case's stream. It now uses the same function the
tape recorder does. Since two scripts needed it, the choice moved to
`adf_file_utils`, which imports nothing but `pathlib`, so its tests run in CI
rather than being skipped along with the ones that need xarray.

**A read-only longitude array.** The same script read longitudes from a file
and shifted them in place. Recent xarray hands that array back read-only, so
the shift raised `ValueError: assignment destination is read-only`; where it
did work, it was editing the open file's own cached values. It is copied first.
Note that the ADF has no shared helper for this: three other places write out
`assign_coords(lon=(((ds.lon + 180) % 360) - 180)).sortby("lon")` by hand.
Unifying them is worth doing, but it changes behaviour in plotting scripts and
does not belong here.

**Left alone, and worth its own issue:** `Inside_SE` is called in
`aerosol_gas_tables.py` but is defined nowhere in the repository, so the
regional path raises `NameError` for anyone who sets `regional`. A comment in
the file already notes it is "unavailable at the moment".

## Testing the pre-existing fixes

Three more configurations, run end to end:

1. Two cases on pre-made time series with no history location anywhere.
2. Two cases, one on pre-made time series and one on history files.
3. The aerosol and gas tables, which write both of their tables again.

The first two cannot run on `main` at all. The third exercises the script and
confirms it still works; the list alignment itself only shows up when a case's
stream is none of the three the script looks for, which no case in the test
data has, so that property is covered by unit test rather than by the run.

## Style

`darker` (black restricted to changed lines) is clean against `main` for
`lib/` and `scripts/`. The new files are fully black-formatted; existing files
keep their own style outside the changed lines.


