### PR TITLE
Report progress while the time series files are written

### DIFF
--- a/lib/adf_diag.py
+++ b/lib/adf_diag.py
@@ -414,6 +414,35 @@ class AdfDiag(AdfWeb):
             return subprocess.run(cmd, shell=False)
         # End def
 
+        def run_pool(commands, label):
+            """Run NCO commands in parallel, reporting each one as it finishes.
+
+            Results are consumed with ``imap_unordered`` rather than ``map`` so
+            that the progress lines appear while the commands are still running.
+            Without them the terminal sits silent for the whole batch, long
+            enough for an ssh session to time out on a large ``diag_var_list``.
+
+            Parameters
+            ----------
+            commands : list
+                NCO commands, each an argument list for :func:`call_ncrcat`.
+            label : str
+                Name of this batch of commands, used in the progress output.
+
+            Returns
+            -------
+            None
+                Writes the files produced by ``commands``.
+            """
+            ntot = len(commands)
+            with mp.Pool(processes=self.num_procs) as mpool:
+                for num, _ in enumerate(mpool.imap_unordered(call_ncrcat, commands), 1):
+                    print(f"\t     {label}: {num} of {ntot} done", flush=True)
+                # End for
+            # End with
+
+        # End def
+
         # Gather the per-case configuration (shared with the GenTS back end):
         cfg = self.get_ts_case_config(baseline=baseline)
         case_names = cfg["case_names"]
@@ -719,17 +748,14 @@ class AdfDiag(AdfWeb):
                 # End variable loop
 
                 # Now run the "ncrcat" subprocesses in parallel:
-                with mp.Pool(processes=self.num_procs) as mpool:
-                    _ = mpool.map(call_ncrcat, list_of_commands)
+                run_pool(list_of_commands, "ncrcat")
 
                 # Run ncatted commands after ncrcat is done
-                with mp.Pool(processes=self.num_procs) as mpool:
-                    _ = mpool.map(call_ncrcat, list_of_ncatted_commands)
+                run_pool(list_of_ncatted_commands, "global attributes")
 
                 # Run ncatted command to remove history attribute
                 # after the global attributes are set
-                with mp.Pool(processes=self.num_procs) as mpool:
-                    _ = mpool.map(call_ncrcat, list_of_hist_commands)
+                run_pool(list_of_hist_commands, "history attribute")
 
                 # Finally, run through the derived variables if applicable
                 if constit_dict:


### PR DESCRIPTION
Closes #442.

### The problem

`create_time_series` prints one line per variable while it assembles the NCO
commands, and then goes completely silent inside three blocking `Pool.map`
calls while every `ncrcat` actually runs. With a long `diag_var_list` that is a
stretch of dead time with no terminal output at all — long enough for an ssh
session to hit its idle timeout and take the run down with it, which is what
#442 reports.

### The change

Consume the pool results with `imap_unordered` instead of `map` and print a
line as each command finishes:

```
	     ncrcat: 7 of 10 done
	     global attributes: 7 of 10 done
	     history attribute: 7 of 10 done
```

Same parallelism, same `num_procs`, and the results were being discarded in
both cases, so nothing about the work changes — the completions just get
reported as they land instead of all at once at the end. `flush=True` so the
progress still shows up when stdout is a pipe or a log file rather than a tty.

No new dependencies, and no attempt to keep a session alive: a long run still
belongs in a batch job or under `tmux`/`screen`. This only makes the silence
visible.

### Testing

Ran a time-series-only model-vs-model config (10 variables including derived
`PRECT`, 2 years, `num_procs: 4`) over two dissimilar cases — a CESM3 alpha
1850 control on `cam.h0a` and an AMIP run on `cam.h0` — in a Casper batch job
with stdout piped rather than a tty, so the flushing was exercised too.

- progress lines appear for all three phases, 1..10 in completion order
- 10 time series files per case, 24 time steps each, derived `PRECT` present
- `adf_user` / `hist_file_path` / `hist_file_list` / `time_period_freq` global
  attributes set, and the `history` attribute removed, i.e. the two `ncatted`
  phases still do their job in the right order

🤖 Generated with [Claude Code](https://claude.com/claude-code)
