### PR TITLE
Make the non-linear contour normalization work again (#478)

### DIFF
--- a/lib/adf_variable_defaults.yaml
+++ b/lib/adf_variable_defaults.yaml
@@ -2517,7 +2517,7 @@ EPFY:
   colormap: "RdYlBu_r"
   contour_adjust: 10000000
   contour_levels: [-50000000,-40000000,-30000000,-20000000,-10000000,-8000000,-6000000,-4000000,-2000000,-1000000,0,1000000,2000000,4000000,6000000,8000000,10000000,20000000,30000000,40000000,50000000]
-  non_linear_levels: True
+  non_linear: True
   diff_colormap: "bwr"
   diff_contour_range: [-20000000,21000000,2000000]
   ylim: [1000,0.1]
@@ -2533,7 +2533,7 @@ EPFZ:
   colormap: "RdYlBu_r"
   contour_adjust: 1000000
   contour_levels: [-5000000,-4000000,-3000000,-2000000,-1000000,-800000,-600000,-400000,-200000,-100000,0,100000,200000,400000,600000,800000,1000000,2000000,3000000,4000000,5000000]
-  non_linear_levels: True
+  non_linear: True
   diff_colormap: "bwr"
   diff_contour_range: [-100000,110000,10000]
   ylim: [1000,0.1]
@@ -2548,7 +2548,7 @@ EPFZ:
 VTEM:
   colormap: "RdYlBu_r"
   contour_levels: [-5,-4,-3,-2,-1,-0.8,-0.6,-0.4,-0.2,-0.1,0,0.1,0.2,0.4,0.6,0.8,1,2,3,4,5]
-  non_linear_levels: True
+  non_linear: True
   diff_colormap: "bwr"
   diff_contour_range: [-2,2.1,0.2]
   ylim: [1000,0.1]
@@ -2565,7 +2565,7 @@ WTEM:
   colormap: "RdYlBu_r"
   contour_levels: [-2,-1.7,-1.4,-1.1,-0.8,-0.65,-0.5,-0.35,-0.2,-0.1,0,0.1,0.2,0.35,0.5,0.65,0.8,1.1,1.4,1.7,2]
   scale_factor: 100
-  non_linear_levels: True
+  non_linear: True
   diff_colormap: "bwr"
   diff_contour_range: [-2,2.1,0.2]
   ylim: [1000,0.1]
@@ -2583,7 +2583,7 @@ PSITEM:
   colormap: "RdYlBu_r"
   contour_levels: [-300000000000,-200000000000,-100000000000,-80000000000,-60000000000,-40000000000,-20000000000,-10000000000,0,10000000000,20000000000,40000000000,60000000000,80000000000,100000000000,200000000000,300000000000]
   contour_adjust: 100000000000
-  non_linear_levels: True
+  non_linear: True
   diff_colormap: "bwr"
   diff_contour_range: [-5000000000,5100000000,500000000]
   ylim: [1000,0.1]
@@ -2603,7 +2603,7 @@ UTENDEPFD:
   scale_factor: 1000
   obs_scale_factor: 1000
   new_unit: "mm/s2"
-  non_linear_levels: True
+  non_linear: True
   diff_colormap: "bwr"
   diff_contour_range: [-0.1,0.11,0.01]
   ylim: [1000,0.1]

--- a/lib/plotting_utils.py
+++ b/lib/plotting_utils.py
@@ -30,7 +30,6 @@ _plot_line(axobject, xdata, ydata, color, **kwargs)
 import numpy as np
 import xarray as xr
 import matplotlib as mpl
-import matplotlib.cm as cm
 import cartopy.crs as ccrs
 
 from adf_diag import AdfDiag
@@ -307,6 +306,29 @@ def meridional_plot_preslon(ax, lon, lev, data, **kwargs):
     ax.set_ylim([np.max(lev), np.min(lev)])
     return img, ax
 
+def colormap_object(cmap):
+    """
+    Return a matplotlib Colormap, given either one or the name of one.
+
+    Parameters
+    ----------
+    cmap : str or matplotlib.colors.Colormap
+        a colormap, or the name the variable defaults give for one
+
+    Returns
+    -------
+    matplotlib.colors.Colormap
+
+    Notes
+    -----
+    Replaces the lookup matplotlib removed in 3.9, which the ADF still called.
+    """
+    if isinstance(cmap, str):
+        return mpl.colormaps[cmap]
+    # End if
+    return cmap
+
+
 def prep_contour_plot(adata, bdata, diffdata, pctdata, **kwargs):
     """Preparation for making contour plots.
 
@@ -358,7 +380,7 @@ def prep_contour_plot(adata, bdata, diffdata, pctdata, **kwargs):
     if 'contour_levels' in kwargs:
         levels1 = kwargs['contour_levels']
         if ('non_linear' in kwargs) and (kwargs['non_linear']):
-            cmap_obj = cm.get_cmap(cmap1)
+            cmap_obj = colormap_object(cmap1)
             norm1 = mpl.colors.BoundaryNorm(levels1, cmap_obj.N)
         else:
             norm1 = mpl.colors.Normalize(vmin=min(levels1), vmax=max(levels1))
@@ -368,14 +390,14 @@ def prep_contour_plot(adata, bdata, diffdata, pctdata, **kwargs):
 
         levels1 = np.arange(*kwargs['contour_levels_range'])
         if ('non_linear' in kwargs) and (kwargs['non_linear']):
-            cmap_obj = cm.get_cmap(cmap1)
+            cmap_obj = colormap_object(cmap1)
             norm1 = mpl.colors.BoundaryNorm(levels1, cmap_obj.N)
         else:
             norm1 = mpl.colors.Normalize(vmin=min(levels1), vmax=max(levels1))
     else:
         levels1 = np.linspace(minval, maxval, 12)
         if ('non_linear' in kwargs) and (kwargs['non_linear']):
-            cmap_obj = cm.get_cmap(cmap1)
+            cmap_obj = colormap_object(cmap1)
             norm1 = mpl.colors.BoundaryNorm(levels1, cmap_obj.N)
         else:
             norm1 = mpl.colors.Normalize(vmin=minval, vmax=maxval)

--- a/lib/test/unit_tests/test_nonlinear_contour_norm.py
+++ b/lib/test/unit_tests/test_nonlinear_contour_norm.py
@@ -1,0 +1,223 @@
+"""
+Collection of python unit tests
+for the non-linear contour normalization.
+
+Some variables are drawn with contour levels that are deliberately not evenly
+spaced -- the TEM fluxes run from -5e7 to 5e7 but are dense near zero -- and
+they ask for a colour mapping that follows those levels rather than the range.
+Two things stopped that working (NCAR/ADF issue #478): the lookup used to turn
+a colormap name into a colormap was removed in matplotlib 3.9, and the
+variable defaults asked for the mapping under a name nothing read.
+
+The key check here is the last one, which reads the defaults file and fails on
+any spelling of the option other than the one the code looks for.  That is the
+mistake that hid the first bug for so long: the defaults looked correct.
+
+NOTE: the tests that exercise plotting_utils import matplotlib, cartopy and
+the rest of the plotting stack, so they are skipped in CI, which installs only
+PyYAML and pytest.  The defaults check needs only PyYAML and runs everywhere.
+"""
+
+import os
+import os.path
+import sys
+import unittest
+
+# Set relevant path variables:
+_CURRDIR = os.path.abspath(os.path.dirname(__file__))
+_ADF_LIB_DIR = os.path.join(_CURRDIR, os.pardir, os.pardir)
+_DEFAULTS_FILE = os.path.join(_ADF_LIB_DIR, "adf_variable_defaults.yaml")
+
+# Add ADF "lib" directory to python path:
+sys.path.append(_ADF_LIB_DIR)
+
+import yaml
+
+try:
+    import numpy as np
+    import xarray as xr
+    import matplotlib
+
+    matplotlib.use("Agg")
+    from plotting_utils import colormap_object, prep_contour_plot
+
+    _HAS_PLOTTING = True
+except ImportError:
+    _HAS_PLOTTING = False
+
+
+# The option the code reads, and the near misses that silently do nothing:
+_OPTION = "non_linear"
+
+
+def _load_defaults():
+    """Read the variable defaults file."""
+    with open(_DEFAULTS_FILE, encoding="utf-8") as fil:
+        return yaml.safe_load(fil)
+
+
+class NonLinearOptionNameTestRoutine(unittest.TestCase):
+    """
+    The defaults have to ask for the option by the name the code reads.
+    """
+
+    def test_no_variable_uses_another_spelling(self):
+        """
+        A variable asking for the non-linear mapping under any other name gets
+        a linear one instead, with nothing to say so: the plot comes out, and
+        only its colours are wrong.  This is what happened to the TEM fluxes,
+        which asked for "non_linear_levels".
+        """
+
+        wrong = {}
+        for variable, settings in _load_defaults().items():
+            if not isinstance(settings, dict):
+                continue
+            # End if
+            for key in settings:
+                if key != _OPTION and _OPTION in str(key):
+                    wrong.setdefault(str(variable), []).append(key)
+                # End if
+            # End for
+        # End for
+
+        self.assertEqual(
+            wrong,
+            {},
+            msg=f"these variables ask for '{_OPTION}' under another name: {wrong}",
+        )
+
+    def test_the_option_is_used_by_some_variable(self):
+        """
+        Guards the check above against quietly passing because the option has
+        been dropped from the defaults altogether.
+        """
+
+        users = [
+            variable
+            for variable, settings in _load_defaults().items()
+            if isinstance(settings, dict) and settings.get(_OPTION)
+        ]
+
+        self.assertTrue(users, msg=f"no variable sets '{_OPTION}'")
+
+
+@unittest.skipUnless(_HAS_PLOTTING, "plotting_utils dependencies not available")
+class NonLinearNormTestRoutine(unittest.TestCase):
+    """
+    Unit tests for the colormap lookup and the norm it feeds.
+    """
+
+    def _data(self):
+        """A small field spanning the range the TEM fluxes cover."""
+        return xr.DataArray(
+            np.linspace(-5e7, 5e7, 100).reshape(10, 10), dims=("lev", "lat")
+        )
+
+    def test_colormap_from_a_name(self):
+        """The defaults give colormaps by name."""
+
+        cmap = colormap_object("viridis")
+
+        self.assertTrue(hasattr(cmap, "N"))
+
+    def test_colormap_from_a_colormap(self):
+        """A colormap that has already been looked up is passed through."""
+
+        cmap = colormap_object("viridis")
+
+        self.assertIs(colormap_object(cmap), cmap)
+
+    def test_non_linear_gives_a_boundary_norm(self):
+        """
+        With the option set, the colours follow the contour levels.  Each of
+        the three ways of specifying levels has its own branch, so each is
+        checked, with a colormap named as every variable that uses the option
+        does.
+        """
+
+        data = self._data()
+        levels = [-5e7, -1e7, -1e6, 0, 1e6, 1e7, 5e7]
+
+        for kwargs in (
+            {"contour_levels": levels},
+            {"contour_levels_range": [-5e7, 5e7, 1e7]},
+            {},  # levels worked out from the data
+        ):
+            cp_info = prep_contour_plot(
+                data,
+                data,
+                data - data,
+                data - data,
+                non_linear=True,
+                colormap="RdYlBu_r",
+                **kwargs,
+            )
+
+            self.assertEqual(
+                type(cp_info["norm1"]).__name__, "BoundaryNorm", msg=str(kwargs)
+            )
+
+    def test_a_centred_norm_still_wins_without_a_colormap(self):
+        """
+        Records an interaction that is easy to trip over: with neither a
+        colormap nor explicit levels given, a later block replaces the norm
+        with one centred on zero, so asking for the non-linear mapping has no
+        effect.  Every variable that asks for it names a colormap, so this
+        does not arise in practice, but a new one that did not would be
+        puzzling.
+        """
+
+        data = self._data()
+
+        cp_info = prep_contour_plot(
+            data, data, data - data, data - data, non_linear=True
+        )
+
+        self.assertEqual(type(cp_info["norm1"]).__name__, "TwoSlopeNorm")
+
+    def test_without_the_option_the_norm_is_linear(self):
+        """Variables that do not ask for it are unaffected."""
+
+        data = self._data()
+
+        cp_info = prep_contour_plot(
+            data, data, data - data, data - data, contour_levels=[-1, 0, 1]
+        )
+
+        self.assertEqual(type(cp_info["norm1"]).__name__, "Normalize")
+
+    def test_every_variable_that_asks_for_it_works(self):
+        """
+        Run the real defaults of every variable that sets the option: before
+        this was fixed, each of them raised AttributeError from the removed
+        colormap lookup.
+        """
+
+        data = self._data()
+        defaults = _load_defaults()
+        checked = 0
+
+        for variable, settings in defaults.items():
+            if not isinstance(settings, dict) or not settings.get(_OPTION):
+                continue
+            # End if
+            cp_info = prep_contour_plot(
+                data, data, data - data, data - data, **settings
+            )
+            self.assertEqual(
+                type(cp_info["norm1"]).__name__, "BoundaryNorm", msg=str(variable)
+            )
+            checked += 1
+        # End for
+
+        self.assertGreater(checked, 0)
+
+
+# Run unit tests if this script is called directly:
+if __name__ == "__main__":
+    unittest.main()
+
+#############
+# End of file
+#############


### PR DESCRIPTION
Fixes #478.

Some variables are drawn with contour levels that are deliberately uneven. The
TEM fluxes run from -5e7 to 5e7 but are bunched near zero, so they ask for a
colour mapping that follows the levels rather than the range. Two things
stopped that working, and each hid the other.

## The colormap lookup was removed from matplotlib

`prep_contour_plot` called the lookup matplotlib removed in 3.9, in three
places. The conda environment pins matplotlib 3.9.4, so this was already
broken for everyone. Any variable asking for the non-linear mapping raised:

```
AttributeError: module 'matplotlib.cm' has no attribute 'get_cmap'
```

`DUST` and `SeaSalt` ask for it, so both failed for anyone plotting them. The
lookup now goes through `colormap_object`, which takes either a name or a
colormap that has already been looked up.

## The TEM variables asked for it under a name nothing reads

`EPFY`, `EPFZ`, `VTEM`, `WTEM`, `PSITEM` and `UTENDEPFD` set
`non_linear_levels` in the variable defaults. The code reads `non_linear`, and
nothing in the ADF reads `non_linear_levels`, so those six were drawn with a
plain linear mapping while their levels were bunched near zero. They now use
the name the code reads.

The two have to be fixed together: renaming the key on its own would take six
variables that quietly had the wrong colours and make them raise instead.

## Testing

Unit tests: 146 pass, up from 138. Two of the new ones need only PyYAML and so
run in CI. One of those reads the defaults file and fails on any spelling of
the option other than the one the code reads, which is what let this sit
unnoticed: the defaults looked right.

The rest check that each of the three ways of giving contour levels produces
the intended mapping, that variables not asking for it are unaffected, and
that every variable in the defaults which asks for it now works -- each of
those raised `AttributeError` before.

Ran the TEM diagnostics end to end against the synthetic WACCM input used when
that code was last worked on: all eight TEM variables plot for five seasons
with no errors, forty figures in total. The EP flux colour bar now steps
evenly through its levels, so the values near zero occupy as much of the bar as
the extremes; before, they were compressed into a sliver and the colours did
not follow the contours.

`DUST` and `SeaSalt` are not in the test data available here, so they are
covered by the unit test that runs every such variable's real defaults through
`prep_contour_plot`, not by a plot.

## One thing noticed, not changed

With neither a colormap nor explicit contour levels given, a later block in
`prep_contour_plot` replaces the norm with one centred on zero, so asking for
the non-linear mapping in that combination still has no effect. Every variable
that asks for it names a colormap, so this does not arise in practice. It is
recorded in a test rather than changed, since changing it would alter plots
for variables that have nothing to do with this issue.
