### PR TITLE
Apply the variable defaults and the recorded time interval to AMWG tables (#423)

### DIFF
--- a/lib/adf_dataset.py
+++ b/lib/adf_dataset.py
@@ -213,18 +213,16 @@ class AdfData:
             ds = xr.open_dataset(sfil, decode_times=False)
         if ds is None:
             warnings.warn("\t    WARNING: invalid data on load_dataset")
-        # assign time to midpoint of interval (even if it is already)
-        if 'time_bnds' in ds:
-            t = ds['time_bnds'].mean(dim='nbnd')
-            t.attrs = ds['time'].attrs
-            ds = ds.assign_coords({'time':t})
-        elif 'time_bounds' in ds:
-            t = ds['time_bounds'].mean(dim='nbnd')
-            t.attrs = ds['time'].attrs
-            ds = ds.assign_coords({'time':t})
-        else:
+            return ds
+        # Assign time to the midpoint of the interval each step covers.  The
+        # shared helper reads the bounds the file names for itself, so a file
+        # calling them something other than 'time_bnds' is handled too, and it
+        # hands back the dataset it was given when the file records no bounds:
+        fixed = utils.use_time_bounds_midpoint(ds)
+        if fixed is ds:
             warnings.warn("\t    INFO: Timeseries file does not have time bounds info.")
-        return xr.decode_cf(ds)
+        # End if
+        return xr.decode_cf(fixed)
 
     def load_timeseries_da(self, case, variablename):
         """Return DataArray from time series file(s).
@@ -544,7 +542,10 @@ class AdfData:
             ds = xr.open_dataset(sfil)
         if ds is None:
             warnings.warn("\t    WARNING: invalid data on load_dataset")
-        return ds
+            return ds
+        # Time stamps that name one end of an averaging interval put steps in
+        # the wrong year, so use what the file records about the interval:
+        return utils.use_time_bounds_midpoint(ds)
 
     def load_da(self, fils, variablename, **kwargs):
         """Return xarray DataArray from file(s) w/ optional scale factor, offset, new units."""

--- a/lib/adf_info.py
+++ b/lib/adf_info.py
@@ -1008,22 +1008,9 @@ class AdfInfo(AdfConfig):
         else:
             cam_ts_data = xr.open_mfdataset(ts_files, decode_times=True, combine='by_coords')
 
-        #Average time dimension over time bounds, if bounds exist:
-        if 'time_bnds' in cam_ts_data:
-            time_bounds_name = 'time_bnds'
-        elif 'time_bounds' in cam_ts_data:
-            time_bounds_name = 'time_bounds'
-        else:
-            time_bounds_name = None
-
-        if time_bounds_name:
-            time = cam_ts_data['time']
-            #NOTE: force `load` here b/c if dask & time is cftime, throws a NotImplementedError:
-            time = xr.DataArray(cam_ts_data[time_bounds_name].load().mean(dim='nbnd').values,
-                                dims=time.dims, attrs=time.attrs)
-            cam_ts_data['time'] = time
-            cam_ts_data.assign_coords(time=time)
-            cam_ts_data = xr.decode_cf(cam_ts_data)
+        # Use the interval each step covers rather than its stamp, so that the
+        # years found here are the years the data actually covers:
+        cam_ts_data = utils.use_time_bounds_midpoint(cam_ts_data)
 
         #Extract first and last years from dataset:
         syr = int(cam_ts_data.time[0].dt.year.values)

--- a/lib/adf_utils.py
+++ b/lib/adf_utils.py
@@ -6,6 +6,8 @@ Functions
 find_ts_files(), select_ts_files(), ts_files_overlap(), ts_file_span(),
 as_hist_str_list(), pick_hist_str()
     re-exported from adf_file_utils; time series file discovery
+use_time_bounds_midpoint()
+    set the time coordinate to the midpoint of the interval each step covers
 load_dataset()
     generalized load dataset method used for plotting/analysis functions
 mask_land_or_ocean(arr, msk, use_nan=False)
@@ -90,6 +92,74 @@ seasons = {"ANN": np.arange(1,13,1),
 #HELPER FUNCTIONS
 #################
 
+def use_time_bounds_midpoint(ds, time_name="time"):
+    """
+    Set the time coordinate to the midpoint of the interval each step covers.
+
+    CAM stamps a monthly average with one end of the interval it covers, and
+    which end depends on the model version: an older CAM h0 file stamps January
+    with February 1st.  Anything that then asks which year a step belongs to --
+    selecting years, averaging by year, grouping by month -- puts that step in
+    the wrong place, which silently drops a year from an annual mean and shifts
+    a seasonal cycle by a month.  The interval itself is not in doubt: the file
+    records it, so the midpoint of the recorded interval is used instead.
+
+    Parameters
+    ----------
+    ds : xr.Dataset
+        dataset to correct
+    time_name : str, optional
+        name of the time coordinate; defaults to ``"time"``
+
+    Returns
+    -------
+    xr.Dataset
+        a dataset whose time coordinate is the midpoint of its bounds, or the
+        dataset unchanged when the file does not say what its bounds are.
+
+    Notes
+    -----
+    The bounds variable is taken from the ``bounds`` attribute of the time
+    coordinate, which is where CF says it belongs and is authoritative when it
+    is there.  Only if that attribute is missing, or names something the file
+    does not contain, are the conventional names ``time_bnds`` and
+    ``time_bounds`` tried.  Files that record no bounds are returned untouched
+    -- there is then nothing better to go on than the stamp itself.
+
+    Doing this where files are opened, rather than in each script, is
+    deliberate: a script that does not know about the stamping convention
+    should not have to.
+    """
+    if time_name not in ds.variables:
+        return ds
+    # End if
+
+    # What the file itself says its bounds are, then the conventional names:
+    candidates = [ds[time_name].attrs.get("bounds"), "time_bnds", "time_bounds"]
+    bounds_name = next(
+        (name for name in candidates if name and name in ds.variables), None
+    )
+    if bounds_name is None:
+        return ds
+    # End if
+
+    bounds = ds[bounds_name]
+    # The bounds are (time, 2), but the second dimension is called 'nbnd' by
+    # CAM and other names elsewhere, so take whichever one is not time:
+    other_dims = [dim for dim in bounds.dims if dim != time_name]
+    if len(other_dims) != 1:
+        # Not a shape this can make sense of, so leave the file alone:
+        return ds
+    # End if
+
+    # load() first: averaging cftime under dask raises NotImplementedError.
+    midpoint = bounds.load().mean(dim=other_dims[0])
+    attrs = ds[time_name].attrs
+    ds = ds.assign_coords({time_name: midpoint})
+    ds[time_name].attrs = attrs
+    return ds
+
+
 def load_dataset(fils):
     """
     This method exists to get an xarray Dataset from input file information that can be passed into the plotting methods.
@@ -111,10 +181,13 @@ def load_dataset(fils):
         warnings.warn(f"\t    WARNING: Input file list is empty.")
         return None
     elif len(fils) > 1:
-        return xr.open_mfdataset(fils, combine='by_coords')
+        ds = xr.open_mfdataset(fils, combine="by_coords")
     else:
-        return xr.open_dataset(fils[0])
-    #End if
+        ds = xr.open_dataset(fils[0])
+    # End if
+    # Time stamps that name one end of an averaging interval put steps in the
+    # wrong year, so use what the file records about the interval instead:
+    return use_time_bounds_midpoint(ds)
 #End def
 
 

--- a/lib/test/unit_tests/test_time_bounds_midpoint.py
+++ b/lib/test/unit_tests/test_time_bounds_midpoint.py
@@ -1,0 +1,234 @@
+"""
+Collection of python unit tests
+for "adf_utils.use_time_bounds_midpoint".
+
+CAM stamps a monthly average with one end of the interval it covers, and which
+end depends on the model version: an older CAM h0 file stamps January with
+February 1st.  Anything that then asks which year a step belongs to puts it in
+the wrong one, which drops a year from an annual mean and shifts a seasonal
+cycle by a month (NCAR/ADF issue #423).
+
+The interval is not in doubt, because the file records it, so the time
+coordinate is replaced by the midpoint of the recorded interval wherever files
+are opened.  These tests cover which variable is believed, and that files
+recording nothing are left alone.
+
+NOTE: these tests import adf_utils, which imports xarray, so they are skipped
+in CI, which installs only PyYAML and pytest.  They run in a full ADF
+environment.
+"""
+
+import os
+import os.path
+import sys
+import unittest
+
+# Set relevant path variables:
+_CURRDIR = os.path.abspath(os.path.dirname(__file__))
+_ADF_LIB_DIR = os.path.join(_CURRDIR, os.pardir, os.pardir)
+
+# Add ADF "lib" directory to python path:
+sys.path.append(_ADF_LIB_DIR)
+
+try:
+    import numpy as np
+    import xarray as xr
+    from adf_utils import use_time_bounds_midpoint
+
+    _HAS_ADF_UTILS = True
+except ImportError:
+    _HAS_ADF_UTILS = False
+
+
+def _monthly_dataset(
+    bounds_name, stamp="end", attrs_name=None, bounds_dim="nbnd", calendar="noleap"
+):
+    """
+    Build a year of monthly data stamped at one end of each interval.
+
+    `stamp` is the end the time coordinate carries, as CAM would write it:
+    "end" is the older CAM h0 convention that puts January at February 1st.
+    `attrs_name` is what the time coordinate's "bounds" attribute claims, which
+    is not always the name of a variable that exists.
+    """
+    edges = xr.date_range(
+        "0001-01-01", periods=13, freq="MS", calendar=calendar, use_cftime=True
+    )
+    lower, upper = edges[:-1], edges[1:]
+    time = upper if stamp == "end" else lower
+    bounds = np.stack([np.array(lower), np.array(upper)], axis=1)
+
+    ds = xr.Dataset(
+        {
+            "T": (("time",), np.arange(12, dtype="f4")),
+            bounds_name: (("time", bounds_dim), bounds),
+        },
+        coords={"time": np.array(time)},
+    )
+    ds["time"].attrs = {"long_name": "time", "bounds": attrs_name or bounds_name}
+    return ds
+
+
+@unittest.skipUnless(_HAS_ADF_UTILS, "adf_utils dependencies not available")
+class TimeBoundsMidpointTestRoutine(unittest.TestCase):
+    """
+    Unit tests for moving the time coordinate to its interval midpoint.
+    """
+
+    def test_end_stamped_month_moves_into_its_own_month(self):
+        """
+        The bug itself: January stamped February 1st is counted as February,
+        and in the last month of a year it is counted as the next year.
+        """
+
+        ds = _monthly_dataset("time_bnds")
+
+        self.assertEqual(ds["time"].values[0].month, 2)  # before: wrong month
+        fixed = use_time_bounds_midpoint(ds)
+        self.assertEqual(fixed["time"].values[0].month, 1)
+        self.assertEqual(fixed["time"].values[0].day, 16)
+        # A year of data covers exactly one year once it is stamped correctly:
+        self.assertEqual({t.year for t in fixed["time"].values}, {1})
+
+    def test_bounds_attribute_is_believed_first(self):
+        """
+        What the file says its bounds are wins.  Here a second, wrong bounds
+        variable carries the conventional name, so trusting the name rather
+        than the attribute would shift every step by a month.
+        """
+
+        ds = _monthly_dataset("real_bnds", attrs_name="real_bnds")
+        # A decoy under the conventional name, covering the following month:
+        decoy_edges = xr.date_range(
+            "0001-02-01", periods=13, freq="MS", calendar="noleap", use_cftime=True
+        )
+        ds["time_bnds"] = (
+            ("time", "nbnd"),
+            np.stack([np.array(decoy_edges[:-1]), np.array(decoy_edges[1:])], axis=1),
+        )
+
+        fixed = use_time_bounds_midpoint(ds)
+
+        self.assertEqual(fixed["time"].values[0].month, 1)
+
+    def test_conventional_names_when_no_attribute(self):
+        """
+        Files that record bounds without pointing at them still have to work,
+        under either spelling the ADF has met.
+        """
+
+        for name in ("time_bnds", "time_bounds"):
+            ds = _monthly_dataset(name)
+            del ds["time"].attrs["bounds"]
+
+            fixed = use_time_bounds_midpoint(ds)
+
+            self.assertEqual(fixed["time"].values[0].month, 1, msg=name)
+
+    def test_attribute_naming_something_absent_falls_back(self):
+        """
+        A "bounds" attribute pointing at a variable the file does not contain
+        must not stop the conventional names being tried.
+        """
+
+        ds = _monthly_dataset("time_bnds", attrs_name="not_here")
+
+        fixed = use_time_bounds_midpoint(ds)
+
+        self.assertEqual(fixed["time"].values[0].month, 1)
+
+    def test_already_at_the_midpoint_is_unchanged(self):
+        """
+        Newer streams stamp the middle of the interval already, so applying
+        this must leave them exactly as they are.
+        """
+
+        edges = xr.date_range(
+            "0001-01-01", periods=13, freq="MS", calendar="noleap", use_cftime=True
+        )
+        ds = _monthly_dataset("time_bnds", stamp="start")
+        ds = ds.assign_coords(
+            time=np.array([lo + (up - lo) / 2 for lo, up in zip(edges[:-1], edges[1:])])
+        )
+        before = ds["time"].values.copy()
+
+        fixed = use_time_bounds_midpoint(ds)
+
+        self.assertTrue(all(a == b for a, b in zip(before, fixed["time"].values)))
+
+    def test_no_bounds_returns_what_it_was_given(self):
+        """
+        With nothing recorded there is nothing better than the stamp, so the
+        dataset comes back untouched -- callers rely on that to know whether
+        anything was done.
+        """
+
+        ds = _monthly_dataset("time_bnds")
+        ds = ds.drop_vars("time_bnds")
+        del ds["time"].attrs["bounds"]
+
+        self.assertIs(use_time_bounds_midpoint(ds), ds)
+
+    def test_no_time_variable_returns_what_it_was_given(self):
+        """A dataset without a time coordinate is not this function's business."""
+
+        ds = xr.Dataset({"area": (("ncol",), np.arange(4, dtype="f4"))})
+
+        self.assertIs(use_time_bounds_midpoint(ds), ds)
+
+    def test_unexpected_bounds_shape_returns_what_it_was_given(self):
+        """
+        Bounds that are not (time, 2) cannot be averaged into midpoints, so
+        the file is left alone rather than guessed at.
+        """
+
+        ds = _monthly_dataset("time_bnds")
+        ds["time_bnds"] = ds["time_bnds"].isel(nbnd=0)  # now one dimensional
+
+        self.assertIs(use_time_bounds_midpoint(ds), ds)
+
+    def test_bounds_dimension_may_be_called_anything(self):
+        """
+        CAM calls the second dimension 'nbnd'; other models use 'bnds' or 'nv'.
+        Whichever it is, it is the one that is not time.
+        """
+
+        ds = _monthly_dataset("time_bnds", bounds_dim="bnds")
+
+        fixed = use_time_bounds_midpoint(ds)
+
+        self.assertEqual(fixed["time"].values[0].month, 1)
+
+    def test_time_attributes_are_kept(self):
+        """
+        The coordinate keeps its metadata, which downstream code and any file
+        written from it still need.
+        """
+
+        ds = _monthly_dataset("time_bnds")
+
+        fixed = use_time_bounds_midpoint(ds)
+
+        self.assertEqual(fixed["time"].attrs.get("long_name"), "time")
+        self.assertEqual(fixed["time"].attrs.get("bounds"), "time_bnds")
+
+    def test_real_calendar_dates_are_handled(self):
+        """
+        Cases run on a standard calendar as well as noleap, and the two are
+        different date types in xarray.
+        """
+
+        ds = _monthly_dataset("time_bnds", calendar="standard")
+
+        fixed = use_time_bounds_midpoint(ds)
+
+        self.assertEqual(fixed["time"].values[0].month, 1)
+
+
+# Run unit tests if this script is called directly:
+if __name__ == "__main__":
+    unittest.main()
+
+#############
+# End of file
+#############

--- a/scripts/analysis/amwg_table.py
+++ b/scripts/analysis/amwg_table.py
@@ -233,9 +233,21 @@ def amwg_table(adf):
                 continue
             #End if
 
-            #Load model variable data from file:
-            ds = utils.load_dataset(ts_files)
-            data = ds[var]
+            # Load model variable data from file, through the ADF's own data
+            # layer so that the scale factor, offset and units named in the
+            # variable defaults are applied.  Reading the files directly gave
+            # tables in the model's raw units, which is not what the defaults
+            # say the variable should be reported in.
+            add_offset, scale_factor = adf.data.get_value_converters(case_name, var)
+            data = adf.data.load_da(
+                ts_files, var, add_offset=add_offset, scale_factor=scale_factor
+            )
+            if data is None:
+                errmsg = f"\t    WARNING: Load failed for variable '{var}', "
+                errmsg += "so it will be skipped."
+                print(errmsg)
+                continue
+            # End if
 
             #Extract units string, if available:
             if hasattr(data, 'units'):

--- a/scripts/averaging/create_climo_files.py
+++ b/scripts/averaging/create_climo_files.py
@@ -351,12 +351,13 @@ def process_variable(adf_user, ts_files, syr, eyr, output_file):
     try:
         # Using chunks={} forces xarray to use dask, which handles memory better
         # than loading everything into RAM at once via open_dataset
-        with xr.open_mfdataset(ts_files, decode_times=True, combine='by_coords',
-                               chunks={'time': 12}) as ds:
-            if 'time_bnds' in ds:
-                new_time = ds['time_bnds'].load().mean(dim='nbnd')
-                ds = ds.assign_coords(time=new_time.values)
-                ds = xr.decode_cf(ds)
+        with xr.open_mfdataset(
+            ts_files, decode_times=True, combine="by_coords", chunks={"time": 12}
+        ) as ds:
+            # Use the interval each step covers rather than its stamp.  This
+            # looked only for 'time_bnds' before, so a model that calls them
+            #'time_bounds' had its climatology built from the raw stamps.
+            ds = utils.use_time_bounds_midpoint(ds)
 
             tslice = get_time_slice_by_year(ds.time, int(syr), int(eyr))
             ds_subset = ds.isel(time=tslice)


### PR DESCRIPTION
Fixes #423.

The AMWG tables were reporting raw model values, and the time stamps in the
time series files were never corrected, so a five year request could produce a
four year average. Both are fixed.

## The variable defaults were not applied

The tables read their time series files directly with xarray, so the scale
factor, offset and units from the variable defaults never reached them. They
now load through the ADF's own data layer, which applies them.

## The time stamps were not corrected

CAM stamps a monthly average with one end of the interval it covers, and which
end depends on the model version: an older CAM h0 file stamps January with
February 1st. Anything that then asks which year a step belongs to puts it in
the wrong one. In the tables that shows up as a lost year, because the annual
mean drops the two years that then look incomplete.

This is fixed where files are opened rather than in the tables, so that a
script which does not know about the stamping convention does not have to.
`adf_utils.use_time_bounds_midpoint` sets the time coordinate to the midpoint
of the interval each step covers, and it is applied by `adf_utils.load_dataset`,
`AdfData.load_dataset`, `AdfData.load_timeseries_dataset`, `create_climo_files`
and `AdfInfo`.

Which variable holds the bounds is taken from the `bounds` attribute of the
time coordinate first, which is where CF says it belongs and is authoritative
when it is there. Only if that attribute is missing, or names something the
file does not contain, are the conventional names `time_bnds` and
`time_bounds` tried. A file that records no bounds is returned untouched, since
there is then nothing better to go on than the stamp itself.

That precedence is not academic. Of the two cases used for testing, one records
`time_bnds` and the other `time_bounds`, and both declare it in the attribute.

Five hand-rolled versions of this logic were in the tree, none of which read
the attribute and all of which assumed the bounds dimension is called `nbnd`.
One of them, in `create_climo_files`, looked only for `time_bnds`, so a model
writing `time_bounds` had its climatologies built from raw stamps as well.
Four are now the one shared function. The two in the TEM scripts are left
alone: TEM has its own data and its own tests, and widening this further would
make the change harder to review. Worth a follow-up.

## What changes for users

Measured on a five year model against model run, for a case stamped at the end
of the interval:

| | before | after |
|---|---|---|
| PRECT unit | `m/s` | `mm d$^{-1}$` |
| PRECT mean | 3.37e-08 | 2.907 |
| sample size | 4 | 5 |

The `2.907` is the old value times the 86400000 the defaults ask for. The extra
year is the stamping fix: the average now covers the five years that were
requested, which also moves the numbers slightly (`TS` 288.575 to 288.544).

A case already stamped mid-interval is unchanged, and the climatology files
written for both cases are identical to those the previous code wrote, so this
does not disturb runs that were already correct. Anyone whose model writes
`time_bounds` and stamps at the end of the interval will see their
climatologies change, because those were being built from the wrong stamps.

## Testing

Unit tests: 135 pass, up from 124. Eleven new ones cover the choice of bounds
variable, including a file whose `bounds` attribute points at one variable
while a differently named decoy carries the conventional name, both spellings
with no attribute at all, an attribute naming something absent, a bounds
dimension called something other than `nbnd`, data already stamped at the
midpoint, files recording no bounds at all, and both the noleap and standard
calendars.

End to end on Casper, model against model over five years, with the before and
after tables in the table above. The run finishes with no errors and writes its
plots, and the climatology files were compared against those from the previous
code and are identical.

## One thing worth a reviewer's eye

`AdfData.load_da` calls `squeeze()` on the variable, which the tables' previous
direct read did not. For a variable with a single vertical level that would
drop the level dimension, and the table skips variables by looking for `lev` in
the coordinates, so such a variable would now be included where it used to be
skipped. No variable in the test configuration is like that, and it is
arguably the better behaviour, but it is a change and it is not something the
issue asked for.
